### PR TITLE
docs/library: Document Pin.board and Pin.cpu attributes.

### DIFF
--- a/docs/library/machine.Pin.rst
+++ b/docs/library/machine.Pin.rst
@@ -244,6 +244,36 @@ The following methods are not part of the core Pin API and only implemented on c
 
    Availability: cc3200, esp32, esp8266, mimxrt, rp2, samd ports.
 
+Attributes
+----------
+
+.. data:: Pin.board
+
+   Contains pins named after the board's silkscreen or schematic labels.
+   For example ``Pin.board.X1`` or ``Pin.board.LED``.
+
+   Availability: alif, esp32, mimxrt, nrf, renesas-ra, rp2, samd, stm32 ports.
+
+.. data:: Pin.cpu
+
+   Contains the MCU pin names as given in the datasheet.
+   For example ``Pin.cpu.A0`` or ``Pin.cpu.GPIO0``.
+
+   Availability: alif, mimxrt, nrf, renesas-ra, rp2, samd, stm32 ports.
+
+Multiple board pins can refer to the same CPU pin. Not all ports provide
+both attributes -- for example, the esp32 port only provides ``Pin.board``.
+
+When constructing a ``Pin`` from a string name, the board pins are searched
+first, then the cpu pins::
+
+    from machine import Pin
+
+    # These all refer to the same physical pin on a Pyboard v1.0:
+    p = Pin(Pin.board.X1, Pin.OUT)
+    p = Pin(Pin.cpu.A0, Pin.OUT)
+    p = Pin("X1", Pin.OUT)         # searches Pin.board, then Pin.cpu
+
 Constants
 ---------
 


### PR DESCRIPTION
### Summary

The `Pin.board` and `Pin.cpu` class attributes are used across most ports and referenced in port-specific quickrefs, but were never documented in the `machine.Pin` API reference. I added an "Attributes" section describing both, noting which ports provide them, and showing how they relate to string-based pin construction.

### Testing

Documentation-only change; verified rst structure reads correctly.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the description above.