### PR TITLE
py/mkrules.mk: Make MICROPY_MODULE_FROZEN_STR conditional on compiler.

### DIFF
--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -224,7 +224,23 @@ endif
 # Set compile options needed to enable frozen code.
 CFLAGS += -DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool
 CFLAGS += -DMICROPY_MODULE_FROZEN_MPY
+
+# MICROPY_MODULE_FROZEN_STR enables freezing .py files as source text that
+# requires the compiler at runtime. If the compiler is disabled, default this
+# to 0 since only pre-compiled .mpy files can be used.
+ifeq ($(MICROPY_ENABLE_COMPILER),0)
+MICROPY_MODULE_FROZEN_STR ?= 0
+else
+MICROPY_MODULE_FROZEN_STR ?= 1
+endif
+ifneq ($(MICROPY_MODULE_FROZEN_STR),0)
 CFLAGS += -DMICROPY_MODULE_FROZEN_STR
+endif
+
+# Pass MICROPY_ENABLE_COMPILER to CFLAGS if explicitly set.
+ifeq ($(MICROPY_ENABLE_COMPILER),0)
+CFLAGS += -DMICROPY_ENABLE_COMPILER=0
+endif
 
 # Set default path variables to be passed to makemanifest.py. These will be
 # available in path substitutions. Additional variables can be set per-board


### PR DESCRIPTION
### Summary
When `MICROPY_ENABLE_COMPILER=0` in a port/variant, freezing modules as source text (`.py`) cannot work because there is no runtime compiler to parse them. Defaults `MICROPY_MODULE_FROZEN_STR` to 0 in this case so the build only uses pre-compiled `.mpy` modules. Legacy behaviour is preserved when the compiler is enabled.

Also propagates `MICROPY_ENABLE_COMPILER=0` to CFLAGS when explicitly set.

### Testing
Unix build with default settings (no behaviour change); a variant build with `MICROPY_ENABLE_COMPILER=0` (frozen-only) now succeeds.