### PR TITLE
ports: Add RTC.memory() backed by hardware registers.

### DIFF
--- a/docs/library/machine.RTC.rst
+++ b/docs/library/machine.RTC.rst
@@ -91,16 +91,74 @@ Methods
 
    ``RTC.memory(data)`` will write *data* to the RTC memory, where *data* is any
    object which supports the buffer protocol (including `bytes`, `bytearray`,
-   `memoryview` and `array.array`). ``RTC.memory()`` reads RTC memory and returns
-   a `bytes` object.
+   `memoryview` and `array.array`). ``RTC.memory()`` reads RTC memory. On
+   alif, mimxrt, rp2, and stm32 it returns a writable ``memoryview`` of
+   32-bit unsigned integers backed directly by the hardware registers or
+   memory. On esp32 and esp8266 it returns a ``bytes`` copy.
 
    Data written to RTC user memory is persistent across restarts, including
-   :ref:`soft_reset` and `machine.deepsleep()`.
+   :ref:`soft_reset` and `machine.deepsleep()`, except on rp2 where data
+   is lost on power-off (see note below).
 
-   The maximum length of RTC user memory is 2048 bytes by default on esp32,
-   and 492 bytes on esp8266.
+   On alif, mimxrt, rp2, and stm32, only the registers covered by the data
+   are modified when writing; registers beyond the data length are left
+   untouched. A partial trailing word is read-modify-written to preserve the
+   remaining bytes.
 
-   Availability: esp32, esp8266 ports.
+   The maximum length depends on the port and hardware:
+
+   =======  ======================================  ============  ==============
+   Port     Backing storage                         Size          Battery-backed
+   =======  ======================================  ============  ==============
+   alif     Backup SRAM                             4096 bytes    yes           
+   esp32    RTC slow memory                         2048 bytes    yes           
+   esp8266  RTC user memory                         492 bytes     yes           
+   mimxrt   SNVS LPGPR registers (4-8 per chip)     16-32 bytes   yes           
+   rp2      Watchdog scratch registers (8)          32 bytes      no            
+   stm32    RTC backup registers (5-32 per family)  20-128 bytes  yes           
+   =======  ======================================  ============  ==============
+
+   .. note::
+
+      On rp2, data persists across soft resets but is lost on power-off.
+
+   Some registers may be reserved by the system depending on port and board
+   configuration. These are exposed in the memoryview but should not be
+   overwritten by application code:
+
+   ======  ==============  =========================================================
+   Port    Register(s)     Used by
+   ======  ==============  =========================================================
+   mimxrt  LPGPR[3]        UF2 bootloader double-tap (when ``USE_UF2_BOOTLOADER``)
+   rp2     scratch[4-7]    pico-sdk ``watchdog_reboot()`` / ``machine.deepsleep()``
+   stm32   BKP0R           Arduino bootloader (Portenta H7, Giga, Opta, Nicla)
+   stm32   BKP16R-BKP18R   ``rfcore_firmware.py`` on STM32WB
+   stm32   last BKP reg    clock frequency (``MICROPY_HW_CLK_LAST_FREQ``)
+   stm32   BKP31R (N6)     mboot bootloader entry
+   ======  ==============  =========================================================
+
+   On ports returning a ``memoryview``, the buffer allows direct register
+   access and can be combined with ``uctypes`` for structured layouts::
+
+      import machine, uctypes
+
+      rtc = machine.RTC()
+      mem = rtc.memory()
+
+      # Direct register access (each element is a 32-bit register)
+      mem[0] = 0x12345678       # write register 0
+      print(hex(mem[0]))        # read register 0
+
+      # Structured access via uctypes (check len(mem) for your board)
+      layout = {
+          "flags": (0 * 4, uctypes.UINT32),    # register 0
+          "counter": (1 * 4, uctypes.UINT32),  # register 1
+      }
+      regs = uctypes.struct(uctypes.addressof(mem), layout)
+      regs.flags = 0x01
+      print(regs.counter)
+
+   Availability: alif, esp32, esp8266, mimxrt, rp2, stm32 ports.
 
 Constants
 ---------

--- a/ports/alif/machine_rtc.c
+++ b/ports/alif/machine_rtc.c
@@ -24,6 +24,8 @@
  * THE SOFTWARE.
  */
 
