### PR TITLE
py/mkrules.mk: Allow PROG to be set on the command line for .exe targets.

### DIFF
--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -250,7 +250,7 @@ ifneq ($(PROG),)
 # Windows, i.e. msvc or mingw builds, but not when using msys or cygwin's gcc.
 COMPILER_TARGET := $(shell $(CC) -dumpmachine)
 ifneq (,$(findstring mingw,$(COMPILER_TARGET)))
-PROG := $(PROG).exe
+override PROG := $(PROG).exe
 endif
 
 all: $(BUILD)/$(PROG)


### PR DESCRIPTION
### Summary
When PROG is given on the make command line (e.g. `PROG=pydfu`) the existing mingw `.exe`-suffix rule has no effect because command-line variables override Makefile assignments. Wraps the assignment in `override` so the suffix is still applied.

Without this, mingw builds invoked with `PROG=foo` produce `foo` but the build rules still expect `foo.exe`.

### Testing
Unix mingw build with and without `PROG=...`; non-mingw builds (no change).