### PR TITLE
lib/micropython-lib: Update pyusb with Windows support.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -28,3 +28,4 @@ ports/cc3200/hal/des.c -text
 ports/cc3200/hal/i2s.c -text
 ports/cc3200/hal/i2s.h -text
 ports/cc3200/version.h -text
+lib/micropython-lib/unix-ffi/pyusb/usb/*.dll filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -29,3 +29,4 @@ ports/cc3200/hal/des.c -text
 ports/cc3200/hal/i2s.c -text
 ports/cc3200/hal/i2s.h -text
 ports/cc3200/version.h -text
+lib/micropython-lib/unix-ffi/pyusb/usb/*.dll filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
### Summary
Bumps the micropython-lib submodule to a fork containing pyusb modifications needed to use libusb-1.0 on Windows. Adds a Git LFS rule for the bundled DLL.

The submodule pointer references `andrewleech/micropython-lib` `pyusb-windows` branch; that change needs its own micropython-lib PR before this lands.

### Testing
unix-ffi pyusb on Linux (existing behaviour preserved); Windows pydfu app build via the standalone bundle.