+#include <string.h>
+
 #include "py/runtime.h"
 #include "py/mphal.h"
 #include "py/mperrno.h"
@@ -192,9 +194,57 @@ static mp_obj_t machine_rtc_alarm(size_t n_args, const mp_obj_t *pos_args, mp_ma
 }
 static MP_DEFINE_CONST_FUN_OBJ_KW(machine_rtc_alarm_obj, 1, machine_rtc_alarm);
 
+// Battery-backed 4KB backup SRAM (not defined in CMSIS headers).
+#define ALIF_BACKUP_SRAM_BASE (0x4902C000)
+#define ALIF_BACKUP_SRAM_SIZE (4096)
+
+#ifndef MICROPY_HW_RTC_USER_MEM_MAX
+#define MICROPY_HW_RTC_USER_MEM_MAX ALIF_BACKUP_SRAM_SIZE
+#endif
+
+#if MICROPY_HW_RTC_USER_MEM_MAX > 0
+
+MP_STATIC_ASSERT((MICROPY_HW_RTC_USER_MEM_MAX % 4) == 0);
+MP_STATIC_ASSERT(MICROPY_HW_RTC_USER_MEM_MAX <= ALIF_BACKUP_SRAM_SIZE);
+
+static mp_obj_t machine_rtc_memory(size_t n_args, const mp_obj_t *args) {
+    if (n_args == 1) {
+        // Return a writable uint32 memoryview over the backup SRAM.
+        // The SRAM is byte-addressable but we use uint32 for API
+        // consistency with the register-based ports. High bit marks
+        // the memoryview as read-write.
+        return mp_obj_new_memoryview('I' | 0x80,
+            MICROPY_HW_RTC_USER_MEM_MAX / 4, (void *)ALIF_BACKUP_SRAM_BASE);
+    } else {
+        // Write data to backup SRAM using 32-bit word writes.
+        // Only the words covered by the data are written; words
+        // beyond the data length are left untouched. A partial trailing
+        // word is read-modify-written to preserve unaddressed bytes.
+        mp_buffer_info_t bufinfo;
+        mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_READ);
+        if (bufinfo.len > MICROPY_HW_RTC_USER_MEM_MAX) {
+            mp_raise_ValueError(MP_ERROR_TEXT("buffer too long"));
+        }
+        volatile uint32_t *mem = (volatile uint32_t *)ALIF_BACKUP_SRAM_BASE;
+        size_t full = bufinfo.len & ~(size_t)3;
+        memcpy((void *)mem, bufinfo.buf, full);
+        if (bufinfo.len & 3) {
+            uint32_t word = mem[full / 4];
+            memcpy(&word, (const uint8_t *)bufinfo.buf + full, bufinfo.len & 3);
+            mem[full / 4] = word;
+        }
+        return mp_const_none;
+    }
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_memory_obj, 1, 2, machine_rtc_memory);
+#endif
+
 static const mp_rom_map_elem_t machine_rtc_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_datetime), MP_ROM_PTR(&machine_rtc_datetime_obj) },
     { MP_ROM_QSTR(MP_QSTR_alarm), MP_ROM_PTR(&machine_rtc_alarm_obj) },
+    #if MICROPY_HW_RTC_USER_MEM_MAX > 0
+    { MP_ROM_QSTR(MP_QSTR_memory), MP_ROM_PTR(&machine_rtc_memory_obj) },
+    #endif
 };
 static MP_DEFINE_CONST_DICT(machine_rtc_locals_dict, machine_rtc_locals_dict_table);
 

--- a/ports/mimxrt/machine_rtc.c
+++ b/ports/mimxrt/machine_rtc.c
@@ -25,6 +25,7 @@
  * THE SOFTWARE.
  */
 
+#include <string.h>
 #include "py/mperrno.h"
 #include "py/runtime.h"
 #include "shared/runtime/mpirq.h"
@@ -328,6 +329,65 @@ static mp_obj_t machine_rtc_alarm_cancel(size_t n_args, const mp_obj_t *args) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_alarm_cancel_obj, 1, 2, machine_rtc_alarm_cancel);
 
