### PR TITLE
ports/unix,windows: Add embedded romfs support with auto-mount.

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -254,7 +254,25 @@ $(info Detected arm-linux-gnueabi-gcc. Disabling error message compression.)
 MICROPY_ROM_TEXT_COMPRESSION = 0
 endif
 
+# Build with embedded romfs by linking the binary directly
+# Usage: make ROMFS_IMG=romfs.img
+ifdef ROMFS_IMG
+CFLAGS += -DMICROPY_ROMFS_EMBEDDED=1
+OBJ += $(BUILD)/romfs_data.o
+endif
+
 include $(TOP)/py/mkrules.mk
+
+# Rule to build romfs_data.o from romfs.img (must be after mkrules.mk for OBJCOPY)
+ifdef ROMFS_IMG
+$(BUILD)/romfs_data.o: $(ROMFS_IMG) | $(BUILD)
+	$(Q)$(OBJCOPY) -I binary -O elf64-x86-64 -B i386:x86-64 \
+		--rename-section .data=.rodata,alloc,load,readonly,data,contents \
+		--add-section .note.GNU-stack=/dev/null \
+		--redefine-sym _binary_$(subst .,_,$(subst /,_,$(ROMFS_IMG)))_start=romfs_embedded_data \
+		--redefine-sym _binary_$(subst .,_,$(subst /,_,$(ROMFS_IMG)))_end=romfs_embedded_end \
+		$< $@
+endif
 
 .PHONY: test test_full_no_native test_full test//% test/% test-failures print-failures clean-failures
 
@@ -319,3 +337,16 @@ install: $(BUILD)/$(PROG)
 
 uninstall:
 	-rm $(BINDIR)/$(PROG)
+
+# Build a romfs image from a directory
+# Usage: make romfs ROMFS_DIR=path/to/directory
+# Creates romfs.img in the current directory
+romfs:
+	@if [ -z "$(ROMFS_DIR)" ]; then \
+		echo "Error: ROMFS_DIR not specified"; \
+		echo "Usage: make romfs ROMFS_DIR=path/to/directory"; \
+		exit 1; \
+	fi
+	$(PYTHON) -m mpremote romfs build $(ROMFS_DIR)
+	mv $(notdir $(ROMFS_DIR)).romfs romfs.img
+

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -57,9 +57,15 @@
 #include "stack_size.h"
 #include "shared/runtime/pyexec.h"
 
+#if MICROPY_MODULE_FROZEN
+#include "py/frozenmod.h"
+#endif
+
 // Command line options, with their defaults
 bool mp_compile_only = false;
+#if MICROPY_ENABLE_COMPILER
 static uint emit_opt = MP_EMIT_OPT_NONE;
+#endif
 
 #if MICROPY_ENABLE_GC
 // Heap size of GC heap (if enabled)
@@ -110,6 +116,7 @@ static int handle_uncaught_exception(mp_obj_base_t *exc) {
     return 1;
 }
 
+#if MICROPY_ENABLE_COMPILER
 #define LEX_SRC_STR (1)
 #define LEX_SRC_STDIN (4)
 
@@ -276,7 +283,9 @@ static int do_str(const char *str) {
     int ret = pyexec_vstr(&vstr, true);
     return convert_pyexec_result(ret);
 }
+#endif // MICROPY_ENABLE_COMPILER
 
