### PR TITLE
extmod/modbluetooth: Add None-check guards for GATTC and stack property.

### DIFF
--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -791,6 +791,9 @@ static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bluetooth_ble_gatts_set_buffer_obj, 3
 #if MICROPY_PY_BLUETOOTH_ENABLE_GATT_CLIENT
 
 static mp_obj_t bluetooth_ble_gattc_discover_services(size_t n_args, const mp_obj_t *args) {
+    if (args[1] == mp_const_none) {
+        return bluetooth_handle_errno(MP_ENOTCONN);
+    }
     mp_int_t conn_handle = mp_obj_get_int(args[1]);
     mp_obj_bluetooth_uuid_t *uuid = NULL;
     if (n_args == 3 && args[2] != mp_const_none) {
@@ -804,6 +807,9 @@ static mp_obj_t bluetooth_ble_gattc_discover_services(size_t n_args, const mp_ob
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bluetooth_ble_gattc_discover_services_obj, 2, 3, bluetooth_ble_gattc_discover_services);
 
 static mp_obj_t bluetooth_ble_gattc_discover_characteristics(size_t n_args, const mp_obj_t *args) {
+    if (args[1] == mp_const_none) {
+        return bluetooth_handle_errno(MP_ENOTCONN);
+    }
     mp_int_t conn_handle = mp_obj_get_int(args[1]);
     mp_int_t start_handle = mp_obj_get_int(args[2]);
     mp_int_t end_handle = mp_obj_get_int(args[3]);
@@ -819,6 +825,9 @@ static mp_obj_t bluetooth_ble_gattc_discover_characteristics(size_t n_args, cons
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bluetooth_ble_gattc_discover_characteristics_obj, 4, 5, bluetooth_ble_gattc_discover_characteristics);
 
 static mp_obj_t bluetooth_ble_gattc_discover_descriptors(size_t n_args, const mp_obj_t *args) {
+    if (args[1] == mp_const_none) {
+        return bluetooth_handle_errno(MP_ENOTCONN);
+    }
     (void)n_args;
     mp_int_t conn_handle = mp_obj_get_int(args[1]);
     mp_int_t start_handle = mp_obj_get_int(args[2]);
@@ -829,6 +838,9 @@ static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bluetooth_ble_gattc_discover_descript
 
 static mp_obj_t bluetooth_ble_gattc_read(mp_obj_t self_in, mp_obj_t conn_handle_in, mp_obj_t value_handle_in) {
     (void)self_in;
+    if (conn_handle_in == mp_const_none) {
+        return bluetooth_handle_errno(MP_ENOTCONN);
+    }
     mp_int_t conn_handle = mp_obj_get_int(conn_handle_in);
     mp_int_t value_handle = mp_obj_get_int(value_handle_in);
     return bluetooth_handle_errno(mp_bluetooth_gattc_read(conn_handle, value_handle));
@@ -836,6 +848,9 @@ static mp_obj_t bluetooth_ble_gattc_read(mp_obj_t self_in, mp_obj_t conn_handle_
 static MP_DEFINE_CONST_FUN_OBJ_3(bluetooth_ble_gattc_read_obj, bluetooth_ble_gattc_read);
 
 static mp_obj_t bluetooth_ble_gattc_write(size_t n_args, const mp_obj_t *args) {
+    if (args[1] == mp_const_none) {
+        return bluetooth_handle_errno(MP_ENOTCONN);
+    }
     mp_int_t conn_handle = mp_obj_get_int(args[1]);
     mp_int_t value_handle = mp_obj_get_int(args[2]);
     mp_obj_t data = args[3];
@@ -851,6 +866,9 @@ static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bluetooth_ble_gattc_write_obj, 4, 5, 
 
 static mp_obj_t bluetooth_ble_gattc_exchange_mtu(mp_obj_t self_in, mp_obj_t conn_handle_in) {
     (void)self_in;
+    if (conn_handle_in == mp_const_none) {
+        return bluetooth_handle_errno(MP_ENOTCONN);
+    }
     uint16_t conn_handle = mp_obj_get_int(conn_handle_in);
     return bluetooth_handle_errno(mp_bluetooth_gattc_exchange_mtu(conn_handle));
 }
@@ -972,6 +990,16 @@ static const mp_rom_map_elem_t bluetooth_ble_locals_dict_table[] = {
     #endif
     #if MICROPY_PY_BLUETOOTH_ENABLE_HCI_CMD
     { MP_ROM_QSTR(MP_QSTR_hci_cmd), MP_ROM_PTR(&bluetooth_ble_hci_cmd_obj) },
+    #endif
+    // Stack identification
+    #if MICROPY_BLUETOOTH_ZEPHYR
+    { MP_ROM_QSTR(MP_QSTR_stack), MP_ROM_QSTR(MP_QSTR_zephyr) },
+    #elif MICROPY_BLUETOOTH_NIMBLE
+    { MP_ROM_QSTR(MP_QSTR_stack), MP_ROM_QSTR(MP_QSTR_nimble) },
+    #elif MICROPY_BLUETOOTH_BTSTACK
+    { MP_ROM_QSTR(MP_QSTR_stack), MP_ROM_QSTR(MP_QSTR_btstack) },
+    #else
+    { MP_ROM_QSTR(MP_QSTR_stack), MP_ROM_QSTR(MP_QSTR_unknown) },
     #endif
 };
 static MP_DEFINE_CONST_DICT(bluetooth_ble_locals_dict, bluetooth_ble_locals_dict_table);


### PR DESCRIPTION
### Summary

When a connection drops and the IRQ handler stores `None` for the conn_handle, any subsequent GATTC call (discover_services, discover_characteristics, discover_descriptors, read, write, exchange_mtu) would raise `TypeError: can't convert NoneType to int` because `mp_obj_get_int()` doesn't accept None. This adds a guard at the entry of each of those 6 functions that returns `ENOTCONN` instead.

Also adds `ble.stack` as a read-only property on the BLE object that returns a string identifying the active BLE stack at compile time (`'zephyr'`, `'nimble'`, `'btstack'`, or `'unknown'`). Useful for test scripts that need to conditionally handle stack-specific behaviour without maintaining a separate port-to-stack lookup.

### Testing

None-checks tested on NimBLE (PYBD) by connecting, disconnecting, then immediately calling gattc operations with the stale conn_handle. Confirmed `OSError: [Errno 128] ENOTCONN` rather than `TypeError`.

`ble.stack` verified on NimBLE PYBD (`'nimble'`) and Zephyr BLE on Pico W (`'zephyr'`).

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the description above.