+// Default: use all LPGPR registers, minus one when UF2 reserves LPGPR[3].
+#ifndef MICROPY_HW_RTC_USER_MEM_MAX
+#define MICROPY_HW_RTC_USER_MEM_MAX ((SNVS_LPGPR_COUNT - MICROPY_MACHINE_UF2_BOOTLOADER) * 4)
+#endif
+
+#if MICROPY_HW_RTC_USER_MEM_MAX > 0
+
+MP_STATIC_ASSERT((MICROPY_HW_RTC_USER_MEM_MAX % 4) == 0);
+#if MICROPY_MACHINE_UF2_BOOTLOADER
+MP_STATIC_ASSERT(MICROPY_HW_RTC_USER_MEM_MAX / 4 + 1 <= SNVS_LPGPR_COUNT);
+#else
+MP_STATIC_ASSERT(MICROPY_HW_RTC_USER_MEM_MAX / 4 <= SNVS_LPGPR_COUNT);
+#endif
+
+// Map contiguous user-memory register index to LPGPR index, skipping
+// LPGPR[3] when it is reserved for the UF2 bootloader double-tap.
+static inline mp_uint_t rtc_mem_lpgpr_index(mp_uint_t i) {
+    #if MICROPY_MACHINE_UF2_BOOTLOADER
+    return i >= 3 ? i + 1 : i;
+    #else
+    return i;
+    #endif
+}
+
+static mp_obj_t machine_rtc_memory(size_t n_args, const mp_obj_t *args) {
+    if (n_args == 1) {
+        // Read RTC memory from SNVS LP GPR registers.
+        uint8_t buf[MICROPY_HW_RTC_USER_MEM_MAX];
+        for (mp_uint_t i = 0; i < MICROPY_HW_RTC_USER_MEM_MAX / 4; i++) {
+            uint32_t val = SNVS->LPGPR[rtc_mem_lpgpr_index(i)];
+            buf[i * 4 + 0] = val & 0xff;
+            buf[i * 4 + 1] = (val >> 8) & 0xff;
+            buf[i * 4 + 2] = (val >> 16) & 0xff;
+            buf[i * 4 + 3] = (val >> 24) & 0xff;
+        }
+        return mp_obj_new_bytes(buf, MICROPY_HW_RTC_USER_MEM_MAX);
+    } else {
+        // Write RTC memory to SNVS LP GPR registers.
+        mp_buffer_info_t bufinfo;
+        mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_READ);
+        if (bufinfo.len > MICROPY_HW_RTC_USER_MEM_MAX) {
+            mp_raise_ValueError(MP_ERROR_TEXT("buffer too long"));
+        }
+        // Zero-fill a local buffer and copy user data into it.
+        uint8_t buf[MICROPY_HW_RTC_USER_MEM_MAX];
+        memset(buf, 0, sizeof(buf));
+        memcpy(buf, bufinfo.buf, bufinfo.len);
+        for (mp_uint_t i = 0; i < MICROPY_HW_RTC_USER_MEM_MAX / 4; i++) {
+            SNVS->LPGPR[rtc_mem_lpgpr_index(i)] = buf[i * 4 + 0]
+                | ((uint32_t)buf[i * 4 + 1] << 8)
+                | ((uint32_t)buf[i * 4 + 2] << 16)
+                | ((uint32_t)buf[i * 4 + 3] << 24);
+        }
+        return mp_const_none;
+    }
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_memory_obj, 1, 2, machine_rtc_memory);
+#endif
+
 static mp_obj_t machine_rtc_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_trigger, ARG_handler, ARG_wake, ARG_hard };
     static const mp_arg_t allowed_args[] = {
@@ -381,6 +441,9 @@ static const mp_rom_map_elem_t machine_rtc_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_cancel), MP_ROM_PTR(&machine_rtc_alarm_cancel_obj) },
     #endif
     { MP_ROM_QSTR(MP_QSTR_irq), MP_ROM_PTR(&machine_rtc_irq_obj) },
+    #if MICROPY_HW_RTC_USER_MEM_MAX > 0
+    { MP_ROM_QSTR(MP_QSTR_memory), MP_ROM_PTR(&machine_rtc_memory_obj) },
+    #endif
     { MP_ROM_QSTR(MP_QSTR_ALARM0), MP_ROM_INT(0) },
 };
 static MP_DEFINE_CONST_DICT(machine_rtc_locals_dict, machine_rtc_locals_dict_table);

