### PR TITLE
py/modgc: Add gc.add_heap() function for runtime heap expansion.

### DIFF
--- a/docs/library/gc.rst
+++ b/docs/library/gc.rst
@@ -81,6 +81,25 @@ Functions
 
        gc.threshold(-1)
 
+.. function:: add_heap(nbytes)
+
+   Allocate *nbytes* of memory from the system and add it as a new heap
+   segment for the garbage collector. This allows expanding the available
+   heap at runtime beyond the initial allocation.
+
+   The minimum size is 4096 bytes. Returns the new total heap size after
+   adding the segment.
+
+   Raises :exc:`ValueError` if *nbytes* is too small, or :exc:`MemoryError`
+   if the system cannot allocate the requested memory.
+
+   Availability: Unix and Windows ports.
+
+   .. admonition:: Difference to CPython
+      :class: attention
+
+      This function is a MicroPython extension.
+
 Example
 -------
 

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -780,6 +780,12 @@ typedef uint64_t mp_uint_t;
 #define MICROPY_GC_SPLIT_HEAP_AUTO (0)
 #endif
 
+// Whether to provide gc.add_heap() to add heap segments from Python.
+// Requires MICROPY_GC_SPLIT_HEAP to be enabled.
+#ifndef MICROPY_GC_SPLIT_HEAP_ADD
+#define MICROPY_GC_SPLIT_HEAP_ADD (0)
+#endif
+
 // Hook to run code during time consuming garbage collector operations
 // *i* is the loop index variable (e.g. can be used to run every x loops)
 #ifndef MICROPY_GC_HOOK_LOOP
@@ -2349,7 +2355,7 @@ typedef time_t mp_timestamp_t;
 #endif
 
 // Allocating new heap area at runtime requires port to be able to allocate from system heap
-#if MICROPY_GC_SPLIT_HEAP_AUTO
+#if MICROPY_GC_SPLIT_HEAP_AUTO || MICROPY_GC_SPLIT_HEAP_ADD
 #ifndef MP_PLAT_ALLOC_HEAP
 #define MP_PLAT_ALLOC_HEAP(size) malloc(size)
 #endif


### PR DESCRIPTION
### Summary
Adds `gc.add_heap(nbytes)` which allocates a new heap segment from the system allocator and registers it with the split-heap GC. Useful on hosted ports where the working set can grow at runtime beyond the initial heap. Available when `MICROPY_GC_SPLIT_HEAP_ADD` is enabled (off by default).

### Testing
Unix port with `MICROPY_GC_SPLIT_HEAP=1` and `MICROPY_GC_SPLIT_HEAP_ADD=1`; verified additional segments are usable and that allocation past the initial heap succeeds.