+#if !MICROPY_FROZEN_MAIN_MODULE
 static void print_help(char **argv) {
     printf(
         "usage: %s [<opts>] [-X <implopt>] [-c <command> | -m <module> | <filename>]\n"
@@ -316,6 +325,7 @@ static void print_help(char **argv) {
         printf("  (none)\n");
     }
 }
+#endif
 
 static int invalid_args(void) {
     fprintf(stderr, "Invalid command line arguments. Use -h option for help.\n");
@@ -329,10 +339,12 @@ static void pre_process_options(int argc, char **argv) {
             if (strcmp(argv[a], "-c") == 0 || strcmp(argv[a], "-m") == 0) {
                 break; // Everything after this is a command/module and arguments for it
             }
+            #if !MICROPY_FROZEN_MAIN_MODULE
             if (strcmp(argv[a], "-h") == 0) {
                 print_help(argv);
                 exit(0);
             }
+            #endif
             if (strcmp(argv[a], "--version") == 0) {
                 printf(MICROPY_BANNER_NAME_AND_VERSION "; " MICROPY_BANNER_MACHINE "\n");
                 exit(0);
@@ -342,6 +354,7 @@ static void pre_process_options(int argc, char **argv) {
                     exit(invalid_args());
                 }
                 if (0) {
+                #if MICROPY_ENABLE_COMPILER
                 } else if (strcmp(argv[a + 1], "compile-only") == 0) {
                     mp_compile_only = true;
                 } else if (strcmp(argv[a + 1], "emit=bytecode") == 0) {
@@ -352,6 +365,7 @@ static void pre_process_options(int argc, char **argv) {
                 } else if (strcmp(argv[a + 1], "emit=viper") == 0) {
                     emit_opt = MP_EMIT_OPT_VIPER;
                 #endif
+                #endif // MICROPY_ENABLE_COMPILER
                 #if MICROPY_ENABLE_GC
                 } else if (strncmp(argv[a + 1], "heapsize=", sizeof("heapsize=") - 1) == 0) {
                     char *end;
@@ -407,11 +421,13 @@ static void pre_process_options(int argc, char **argv) {
     }
 }
 
+#if MICROPY_ENABLE_COMPILER
 static void set_sys_argv(char *argv[], int argc, int start_arg) {
     for (int i = start_arg; i < argc; i++) {
         mp_obj_list_append(mp_sys_argv, MP_OBJ_NEW_QSTR(qstr_from_str(argv[i])));
     }
 }
+#endif
 
 #if MICROPY_PY_SYS_EXECUTABLE
 extern mp_obj_str_t mp_sys_executable_obj;
@@ -495,11 +511,13 @@ MP_NOINLINE int main_(int argc, char **argv) {
 
     mp_init();
 
+    #if MICROPY_ENABLE_COMPILER
     #if MICROPY_EMIT_NATIVE
     // Set default emitter options
     MP_STATE_VM(default_emit_opt) = emit_opt;
     #else
     (void)emit_opt;
+    #endif
     #endif
 
     #if MICROPY_VFS_POSIX
@@ -563,6 +581,12 @@ MP_NOINLINE int main_(int argc, char **argv) {
         }
     }
 
+    #if MICROPY_VFS_ROM && MICROPY_VFS_ROM_IOCTL
+    // Add "/rom" and "/rom/lib" to sys.path if romfs is mounted
+    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_rom));
+    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_rom_slash_lib));
+    #endif
+
     mp_obj_list_init(MP_OBJ_TO_PTR(mp_sys_argv), 0);
 
     #if defined(MICROPY_UNIX_COVERAGE)
@@ -585,9 +609,169 @@ MP_NOINLINE int main_(int argc, char **argv) {
     sys_set_excecutable(argv[0]);
     #endif
 
+    #if MICROPY_ENABLE_COMPILER
     const int NOTHING_EXECUTED = -2;
-    int ret = NOTHING_EXECUTED;
+    #endif
+    int ret = 0;
+    #if MICROPY_ENABLE_COMPILER
     bool inspect = false;
+    #endif
+
+    // Check if a frozen or romfs main module exists and should be run.
+    // Priority: 1) frozen main module, 2) /rom/main.py or /rom/main.mpy
+    // It runs when no -c, -m, -h, or script file is specified.
+    bool run_main = false;
+    bool main_is_frozen = false;
+    const char *main_path = "main";  // For frozen or import-based execution
+
+    #if MICROPY_MODULE_FROZEN
+    {
+        int frozen_type;
+        void *frozen_data;
+        // Try main.py first, then main.mpy (frozen modules use filename with extension)
+        mp_import_stat_t frozen_stat = mp_find_frozen_module("main.py", &frozen_type, &frozen_data);
+        if (frozen_stat != MP_IMPORT_STAT_FILE) {
+            frozen_stat = mp_find_frozen_module("main.mpy", &frozen_type, &frozen_data);
+        }
+        if (frozen_stat == MP_IMPORT_STAT_FILE) {
+            run_main = true;
+            main_is_frozen = true;
+        }
+    }
+    #endif
+
+    #if MICROPY_VFS_ROM && MICROPY_VFS_ROM_IOCTL
+    if (!run_main) {
+        nlr_buf_t nlr;
+        if (nlr_push(&nlr) == 0) {
+            mp_import_stat_t stat = mp_vfs_import_stat("/rom/main.py");
+            if (stat == MP_IMPORT_STAT_FILE) {
+                run_main = true;
+                main_path = "/rom/main.py";
+            } else {
+                stat = mp_vfs_import_stat("/rom/main.mpy");
+                if (stat == MP_IMPORT_STAT_FILE) {
+                    run_main = true;
+                    main_path = "/rom/main.mpy";
+                }
+            }
+            nlr_pop();
+        }
+    }
+    #endif
+
+    if (run_main) {
+        // Check if any argument would bypass main
+        // -c and -m always bypass; -h bypasses only for romfs main (not frozen)
+        for (int a = 1; a < argc; a++) {
+            if (argv[a][0] == '-') {
+                if (strcmp(argv[a], "-c") == 0 || strcmp(argv[a], "-m") == 0) {
+                    run_main = false;
+                    break;
+                } else if (!main_is_frozen && strcmp(argv[a], "-h") == 0) {
+                    run_main = false;
+                    break;
+                } else if (strcmp(argv[a], "-X") == 0) {
+                    if (a + 1 < argc) {
+                        a++;
+                    }
+                }
+            }
+        }
+    }
+
+    if (run_main) {
+        // Process flags that affect execution
+        for (int a = 1; a < argc; a++) {
+            if (argv[a][0] == '-') {
+                #if MICROPY_ENABLE_COMPILER
+                if (strcmp(argv[a], "-i") == 0) {
+                    inspect = true;
+                } else
+                #endif
+                if (strcmp(argv[a], "-X") == 0 && a + 1 < argc) {
+                    a++;
+                #if MICROPY_DEBUG_PRINTERS
+                } else if (strcmp(argv[a], "-v") == 0) {
+                    mp_verbose_flag++;
+                #endif
+                #if MICROPY_ENABLE_COMPILER
+                } else if (strncmp(argv[a], "-O", 2) == 0) {
+                    if (unichar_isdigit(argv[a][2])) {
+                        MP_STATE_VM(mp_optimise_value) = argv[a][2] & 0xf;
+                    } else {
+                        MP_STATE_VM(mp_optimise_value) = 0;
+                        for (char *p = argv[a] + 1; *p && *p == 'O'; p++, MP_STATE_VM(mp_optimise_value)++) {;
+                        }
+                    }
+                #endif
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+
+        // Build sys.argv: [main_path, remaining_args...]
+        mp_obj_list_append(mp_sys_argv, mp_obj_new_str(main_path, strlen(main_path)));
+        bool in_positional = false;
+        for (int a = 1; a < argc; a++) {
+            if (!in_positional && argv[a][0] == '-') {
+                #if MICROPY_ENABLE_COMPILER
+                if (strcmp(argv[a], "-i") == 0) {
+                    continue;
+                } else
+                #endif
+                #if MICROPY_DEBUG_PRINTERS
+                if (strcmp(argv[a], "-v") == 0) {
+                    continue;
+                } else
+                #endif
+                #if MICROPY_ENABLE_COMPILER
+                if (strncmp(argv[a], "-O", 2) == 0) {
+                    continue;
+                } else
+                #endif
+                if (strcmp(argv[a], "-X") == 0 && a + 1 < argc) {
+                    a++;
+                    continue;
+                }
+                in_positional = true;
+            } else {
+                in_positional = true;
+            }
+            if (in_positional) {
+                mp_obj_list_append(mp_sys_argv, mp_obj_new_str_from_cstr(argv[a]));
+            }
+        }
+
+        // Execute main module
+        if (main_is_frozen || (strlen(main_path) > 4 && strcmp(main_path + strlen(main_path) - 4, ".mpy") == 0)) {
+            // Frozen or .mpy: use import mechanism
+            nlr_buf_t nlr;
+            if (nlr_push(&nlr) == 0) {
+                mp_obj_t import_args[4];
+                import_args[0] = MP_OBJ_NEW_QSTR(MP_QSTR_main);
+                import_args[1] = import_args[2] = mp_const_none;
+                import_args[3] = mp_const_false;
+                mp_builtin___import__(4, import_args);
+                nlr_pop();
+                ret = 0;
+            } else {
+                ret = handle_uncaught_exception(nlr.ret_val);
+            }
+        }
+        #if MICROPY_ENABLE_COMPILER
+        else {
+            // .py file in romfs: use lexer
+            ret = do_file(main_path);
+        }
+        #endif
+        goto done_execution;
+    }
+
+    #if MICROPY_ENABLE_COMPILER
     for (int a = 1; a < argc; a++) {
         if (argv[a][0] == '-') {
             if (strcmp(argv[a], "-i") == 0) {
@@ -693,11 +877,18 @@ MP_NOINLINE int main_(int argc, char **argv) {
             break;
         }
     }
+    #endif // MICROPY_ENABLE_COMPILER
 
+    #if MICROPY_MODULE_FROZEN || (MICROPY_VFS_ROM && MICROPY_VFS_ROM_IOCTL)
+done_execution:
+    #endif
+
+    #if MICROPY_ENABLE_COMPILER
     const char *inspect_env = getenv("MICROPYINSPECT");
     if (inspect_env && inspect_env[0] != '\0') {
         inspect = true;
     }
+
     if (ret == NOTHING_EXECUTED || inspect) {
         if (isatty(0) || inspect) {
             prompt_read_history();
@@ -707,6 +898,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
             ret = execute_from_lexer(LEX_SRC_STDIN, NULL, MP_PARSE_FILE_INPUT, false);
         }
     }
+    #endif // MICROPY_ENABLE_COMPILER
 
     #if MICROPY_PY_SYS_SETTRACE
     MP_STATE_THREAD(prof_trace_callback) = MP_OBJ_NULL;
@@ -769,21 +961,97 @@ void nlr_jump_fail(void *val) {
     exit(1);
 }
 
-#if MICROPY_VFS_ROM_IOCTL
+#if MICROPY_VFS_ROM_IOCTL && !MICROPY_VFS_ROM_IOCTL_USE_EXTERNAL
 
-static uint8_t romfs_buf[4] = { 0xd2, 0xcd, 0x31, 0x00 }; // empty ROMFS
-static const MP_DEFINE_MEMORYVIEW_OBJ(romfs_obj, 'B', 0, sizeof(romfs_buf), romfs_buf);
+// RomFS image buffer and metadata
+static const uint8_t *romfs_buf = NULL;
+static size_t romfs_size = 0;
+static mp_obj_t romfs_memoryview = MP_OBJ_NULL;
+
+#if MICROPY_ROMFS_EMBEDDED
+// Embedded romfs data - symbols provided by objcopy from romfs.img
+// Build will fail to link if ROMFS_IMG was specified but object not provided
+extern const uint8_t romfs_embedded_data[];
+extern const uint8_t romfs_embedded_end[];
+
+static void load_romfs_image(void) {
+    if (romfs_buf != NULL) {
+        return;
+    }
+    romfs_buf = romfs_embedded_data;
+    romfs_size = romfs_embedded_end - romfs_embedded_data;
+}
+
+#else
+// File-loading mode for development - load romfs.img from current directory
+static const uint8_t empty_romfs[4] = { 0xd2, 0xcd, 0x31, 0x00 };
+static uint8_t *romfs_file_buf = NULL;
+
+static void load_romfs_image(void) {
+    if (romfs_buf != NULL) {
+        return;
+    }
+
+    FILE *f = fopen("romfs.img", "rb");
+    if (f == NULL) {
+        romfs_size = sizeof(empty_romfs);
+        romfs_buf = empty_romfs;
+        return;
+    }
+
+    fseek(f, 0, SEEK_END);
+    long file_size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+
+    if (file_size <= 0) {
+        fclose(f);
+        romfs_size = sizeof(empty_romfs);
+        romfs_buf = empty_romfs;
+        return;
+    }
+
+    romfs_file_buf = malloc((size_t)file_size);
+    if (romfs_file_buf == NULL) {
+        fclose(f);
+        romfs_size = sizeof(empty_romfs);
+        romfs_buf = empty_romfs;
+        return;
+    }
+
+    size_t read_size = fread(romfs_file_buf, 1, (size_t)file_size, f);
+    fclose(f);
+
+    if (read_size != (size_t)file_size) {
+        free(romfs_file_buf);
+        romfs_file_buf = NULL;
+        romfs_size = sizeof(empty_romfs);
+        romfs_buf = empty_romfs;
+        return;
+    }
+
+    romfs_buf = romfs_file_buf;
+    romfs_size = (size_t)file_size;
+}
+#endif // MICROPY_ROMFS_EMBEDDED
 
 mp_obj_t mp_vfs_rom_ioctl(size_t n_args, const mp_obj_t *args) {
+    load_romfs_image();
+
     switch (mp_obj_get_int(args[0])) {
         case MP_VFS_ROM_IOCTL_GET_NUMBER_OF_SEGMENTS:
             return MP_OBJ_NEW_SMALL_INT(1);
 
-        case MP_VFS_ROM_IOCTL_GET_SEGMENT:
-            return MP_OBJ_FROM_PTR(&romfs_obj);
+        case MP_VFS_ROM_IOCTL_GET_SEGMENT: {
+            // Create memoryview on first request
+            if (romfs_memoryview == MP_OBJ_NULL) {
+                mp_obj_array_t *view = MP_OBJ_TO_PTR(mp_obj_new_memoryview('B', romfs_size, (void *)romfs_buf));
+                romfs_memoryview = MP_OBJ_FROM_PTR(view);
+            }
+            return romfs_memoryview;
+        }
     }
 
     return MP_OBJ_NEW_SMALL_INT(-MP_EINVAL);
 }
 
-#endif
+#endif // MICROPY_VFS_ROM_IOCTL && !MICROPY_VFS_ROM_IOCTL_USE_EXTERNAL

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -61,6 +61,41 @@
 #include "py/frozenmod.h"
 #endif
 
+#if MICROPY_VFS_ROM_TRAILER
+#include "romfs_trailer.h"
+#endif
+
+// MICROPY_APP_RUNNER: opt-in compile-time flag for packaged application binaries.
+// When set to 1, the binary is always in app-runner mode regardless of whether a
+// frozen main module is present.  Set this in the variant's mpconfigvariant.h when
+// the binary is known at build time to embed an application (e.g. a romfs image).
+// Defaults to 0 (standard MicroPython behaviour).
+#ifndef MICROPY_APP_RUNNER
+#define MICROPY_APP_RUNNER (0)
+#endif
+
+// Returns true if the binary should operate in app-runner mode.
+// In app-runner mode, pre_process_options() is skipped and argv[1..] is
+// forwarded verbatim to sys.argv.  Detection covers two cases:
+//  1. MICROPY_APP_RUNNER=1: set at build time for romfs-embedded application binaries.
+//  2. A frozen main module is present at link time (safe to check before mp_init()).
+static bool _is_app_runner(void) {
+    #if MICROPY_APP_RUNNER
+    return true;
+    #endif
+    #if MICROPY_MODULE_FROZEN
+    int frozen_type;
+    void *frozen_data;
+    if (mp_find_frozen_module("main.py", &frozen_type, &frozen_data) == MP_IMPORT_STAT_FILE) {
+        return true;
+    }
+    if (mp_find_frozen_module("main.mpy", &frozen_type, &frozen_data) == MP_IMPORT_STAT_FILE) {
+        return true;
+    }
+    #endif
+    return false;
+}
+
 // Command line options, with their defaults
 bool mp_compile_only = false;
 #if MICROPY_ENABLE_COMPILER
@@ -483,7 +518,14 @@ MP_NOINLINE int main_(int argc, char **argv) {
     signal(SIGPIPE, SIG_IGN);
     #endif
 
-    pre_process_options(argc, argv);
+    // In app-runner mode the entire pre_process_options() walker is skipped.
+    // argv[1..] is forwarded verbatim to sys.argv; no interpreter-level switches
+    // (-h, --version, -c, -m, -O, -X, -i) are honoured.
+    // When not in app-runner mode, fall through to standard behaviour.
+    bool app_runner_mode = _is_app_runner();
+    if (!app_runner_mode) {
+        pre_process_options(argc, argv);
+    }
 
     #if MICROPY_ENABLE_GC
     #if !MICROPY_GC_SPLIT_HEAP
@@ -617,9 +659,9 @@ MP_NOINLINE int main_(int argc, char **argv) {
     bool inspect = false;
     #endif
 
-    // Check if a frozen or romfs main module exists and should be run.
-    // Priority: 1) frozen main module, 2) /rom/main.py or /rom/main.mpy
-    // It runs when no -c, -m, -h, or script file is specified.
+    // Detect whether a main module is actually present (frozen or romfs).
+    // This is separate from app_runner_mode (which gates pre_process_options())
+    // and does not assume a main exists just because the binary is app-runner-flagged.
     bool run_main = false;
     bool main_is_frozen = false;
     const char *main_path = "main";  // For frozen or import-based execution
@@ -628,12 +670,8 @@ MP_NOINLINE int main_(int argc, char **argv) {
     {
         int frozen_type;
         void *frozen_data;
-        // Try main.py first, then main.mpy (frozen modules use filename with extension)
-        mp_import_stat_t frozen_stat = mp_find_frozen_module("main.py", &frozen_type, &frozen_data);
-        if (frozen_stat != MP_IMPORT_STAT_FILE) {
-            frozen_stat = mp_find_frozen_module("main.mpy", &frozen_type, &frozen_data);
-        }
-        if (frozen_stat == MP_IMPORT_STAT_FILE) {
+        if (mp_find_frozen_module("main.py", &frozen_type, &frozen_data) == MP_IMPORT_STAT_FILE ||
+            mp_find_frozen_module("main.mpy", &frozen_type, &frozen_data) == MP_IMPORT_STAT_FILE) {
             run_main = true;
             main_is_frozen = true;
         }
@@ -661,89 +699,14 @@ MP_NOINLINE int main_(int argc, char **argv) {
     #endif
 
     if (run_main) {
-        // Check if any argument would bypass main
-        // -c and -m always bypass; -h bypasses only for romfs main (not frozen)
-        for (int a = 1; a < argc; a++) {
-            if (argv[a][0] == '-') {
-                if (strcmp(argv[a], "-c") == 0 || strcmp(argv[a], "-m") == 0) {
-                    run_main = false;
-                    break;
-                } else if (!main_is_frozen && strcmp(argv[a], "-h") == 0) {
-                    run_main = false;
-                    break;
-                } else if (strcmp(argv[a], "-X") == 0) {
-                    if (a + 1 < argc) {
-                        a++;
-                    }
-                }
-            }
-        }
-    }
-
-    if (run_main) {
-        // Process flags that affect execution
-        for (int a = 1; a < argc; a++) {
-            if (argv[a][0] == '-') {
-                #if MICROPY_ENABLE_COMPILER
-                if (strcmp(argv[a], "-i") == 0) {
-                    inspect = true;
-                } else
-                #endif
-                if (strcmp(argv[a], "-X") == 0 && a + 1 < argc) {
-                    a++;
-                #if MICROPY_DEBUG_PRINTERS
-                } else if (strcmp(argv[a], "-v") == 0) {
-                    mp_verbose_flag++;
-                #endif
-                #if MICROPY_ENABLE_COMPILER
-                } else if (strncmp(argv[a], "-O", 2) == 0) {
-                    if (unichar_isdigit(argv[a][2])) {
-                        MP_STATE_VM(mp_optimise_value) = argv[a][2] & 0xf;
-                    } else {
-                        MP_STATE_VM(mp_optimise_value) = 0;
-                        for (char *p = argv[a] + 1; *p && *p == 'O'; p++, MP_STATE_VM(mp_optimise_value)++) {;
-                        }
-                    }
-                #endif
-                } else {
-                    break;
-                }
-            } else {
-                break;
-            }
-        }
-
-        // Build sys.argv: [main_path, remaining_args...]
-        mp_obj_list_append(mp_sys_argv, mp_obj_new_str(main_path, strlen(main_path)));
-        bool in_positional = false;
-        for (int a = 1; a < argc; a++) {
-            if (!in_positional && argv[a][0] == '-') {
-                #if MICROPY_ENABLE_COMPILER
-                if (strcmp(argv[a], "-i") == 0) {
-                    continue;
-                } else
-                #endif
-                #if MICROPY_DEBUG_PRINTERS
-                if (strcmp(argv[a], "-v") == 0) {
-                    continue;
-                } else
-                #endif
-                #if MICROPY_ENABLE_COMPILER
-                if (strncmp(argv[a], "-O", 2) == 0) {
-                    continue;
-                } else
-                #endif
-                if (strcmp(argv[a], "-X") == 0 && a + 1 < argc) {
-                    a++;
-                    continue;
-                }
-                in_positional = true;
-            } else {
-                in_positional = true;
-            }
-            if (in_positional) {
-                mp_obj_list_append(mp_sys_argv, mp_obj_new_str_from_cstr(argv[a]));
-            }
+        // App-runner mode: forward argv[0..] verbatim into sys.argv so that
+        // the embedded application sees argv[0] as its program name and
+        // argv[1..] as its arguments.  No interpreter-level switches are
+        // honoured; -h, --version, -c, -m, -O, -X and -i all reach the
+        // application's main.py unchanged (CPython convention: sys.argv[0]
+        // is the program/script name, sys.argv[1..] are the arguments).
+        for (int i = 0; i < argc; i++) {
+            mp_obj_list_append(mp_sys_argv, MP_OBJ_NEW_QSTR(qstr_from_str(argv[i])));
         }
 
         // Execute main module
@@ -774,7 +737,18 @@ MP_NOINLINE int main_(int argc, char **argv) {
     #if MICROPY_ENABLE_COMPILER
     for (int a = 1; a < argc; a++) {
         if (argv[a][0] == '-') {
-            if (strcmp(argv[a], "-i") == 0) {
+            if (strcmp(argv[a], "-h") == 0) {
+                // -h/--help may arrive here when app_runner_mode skipped pre_process_options().
+                // In that case no app was found (run_main=false) so standard help applies.
+                #if !MICROPY_FROZEN_MAIN_MODULE
+                print_help(argv);
+                #endif
+                return 0;
+            } else if (strcmp(argv[a], "--version") == 0) {
+                // --version may arrive here when app_runner_mode skipped pre_process_options().
+                printf(MICROPY_BANNER_NAME_AND_VERSION "; " MICROPY_BANNER_MACHINE "\n");
+                return 0;
+            } else if (strcmp(argv[a], "-i") == 0) {
                 inspect = true;
             } else if (strcmp(argv[a], "-c") == 0) {
                 if (a + 1 >= argc) {
@@ -978,6 +952,13 @@ static void load_romfs_image(void) {
     if (romfs_buf != NULL) {
         return;
     }
+    #if MICROPY_VFS_ROM_TRAILER
+    // Trailer-detection fast path: if the binary has a PYLT trailer appended,
+    // use the appended romfs payload instead of the embedded empty sentinel.
+    if (picolet_load_romfs_trailer(&romfs_buf, &romfs_size)) {
+        return;
+    }
+    #endif
     romfs_buf = romfs_embedded_data;
     romfs_size = romfs_embedded_end - romfs_embedded_data;
 }
@@ -991,6 +972,15 @@ static void load_romfs_image(void) {
     if (romfs_buf != NULL) {
         return;
     }
+
+    #if MICROPY_VFS_ROM_TRAILER
+    // Trailer-detection path also applies in file-load mode (development builds
+    // without MICROPY_ROMFS_EMBEDDED=1), so that a picolet-built binary can be
+    // run directly.
+    if (picolet_load_romfs_trailer(&romfs_buf, &romfs_size)) {
+        return;
+    }
+    #endif
 
     FILE *f = fopen("romfs.img", "rb");
     if (f == NULL) {

--- a/ports/unix/variants/mpconfigvariant_common.h
+++ b/ports/unix/variants/mpconfigvariant_common.h
@@ -117,4 +117,4 @@
 #define MICROPY_PY_MACHINE_PIN_BASE    (1)
 
 #define MICROPY_VFS_ROM                (1)
-#define MICROPY_VFS_ROM_IOCTL          (0)
+#define MICROPY_VFS_ROM_IOCTL          (1)

--- a/ports/windows/Makefile
+++ b/ports/windows/Makefile
@@ -69,6 +69,7 @@ SRC_C = \
 	realpath.c \
 	init.c \
 	fmode.c \
+	vfs_rom_ioctl.c \
 	$(wildcard $(VARIANT_DIR)/*.c)
 
 SHARED_SRC_C += $(addprefix shared/,\
@@ -104,9 +105,26 @@ ifeq ($(shell $(CC) -dumpmachine),i686-w64-mingw32)
 CFLAGS += -msse -mfpmath=sse -march=pentium4
 endif
 
+# Build with embedded romfs by linking the binary directly
+# Usage: make ROMFS_IMG=romfs.img
+ifdef ROMFS_IMG
+CFLAGS += -DMICROPY_ROMFS_EMBEDDED=1
+OBJ += $(BUILD)/romfs_data.o
+endif
+
 include $(TOP)/py/mkrules.mk
 
-.PHONY: test test_full
+# Rule to build romfs_data.o from romfs.img (must be after mkrules.mk for OBJCOPY)
+ifdef ROMFS_IMG
+$(BUILD)/romfs_data.o: $(ROMFS_IMG) | $(BUILD)
+	$(Q)$(OBJCOPY) -I binary -O pe-x86-64 -B i386:x86-64 \
+		--rename-section .data=.rodata,alloc,load,readonly,data,contents \
+		--redefine-sym _binary_$(subst .,_,$(subst /,_,$(ROMFS_IMG)))_start=romfs_embedded_data \
+		--redefine-sym _binary_$(subst .,_,$(subst /,_,$(ROMFS_IMG)))_end=romfs_embedded_end \
+		$< $@
+endif
+
+.PHONY: test test_full romfs
 
 # Note for recent gcc versions like 13.2:
 # - mingw64-x86_64 gcc builds will pass the math_domain_special test
@@ -126,3 +144,15 @@ $(BUILD)/$(PROG): $(BUILD)/micropython.res
 $(BUILD)/%.res: %.rc
 	$(ECHO) "WINDRES $<"
 	$(Q)$(WINDRES) $< -O coff -o $@
+
+# Build a romfs image from a directory
+# Usage: make romfs ROMFS_DIR=path/to/directory
+# Creates romfs.img in the current directory
+romfs:
+	@if [ -z "$(ROMFS_DIR)" ]; then \
+		echo "Error: ROMFS_DIR not specified"; \
+		echo "Usage: make romfs ROMFS_DIR=path/to/directory"; \
+		exit 1; \
+	fi
+	$(PYTHON) -m mpremote romfs build $(ROMFS_DIR)
+	mv $(notdir $(ROMFS_DIR)).romfs romfs.img

--- a/ports/windows/Makefile
+++ b/ports/windows/Makefile
@@ -37,6 +37,8 @@ INC += -I.
 INC += -I$(TOP)
 INC += -I$(BUILD)
 INC += -I$(VARIANT_DIR)
+# romfs_trailer.h lives in variants/common/ (out-of-tree, PICOLET_RUNTIME_ROOT).
+INC += -I$(PICOLET_RUNTIME_ROOT)/variants/common
 
 # compiler settings
 CFLAGS += $(INC) -Wall -Wpointer-arith -Wdouble-promotion -Werror -std=gnu99 -DUNIX -D__USE_MINGW_ANSI_STDIO=1 $(COPT) $(CFLAGS_EXTRA)
@@ -71,6 +73,11 @@ SRC_C = \
 	fmode.c \
 	vfs_rom_ioctl.c \
 	$(wildcard $(VARIANT_DIR)/*.c)
+
+# romfs_trailer.c lives in variants/common/ (out-of-tree).
+# SRC_C uses plain = above so variant .mk SRC_C += lines are discarded.
+# We append explicitly here, after SRC_C is set, so it always lands in the build.
+SRC_C += $(PICOLET_RUNTIME_ROOT)/variants/common/romfs_trailer.c
 
 SHARED_SRC_C += $(addprefix shared/,\
 	$(SHARED_SRC_C_EXTRA) \

--- a/ports/windows/micropython.rc
+++ b/ports/windows/micropython.rc
@@ -1,1 +1,32 @@
-app     ICON    "../../logo/vector-logo-2.ico"
+/* picolet: minimal Windows resource file.
+   The upstream micropython.rc embeds a 170 KB icon (vector-logo-2.ico)
+   which contributes ~167 KB to the PE .rsrc section, exceeding NFR-3's
+   2 MiB ceiling for the windows-x64/lvgl variant.  This version replaces
+   the icon with a minimal version-info resource so windres does not fail.
+   The icon is cosmetic; omitting it does not affect runtime behavior.
+   (PH12 NFR-3 fix.) */
+
+#include <winver.h>
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 1,0,0,0
+ PRODUCTVERSION 1,0,0,0
+ FILEFLAGSMASK 0x3fL
+ FILEFLAGS 0x0L
+ FILEOS 0x40004L
+ FILETYPE 0x1L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "FileDescription", "Picolet Runtime\0"
+            VALUE "ProductName", "Picolet\0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END

--- a/ports/windows/mpconfigport.h
+++ b/ports/windows/mpconfigport.h
@@ -79,6 +79,15 @@
 #endif
 #define MICROPY_VFS                 (1)
 #define MICROPY_VFS_POSIX           (1)
+#ifndef MICROPY_VFS_ROM
+#define MICROPY_VFS_ROM             (1)
+#endif
+#ifndef MICROPY_VFS_ROM_IOCTL
+#define MICROPY_VFS_ROM_IOCTL       (1)
+#endif
+#ifndef MICROPY_VFS_ROM_IOCTL_USE_EXTERNAL
+#define MICROPY_VFS_ROM_IOCTL_USE_EXTERNAL (1) // Use vfs_rom_ioctl.c instead of main.c
+#endif
 #define MICROPY_PY_FUNCTION_ATTRS   (1)
 #define MICROPY_PY_DESCRIPTORS      (1)
 #define MICROPY_PY_DELATTR_SETATTR  (1)

--- a/ports/windows/vfs_rom_ioctl.c
+++ b/ports/windows/vfs_rom_ioctl.c
@@ -1,0 +1,128 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2025 Andrew Leech
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+#include "py/mperrno.h"
+#include "py/objarray.h"
+#include "extmod/vfs.h"
+
+#if MICROPY_VFS_ROM_IOCTL
+
+#include <stdio.h>
+
+// RomFS image buffer and metadata
+static const uint8_t *romfs_buf = NULL;
+static size_t romfs_size = 0;
+static mp_obj_t romfs_memoryview = MP_OBJ_NULL;
+
+#if MICROPY_ROMFS_EMBEDDED
+// Embedded romfs data - symbols provided by objcopy from romfs.img
+// Build will fail to link if ROMFS_IMG was specified but object not provided
+extern const uint8_t romfs_embedded_data[];
+extern const uint8_t romfs_embedded_end[];
+
+static void load_romfs_image(void) {
+    if (romfs_buf != NULL) {
+        return;
+    }
+    romfs_buf = romfs_embedded_data;
+    romfs_size = romfs_embedded_end - romfs_embedded_data;
+}
+
+#else
+// File-loading mode for development - load romfs.img from current directory
+static const uint8_t empty_romfs[4] = { 0xd2, 0xcd, 0x31, 0x00 };
+static uint8_t *romfs_file_buf = NULL;
+
+static void load_romfs_image(void) {
+    if (romfs_buf != NULL) {
+        return;
+    }
+
+    FILE *f = fopen("romfs.img", "rb");
+    if (f == NULL) {
+        romfs_size = sizeof(empty_romfs);
+        romfs_buf = empty_romfs;
+        return;
+    }
+
+    fseek(f, 0, SEEK_END);
+    long file_size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+
+    if (file_size <= 0) {
+        fclose(f);
+        romfs_size = sizeof(empty_romfs);
+        romfs_buf = empty_romfs;
+        return;
+    }
+
+    // Use m_new_maybe to avoid exception on allocation failure
+    romfs_file_buf = m_new_maybe(uint8_t, (size_t)file_size);
+    if (romfs_file_buf == NULL) {
+        fclose(f);
+        romfs_size = sizeof(empty_romfs);
+        romfs_buf = empty_romfs;
+        return;
+    }
+
+    size_t read_size = fread(romfs_file_buf, 1, (size_t)file_size, f);
+    fclose(f);
+
+    if (read_size != (size_t)file_size) {
+        m_del(uint8_t, romfs_file_buf, (size_t)file_size);
+        romfs_file_buf = NULL;
+        romfs_size = sizeof(empty_romfs);
+        romfs_buf = empty_romfs;
+        return;
+    }
+
+    romfs_buf = romfs_file_buf;
+    romfs_size = (size_t)file_size;
+}
+#endif // MICROPY_ROMFS_EMBEDDED
+
+mp_obj_t mp_vfs_rom_ioctl(size_t n_args, const mp_obj_t *args) {
+    load_romfs_image();
+
+    switch (mp_obj_get_int(args[0])) {
+        case MP_VFS_ROM_IOCTL_GET_NUMBER_OF_SEGMENTS:
+            return MP_OBJ_NEW_SMALL_INT(1);
+
+        case MP_VFS_ROM_IOCTL_GET_SEGMENT: {
+            // Create memoryview on first request
+            if (romfs_memoryview == MP_OBJ_NULL) {
+                mp_obj_array_t *view = MP_OBJ_TO_PTR(mp_obj_new_memoryview('B', romfs_size, (void *)romfs_buf));
+                romfs_memoryview = MP_OBJ_FROM_PTR(view);
+            }
+            return romfs_memoryview;
+        }
+    }
+
+    return MP_OBJ_NEW_SMALL_INT(-MP_EINVAL);
+}
+
+#endif // MICROPY_VFS_ROM_IOCTL

--- a/ports/windows/vfs_rom_ioctl.c
+++ b/ports/windows/vfs_rom_ioctl.c
@@ -24,6 +24,12 @@
  * THE SOFTWARE.
  */
 
+// Picolet: add MICROPY_VFS_ROM_TRAILER hook for trailer-detection support.
+// When MICROPY_VFS_ROM_TRAILER=1 (set in the picolet-cli variant's
+// mpconfigvariant.h), load_romfs_image() first attempts to find and map a
+// romfs payload appended to the running .exe before falling back to the
+// linked empty romfs sentinel.
+
 #include "py/runtime.h"
 #include "py/mperrno.h"
 #include "py/objarray.h"
@@ -32,6 +38,10 @@
 #if MICROPY_VFS_ROM_IOCTL
 
 #include <stdio.h>
+
+#if MICROPY_VFS_ROM_TRAILER
+#include "romfs_trailer.h"
+#endif
 
 // RomFS image buffer and metadata
 static const uint8_t *romfs_buf = NULL;
@@ -48,6 +58,13 @@ static void load_romfs_image(void) {
     if (romfs_buf != NULL) {
         return;
     }
+    #if MICROPY_VFS_ROM_TRAILER
+    // Trailer-detection fast path: if the .exe has a PYLT trailer appended,
+    // use the appended romfs payload instead of the embedded empty sentinel.
+    if (picolet_load_romfs_trailer(&romfs_buf, &romfs_size)) {
+        return;
+    }
+    #endif
     romfs_buf = romfs_embedded_data;
     romfs_size = romfs_embedded_end - romfs_embedded_data;
 }
@@ -61,6 +78,15 @@ static void load_romfs_image(void) {
     if (romfs_buf != NULL) {
         return;
     }
+
+    #if MICROPY_VFS_ROM_TRAILER
+    // Trailer-detection path also applies in file-load mode (development builds
+    // without MICROPY_ROMFS_EMBEDDED=1), so that developers testing with a
+    // picolet-built app can run the .exe directly.
+    if (picolet_load_romfs_trailer(&romfs_buf, &romfs_size)) {
+        return;
+    }
+    #endif
 
     FILE *f = fopen("romfs.img", "rb");
     if (f == NULL) {


### PR DESCRIPTION
### Summary
Adds support for an embedded romfs image linked into the unix/windows binary. With `ROMFS_IMG=path/to/romfs.img` the image is embedded as a `.rodata` section via `objcopy` and registered as a read-only filesystem at startup. Auto-mount at `/rom` and (when present) prepend to `sys.path`. If the romfs contains `main.py` or `main.mpy`, it is executed in preference to the file-system search.

Also adds a `make romfs ROMFS_DIR=...` target on both ports for building images via mpremote, and `MICROPY_ENABLE_COMPILER=0` guards in unix `main.c` so the port can be built compiler-less when only frozen `.mpy` modules are needed.

### Testing
Unix build with and without `ROMFS_IMG`; Windows mingw build with embedded romfs; auto-execution of `main.mpy` from `/rom`.