--- a/ports/mimxrt/machine_rtc.c
+++ b/ports/mimxrt/machine_rtc.c
@@ -329,58 +329,43 @@ static mp_obj_t machine_rtc_alarm_cancel(size_t n_args, const mp_obj_t *args) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_alarm_cancel_obj, 1, 2, machine_rtc_alarm_cancel);
 
-// Default: use all LPGPR registers, minus one when UF2 reserves LPGPR[3].
+// Expose the full LPGPR register array as RTC user memory.
+// LPGPR[3] is used by the UF2 bootloader double-tap (DBL_TAP_REG) when
+// MICROPY_MACHINE_UF2_BOOTLOADER is enabled; users should avoid bytes
+// 12-15 in that case. See docs for reserved register details.
 #ifndef MICROPY_HW_RTC_USER_MEM_MAX
-#define MICROPY_HW_RTC_USER_MEM_MAX ((SNVS_LPGPR_COUNT - MICROPY_MACHINE_UF2_BOOTLOADER) * 4)
+#define MICROPY_HW_RTC_USER_MEM_MAX (SNVS_LPGPR_COUNT * 4)
 #endif
 
 #if MICROPY_HW_RTC_USER_MEM_MAX > 0
 
 MP_STATIC_ASSERT((MICROPY_HW_RTC_USER_MEM_MAX % 4) == 0);
-#if MICROPY_MACHINE_UF2_BOOTLOADER
-MP_STATIC_ASSERT(MICROPY_HW_RTC_USER_MEM_MAX / 4 + 1 <= SNVS_LPGPR_COUNT);
-#else
 MP_STATIC_ASSERT(MICROPY_HW_RTC_USER_MEM_MAX / 4 <= SNVS_LPGPR_COUNT);
