### PR TITLE
Esp32c6 adc set to 12bits

### DIFF
--- a/ports/esp32/adc.c
+++ b/ports/esp32/adc.c
@@ -45,7 +45,7 @@ void madcblock_bits_helper(machine_adc_block_obj_t *self, mp_int_t bits) {
             self->width = ADC_WIDTH_BIT_11;
             break;
         #endif
-        #if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3
+        #if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32C6
         case 12:
             self->width = ADC_WIDTH_BIT_12;
             break;

--- a/ports/esp32/machine_adc_block.c
+++ b/ports/esp32/machine_adc_block.c
@@ -32,10 +32,10 @@
 #include "driver/adc.h"
 
 machine_adc_block_obj_t madcblock_obj[] = {
-    #if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3
+    #if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32C6
     {{&machine_adc_block_type}, ADC_UNIT_1, 12, -1, {0}},
     {{&machine_adc_block_type}, ADC_UNIT_2, 12, -1, {0}},
-    #elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32C6
+    #elif CONFIG_IDF_TARGET_ESP32S2
     {{&machine_adc_block_type}, ADC_UNIT_1, 13, -1, {0}},
     {{&machine_adc_block_type}, ADC_UNIT_2, 13, -1, {0}},
     #endif


### PR DESCRIPTION
1) Changed esp32c6 to 12 bits according to the specification (https://www.espressif.com/en/products/socs/esp32-c6)
2) added CONFIG_IDF_TARGET_ESP32C6 to adc.c since this config was missiging