-#endif
-
-// Map contiguous user-memory register index to LPGPR index, skipping
-// LPGPR[3] when it is reserved for the UF2 bootloader double-tap.
-static inline mp_uint_t rtc_mem_lpgpr_index(mp_uint_t i) {
-    #if MICROPY_MACHINE_UF2_BOOTLOADER
-    return i >= 3 ? i + 1 : i;
-    #else
-    return i;
-    #endif
-}
 
 static mp_obj_t machine_rtc_memory(size_t n_args, const mp_obj_t *args) {
     if (n_args == 1) {
-        // Read RTC memory from SNVS LP GPR registers.
-        uint8_t buf[MICROPY_HW_RTC_USER_MEM_MAX];
-        for (mp_uint_t i = 0; i < MICROPY_HW_RTC_USER_MEM_MAX / 4; i++) {
-            uint32_t val = SNVS->LPGPR[rtc_mem_lpgpr_index(i)];
-            buf[i * 4 + 0] = val & 0xff;
-            buf[i * 4 + 1] = (val >> 8) & 0xff;
-            buf[i * 4 + 2] = (val >> 16) & 0xff;
-            buf[i * 4 + 3] = (val >> 24) & 0xff;
-        }
-        return mp_obj_new_bytes(buf, MICROPY_HW_RTC_USER_MEM_MAX);
+        // Return a writable uint32 memoryview over the LPGPR registers.
+        // Typecode 'I' (uint32) forces word-aligned access. High bit
+        // marks the memoryview as read-write.
+        return mp_obj_new_memoryview('I' | 0x80,
+            MICROPY_HW_RTC_USER_MEM_MAX / 4, (void *)&SNVS->LPGPR[0]);
     } else {
-        // Write RTC memory to SNVS LP GPR registers.
+        // Write data to LPGPR registers using 32-bit word writes.
+        // Only the registers covered by the data are written; registers
+        // beyond the data length are left untouched. A partial trailing
+        // word is zero-padded to the word boundary.
         mp_buffer_info_t bufinfo;
         mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_READ);
         if (bufinfo.len > MICROPY_HW_RTC_USER_MEM_MAX) {
             mp_raise_ValueError(MP_ERROR_TEXT("buffer too long"));
         }
-        // Zero-fill a local buffer and copy user data into it.
-        uint8_t buf[MICROPY_HW_RTC_USER_MEM_MAX];
-        memset(buf, 0, sizeof(buf));
-        memcpy(buf, bufinfo.buf, bufinfo.len);
-        for (mp_uint_t i = 0; i < MICROPY_HW_RTC_USER_MEM_MAX / 4; i++) {
-            SNVS->LPGPR[rtc_mem_lpgpr_index(i)] = buf[i * 4 + 0]
-                | ((uint32_t)buf[i * 4 + 1] << 8)
-                | ((uint32_t)buf[i * 4 + 2] << 16)
-                | ((uint32_t)buf[i * 4 + 3] << 24);
+        volatile uint32_t *regs = (volatile uint32_t *)&SNVS->LPGPR[0];
+        size_t full = bufinfo.len & ~(size_t)3;
+        memcpy((void *)regs, bufinfo.buf, full);
+        if (bufinfo.len & 3) {
+            uint32_t word = regs[full / 4];
+            memcpy(&word, (const uint8_t *)bufinfo.buf + full, bufinfo.len & 3);
+            regs[full / 4] = word;
         }
         return mp_const_none;
     }

--- a/ports/mimxrt/machine_rtc.c
+++ b/ports/mimxrt/machine_rtc.c
@@ -353,7 +353,7 @@ static mp_obj_t machine_rtc_memory(size_t n_args, const mp_obj_t *args) {
         // Write data to LPGPR registers using 32-bit word writes.
         // Only the registers covered by the data are written; registers
         // beyond the data length are left untouched. A partial trailing
-        // word is zero-padded to the word boundary.
+        // word is read-modify-written to preserve unaddressed bytes.
         mp_buffer_info_t bufinfo;
         mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_READ);
         if (bufinfo.len > MICROPY_HW_RTC_USER_MEM_MAX) {

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -140,6 +140,15 @@ uint32_t trng_random_u32(void);
 #define MICROPY_PY_ONEWIRE                  (1)
 #define MICROPY_PY_MACHINE_BOOTLOADER       (1)
 
+#ifndef MICROPY_MACHINE_UF2_BOOTLOADER
+#define MICROPY_MACHINE_UF2_BOOTLOADER  (0)
+#endif
+
+// RTC user memory backed by SNVS LP GPR registers (battery-backed).
+// Auto-sized to the hardware LPGPR count; LPGPR[3] is skipped when the
+// UF2 bootloader is enabled. Override in mpconfigboard.h, or set to 0
+// to disable.
+
 // fatfs configuration used in ffconf.h
 #define MICROPY_FATFS_ENABLE_LFN            (2)
 #define MICROPY_FATFS_LFN_CODE_PAGE         437 /* 1=SFN/ANSI 437=LFN/U.S.(OEM) */

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -145,9 +145,9 @@ uint32_t trng_random_u32(void);
 #endif
 
 // RTC user memory backed by SNVS LP GPR registers (battery-backed).
-// Auto-sized to the hardware LPGPR count; LPGPR[3] is skipped when the
-// UF2 bootloader is enabled. Override in mpconfigboard.h, or set to 0
-// to disable.
+// Auto-sized to the full hardware LPGPR array. LPGPR[3] is reserved by the
+// UF2 bootloader when enabled; see docs for details. Override in
+// mpconfigboard.h, or set to 0 to disable.
 
 // fatfs configuration used in ffconf.h
 #define MICROPY_FATFS_ENABLE_LFN            (2)

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -144,11 +144,6 @@ uint32_t trng_random_u32(void);
 #define MICROPY_MACHINE_UF2_BOOTLOADER  (0)
 #endif
 
-// RTC user memory backed by SNVS LP GPR registers (battery-backed).
-// Auto-sized to the full hardware LPGPR array. LPGPR[3] is reserved by the
-// UF2 bootloader when enabled; see docs for details. Override in
-// mpconfigboard.h, or set to 0 to disable.
-
 // fatfs configuration used in ffconf.h
 #define MICROPY_FATFS_ENABLE_LFN            (2)
 #define MICROPY_FATFS_LFN_CODE_PAGE         437 /* 1=SFN/ANSI 437=LFN/U.S.(OEM) */

--- a/ports/rp2/machine_rtc.c
+++ b/ports/rp2/machine_rtc.c
@@ -31,6 +31,7 @@
 #include <sys/time.h>
 
 #include "pico/aon_timer.h"
+#include "hardware/structs/watchdog.h"
 
 #include "py/nlr.h"
 #include "py/obj.h"
@@ -99,8 +100,60 @@ static mp_obj_t machine_rtc_datetime(mp_uint_t n_args, const mp_obj_t *args) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_datetime_obj, 1, 2, machine_rtc_datetime);
 
+// Expose watchdog scratch registers as RTC user memory.
+// scratch[4..7] are used by the pico-sdk watchdog_reboot() for boot
+// target address/magic; users should avoid those bytes when using the
+// watchdog reboot API. They are not hidden, same approach as the
+// stm32 and mimxrt implementations.
+// RP2040 and RP2350 both have 8 scratch registers.
+#define WATCHDOG_SCRATCH_REG_COUNT (8)
+
+#ifndef MICROPY_HW_RTC_USER_MEM_MAX
+#define MICROPY_HW_RTC_USER_MEM_MAX (WATCHDOG_SCRATCH_REG_COUNT * 4)
+#endif
+
+#if MICROPY_HW_RTC_USER_MEM_MAX > 0
+
+MP_STATIC_ASSERT(WATCHDOG_SCRATCH_REG_COUNT == sizeof(watchdog_hw->scratch) / sizeof(watchdog_hw->scratch[0]));
+MP_STATIC_ASSERT((MICROPY_HW_RTC_USER_MEM_MAX % 4) == 0);
+MP_STATIC_ASSERT(MICROPY_HW_RTC_USER_MEM_MAX / 4 <= WATCHDOG_SCRATCH_REG_COUNT);
+
+static mp_obj_t machine_rtc_memory(size_t n_args, const mp_obj_t *args) {
+    if (n_args == 1) {
+        // Return a writable uint32 memoryview over the scratch registers.
+        // Typecode 'I' (uint32) forces word-aligned access. High bit
+        // marks the memoryview as read-write.
+        return mp_obj_new_memoryview('I' | 0x80,
+            MICROPY_HW_RTC_USER_MEM_MAX / 4, (void *)&watchdog_hw->scratch[0]);
+    } else {
+        // Write data to scratch registers using 32-bit word writes.
+        // Only the registers covered by the data are written; registers
+        // beyond the data length are left untouched. A partial trailing
+        // word is read-modify-written to preserve unaddressed bytes.
+        mp_buffer_info_t bufinfo;
+        mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_READ);
+        if (bufinfo.len > MICROPY_HW_RTC_USER_MEM_MAX) {
+            mp_raise_ValueError(MP_ERROR_TEXT("buffer too long"));
+        }
+        volatile uint32_t *regs = (volatile uint32_t *)&watchdog_hw->scratch[0];
+        size_t full = bufinfo.len & ~(size_t)3;
+        memcpy((void *)regs, bufinfo.buf, full);
+        if (bufinfo.len & 3) {
+            uint32_t word = regs[full / 4];
+            memcpy(&word, (const uint8_t *)bufinfo.buf + full, bufinfo.len & 3);
+            regs[full / 4] = word;
+        }
+        return mp_const_none;
+    }
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_memory_obj, 1, 2, machine_rtc_memory);
+#endif
+
 static const mp_rom_map_elem_t machine_rtc_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_datetime), MP_ROM_PTR(&machine_rtc_datetime_obj) },
+    #if MICROPY_HW_RTC_USER_MEM_MAX > 0
+    { MP_ROM_QSTR(MP_QSTR_memory), MP_ROM_PTR(&machine_rtc_memory_obj) },
+    #endif
 };
 static MP_DEFINE_CONST_DICT(machine_rtc_locals_dict, machine_rtc_locals_dict_table);
 

--- a/ports/stm32/rtc.c
+++ b/ports/stm32/rtc.c
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include <string.h>
 #include "py/runtime.h"
 #include "shared/timeutils/timeutils.h"
 #include "extint.h"
@@ -36,6 +37,36 @@
 #define RCC_OSCILLATORTYPE_LSI RCC_OSCILLATORTYPE_LSI1
 #define __HAL_RCC_LSI_ENABLE __HAL_RCC_LSI1_ENABLE
 #define __HAL_RCC_LSI_DISABLE __HAL_RCC_LSI1_DISABLE
+#endif
+
+// Backup register base address: families with TAMP peripheral use
+// TAMP->BKP0R, older families use RTC->BKP0R.
+#if defined(TAMP)
+#define RTC_BKP_REG_BASE (&TAMP->BKP0R)
+#else
+#define RTC_BKP_REG_BASE (&RTC->BKP0R)
+#endif
+
+// Normalize backup register count across CMSIS header variants.
+#if defined(RTC_BKP_NUMBER)
+#define MICROPY_HW_RTC_BKP_REG_COUNT RTC_BKP_NUMBER
+#elif defined(TAMP_BKP_NUMBER)
+#define MICROPY_HW_RTC_BKP_REG_COUNT TAMP_BKP_NUMBER
+#elif defined(RTC_BACKUP_NB)
+#define MICROPY_HW_RTC_BKP_REG_COUNT RTC_BACKUP_NB
+#elif defined(RTC_BKP_NB)
+#define MICROPY_HW_RTC_BKP_REG_COUNT RTC_BKP_NB
+#else
+#define MICROPY_HW_RTC_BKP_REG_COUNT 0
+#endif
+
+#ifndef MICROPY_HW_RTC_USER_MEM_MAX
+#define MICROPY_HW_RTC_USER_MEM_MAX (MICROPY_HW_RTC_BKP_REG_COUNT * 4)
+#endif
+
+#if MICROPY_HW_RTC_USER_MEM_MAX > 0
+MP_STATIC_ASSERT((MICROPY_HW_RTC_USER_MEM_MAX % 4) == 0);
+MP_STATIC_ASSERT(MICROPY_HW_RTC_USER_MEM_MAX / 4 <= MICROPY_HW_RTC_BKP_REG_COUNT);
 #endif
 
 /// \moduleref pyb
@@ -919,12 +950,52 @@ mp_obj_t pyb_rtc_calibration(size_t n_args, const mp_obj_t *args) {
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pyb_rtc_calibration_obj, 1, 2, pyb_rtc_calibration);
 
+// Expose the full BKP register array as RTC user memory.
+// BKP_DR0 is used by the Arduino bootloader magic value, and the top
+// register (RTC_BKP_NUMBER-1) stores CLK_LAST_FREQ for some boards.
+// These are not hidden, same approach as the mimxrt implementation.
+#if MICROPY_HW_RTC_USER_MEM_MAX > 0
+static mp_obj_t pyb_rtc_memory(size_t n_args, const mp_obj_t *args) {
+    rtc_init_finalise();
+    if (n_args == 1) {
+        // Return a writable uint32 memoryview over the BKP registers.
+        // Typecode 'I' (uint32) forces word-aligned access. High bit
+        // marks the memoryview as read-write.
+        return mp_obj_new_memoryview('I' | 0x80,
+            MICROPY_HW_RTC_USER_MEM_MAX / 4, (void *)RTC_BKP_REG_BASE);
+    } else {
+        // Write data to BKP registers using 32-bit word writes.
+        // Only the registers covered by the data are written; registers
+        // beyond the data length are left untouched. A partial trailing
+        // word is zero-padded to the word boundary.
+        mp_buffer_info_t bufinfo;
+        mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_READ);
+        if (bufinfo.len > MICROPY_HW_RTC_USER_MEM_MAX) {
+            mp_raise_ValueError(MP_ERROR_TEXT("buffer too long"));
+        }
+        volatile uint32_t *regs = (volatile uint32_t *)RTC_BKP_REG_BASE;
+        size_t full = bufinfo.len & ~(size_t)3;
+        memcpy((void *)regs, bufinfo.buf, full);
+        if (bufinfo.len & 3) {
+            uint32_t word = regs[full / 4];
+            memcpy(&word, (const uint8_t *)bufinfo.buf + full, bufinfo.len & 3);
+            regs[full / 4] = word;
+        }
+        return mp_const_none;
+    }
+}
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pyb_rtc_memory_obj, 1, 2, pyb_rtc_memory);
+#endif
+
 static const mp_rom_map_elem_t pyb_rtc_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&pyb_rtc_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_info), MP_ROM_PTR(&pyb_rtc_info_obj) },
     { MP_ROM_QSTR(MP_QSTR_datetime), MP_ROM_PTR(&pyb_rtc_datetime_obj) },
     { MP_ROM_QSTR(MP_QSTR_wakeup), MP_ROM_PTR(&pyb_rtc_wakeup_obj) },
     { MP_ROM_QSTR(MP_QSTR_calibration), MP_ROM_PTR(&pyb_rtc_calibration_obj) },
+    #if MICROPY_HW_RTC_USER_MEM_MAX > 0
+    { MP_ROM_QSTR(MP_QSTR_memory), MP_ROM_PTR(&pyb_rtc_memory_obj) },
+    #endif
 };
 static MP_DEFINE_CONST_DICT(pyb_rtc_locals_dict, pyb_rtc_locals_dict_table);
 

--- a/ports/stm32/rtc.c
+++ b/ports/stm32/rtc.c
@@ -967,7 +967,7 @@ static mp_obj_t pyb_rtc_memory(size_t n_args, const mp_obj_t *args) {
         // Write data to BKP registers using 32-bit word writes.
         // Only the registers covered by the data are written; registers
         // beyond the data length are left untouched. A partial trailing
-        // word is zero-padded to the word boundary.
+        // word is read-modify-written to preserve unaddressed bytes.
         mp_buffer_info_t bufinfo;
         mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_READ);
         if (bufinfo.len > MICROPY_HW_RTC_USER_MEM_MAX) {


### PR DESCRIPTION
### Summary

Adds `RTC.memory()` to mimxrt, stm32, rp2, and alif ports. On read it returns a writable uint32 `memoryview` backed directly by the hardware registers / memory, so users get direct register access, slicing, and uctypes integration without any copying. On write, `RTC.memory(data)` does a word-aligned bulk write that only touches the registers covered by the input data.

Each port auto-sizes to the available hardware: SNVS LPGPR on mimxrt (16-32 bytes), RTC backup registers on stm32 (20-128 bytes), watchdog scratch on rp2 (32 bytes), and 4KB battery-backed SRAM on alif. Boards can override `MICROPY_HW_RTC_USER_MEM_MAX` if needed.

Some registers are used by system firmware (UF2 bootloader on mimxrt, CLK_LAST_FREQ / mboot / rfcore on stm32, watchdog_reboot on rp2). These are documented in the RST but not hidden, the full register array is always exposed so users can address specific registers for purposes like mboot status reporting or bootloader flags.

On rp2 the watchdog scratch registers aren't battery-backed, data only survives soft resets.

### Testing

Tested on hardware across all four ports:

- MIMXRT1010-EVK (RT1011, 4 LPGPR, no UF2): 16 bytes, all tests pass
- Seeed ARCH MIX (RT1052, 8 LPGPR, UF2): 32 bytes, all tests pass
- NUCLEO-F429ZI (STM32F4, 20 BKP regs): 80 bytes, all tests pass
- NUCLEO-H563ZI (STM32H5/TAMP, 32 BKP regs): 128 bytes, all tests pass
- NUCLEO-WB55 (STM32WB, 20 BKP regs): 80 bytes, all tests pass
- Pico 2 W (RP2350, 8 scratch regs): 32 bytes, all tests pass
- OpenMV AE3 (Alif AE722, 4KB backup SRAM): 4096 bytes, all tests pass

Tests cover direct memoryview register write/read, bulk write with untouched register preservation, partial trailing word read-modify-write, buffer-too-long ValueError, and persistence across soft reset.

Also build-tested on MIMXRT1170_EVK, NUCLEO_G0B1RE, NUCLEO_H7A3ZI_Q, and PYBV10.

### Trade-offs and Alternatives

The read path returns a uint32 `memoryview` rather than `bytes` (as esp32/esp8266 do) or a `bytearray`. A `bytes` copy is safe but doesn't allow direct register writes. A `bytearray` by reference allows byte-level access but STM32 backup registers require 32-bit aligned writes, so byte stores through the bytearray silently corrupt data. The uint32 memoryview forces word-aligned access at the type level which matches the hardware constraint, and works well with uctypes for structured register layouts.

The full register array is exposed including system-reserved locations, rather than hiding them with skip logic (an earlier revision did skip LPGPR[3] on mimxrt for the UF2 bootloader). Hiding registers creates confusing offset mapping when users need to address specific registers for things like mboot status or bootloader flags, and the same approach would be impractical on stm32 where reserved registers are scattered across the array.

The write path only modifies registers covered by the input data rather than zero-filling the remainder. This is important when the register space is shared with system firmware, a bulk write of a couple of bytes shouldn't clobber the clock frequency register at the other end of the array.

The esp32/esp8266 ports still return `bytes` with length tracking. Updating those to match the memoryview approach would be a separate change.

Closes #18960.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the description above.