### PR TITLE
baochip: Add USB-CDC support.

### DIFF
--- a/ports/baochip/Makefile
+++ b/ports/baochip/Makefile
@@ -90,26 +90,31 @@ CFLAGS += $(INC)
 # Port C sources.
 SRC_C = \
     main.c \
+    baochip_irq.c \
     machine_pin.c \
     mphalport.c \
 
 # SDK sources compiled directly into the firmware. Listed here per file
 # so the build picks up only what we actually use.
 # NOTE: never compile $(DABAO_SDK_DIR)/src/common/bao_stdlib/stdlib.c --
-# it defines a weak trap_dispatch that conflicts with the real one in
-# hardware_irq/irq.c, plus SDK-style wrappers (bao_init, mini_printf)
-# that we replace with MicroPython idioms.
+# it defines a weak trap_dispatch that conflicts with the real one.
+# NOTE: hardware_irq/irq.c is replaced by ports/baochip/baochip_irq.c so
+# the port owns the trap handler (it dumps mcause/mepc/mtval on a fault
+# instead of the SDK's silent halt).  baochip_irq.c provides the same
+# irq_* symbols the SDK uart.c/gpio.c link against.
 SDK_SRC = $(addprefix $(DABAO_SDK)/, \
-    src/bao1x/hardware_irq/irq.c \
     src/bao1x/hardware_uart/uart.c \
     src/bao1x/hardware_gpio/gpio.c \
     src/sevs/sevs_assert_target.c \
     )
 
 # Assembly sources.
-SRC_S = $(addprefix $(DABAO_SDK)/, \
-    src/runtime/crt0.S \
-    )
+# crt0.S is a port-owned copy (not the SDK's) so the trap entry can use a
+# dedicated trap stack instead of scratch space at the top of the main
+# stack -- see ports/baochip/crt0.S and the _trap_stack_* symbols in
+# baochip.ld.
+SRC_S = \
+    crt0.S \
 
 SRC_S += shared/runtime/gchelper_rv32i.s
 
@@ -121,6 +126,38 @@ SRC_C += \
     shared/runtime/stdout_helpers.c \
     shared/runtime/sys_stdio_mphal.c \
     shared/readline/readline.c \
+
+# Native USB-CDC support (Phase 2).  Build inputs are gated entirely
+# on this make variable, so MICROPY_HW_ENABLE_USBDEV=0 sees zero
+# TinyUSB cost.
+MICROPY_HW_ENABLE_USBDEV ?= 1
+ifeq ($(MICROPY_HW_ENABLE_USBDEV),1)
+GIT_SUBMODULES += lib/tinyusb
+
+INC += -I$(TOP)/lib/tinyusb/src
+INC += -I$(TOP)/lib/tinyusb/src/portable/corigine/udc
+INC += -I$(TOP)/shared/tinyusb
+INC += -Iusb
+
+CFLAGS += -DMICROPY_HW_ENABLE_USBDEV=1
+
+SRC_C += \
+    usb/dcd_baochip_port.c \
+    shared/tinyusb/mp_usbd.c \
+    shared/tinyusb/mp_usbd_cdc.c \
+    shared/tinyusb/mp_usbd_descriptor.c \
+    shared/tinyusb/mp_usbd_runtime.c \
+
+TINYUSB_SRC_C += \
+    lib/tinyusb/src/tusb.c \
+    lib/tinyusb/src/common/tusb_fifo.c \
+    lib/tinyusb/src/device/usbd.c \
+    lib/tinyusb/src/device/usbd_control.c \
+    lib/tinyusb/src/class/cdc/cdc_device.c \
+    lib/tinyusb/src/portable/corigine/udc/dcd_corigine_udc.c \
+
+SRC_QSTR += shared/tinyusb/mp_usbd_runtime.c shared/tinyusb/mp_usbd.c
+endif
 
 # Pin generation
 GEN_PIN_MKPINS     = boards/make-pins.py
@@ -136,6 +173,9 @@ OBJ += $(GEN_PINS_SRC:.c=.o)
 OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SDK_SRC:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(patsubst %.S,%.o, $(patsubst %.s,%.o, $(SRC_S))))
+ifeq ($(MICROPY_HW_ENABLE_USBDEV),1)
+OBJ += $(addprefix $(BUILD)/, $(TINYUSB_SRC_C:.c=.o))
+endif
 
 LDFLAGS += -T baochip.ld
 

--- a/ports/baochip/baochip.ld
+++ b/ports/baochip/baochip.ld
@@ -54,8 +54,21 @@ MEMORY
     IFRAM (rw)    : ORIGIN = 0x50000000, LENGTH = 0x20000
 }
 
+/*
+ * Dedicated trap/interrupt stack at the very top of SRAM, separate from
+ * the main C stack.  crt0's _trap_entry switches to _trap_stack_top on
+ * every trap; keeping it out of the main stack means a deep interrupt
+ * handler (the USB DCD's event-ring drain) can never corrupt the main
+ * thread's frames.  Sized generously: the fixed trap overhead is ~400
+ * bytes (register save frame + C-stack reserve) and the deepest handler
+ * path is well under the remainder.
+ */
+_trap_stack_size = 0x1000;
+_trap_stack_top  = ORIGIN(SRAM) + LENGTH(SRAM);
+
 _stack_size = 0x4000;
-_stack_top  = ORIGIN(SRAM) + LENGTH(SRAM);
+/* Main C stack starts just below the dedicated trap stack and grows down. */
+_stack_top  = _trap_stack_top - _trap_stack_size;
 
 SECTIONS
 {

--- a/ports/baochip/baochip_irq.c
+++ b/ports/baochip/baochip_irq.c
@@ -1,0 +1,232 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 MicroPython contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Port-owned interrupt dispatch and trap handler for the Baochip-1x.
+//
+// Replaces the Dabao SDK's hardware_irq/irq.c (which is excluded from the
+// build).  The IRQ-array dispatch protocol matches the SDK's; the
+// difference is the exception path: rather than the SDK's "light an LED
+// and spin forever", an unexpected RISC-V exception dumps mcause / mepc /
+// mtval over the REPL UART so a fault can be located in the disassembly,
+// then halts.  The dump uses only the polled uart_write primitive, so it
+// is safe to run with the scheduler and USB stack in any state.
+
+#include <stdint.h>
+
+#include "py/mpconfig.h"
+#include "hardware/irq.h"
+#include "hardware/uart.h"
+
+// IRQ-array base addresses (VexRiscv interrupt controller windows).
+// Mirrors the table in the SDK's irq.c.
+static const uint32_t irq_array_base[20] = {
+    0xE0004000,  /*  0: MDMA, BIO */
+    0xE0005000,  /*  1: USB */
+    0xE0010000,  /*  2: QFC, MDMA, Mailbox, AO wakeup */
+    0xE0011000,  /*  3: Crypto */
+    0xE0012000,  /*  4: Crypto dupes */
+    0xE0013000,  /*  5: UART */
+    0xE0014000,  /*  6: SPI master */
+    0xE0015000,  /*  7: I2C */
+    0xE0016000,  /*  8: SDIO, I2S, Camera, ADC */
+    0xE0017000,  /*  9: SCIF, SPI slave, PWM */
+    0xE0006000,  /* 10: IOX, USB, SDDC, BIO */
+    0xE0007000,  /* 11: I2S dupes */
+    0xE0008000,  /* 12: I2C NACK/error */
+    0xE0009000,  /* 13: Bus errors, SCE errors */
+    0xE000A000,  /* 14: UART2/3 dupes, TRNG */
+    0xE000B000,  /* 15: Security sensor */
+    0xE000C000,  /* 16: Camera, I2S, SPIM dupes */
+    0xE000D000,  /* 17: I2C1, BIO, QFC, ADC dupes */
+    0xE000E000,  /* 18: BIO, I2C2, I2C NACK dupes */
+    0xE000F000,  /* 19: Mailbox, BIO, SDIO dupes */
+};
+
+#define IRQ_EV_PENDING      0x10
+#define IRQ_EV_ENABLE       0x14
+
+// 20 IRQ arrays + slots 20-29 unused + slot 30 for Timer0.
+#define IRQ_TABLE_SIZE      31
+static irq_handler_t irq_handlers[IRQ_TABLE_SIZE];
+
+static inline uint32_t csr_read_mim(void) {
+    uint32_t val;
+    __asm__ volatile ("csrr %0, 0xBC0" : "=r" (val));
+    return val;
+}
+
+static inline void csr_write_mim(uint32_t val) {
+    __asm__ volatile ("csrw 0xBC0, %0" : : "r" (val));
+}
+
+static inline uint32_t csr_read_mip_vex(void) {
+    uint32_t val;
+    __asm__ volatile ("csrr %0, 0xFC0" : "=r" (val));
+    return val;
+}
+
+void irq_init(void) {
+    for (int i = 0; i < IRQ_TABLE_SIZE; i++) {
+        irq_handlers[i] = (irq_handler_t)0;
+    }
+    // Disable all IRQ lines in MIM.
+    csr_write_mim(0);
+    // mie.MEIE (bit 11): machine external interrupts.
+    __asm__ volatile ("csrs mie, %0" : : "r" (1 << 11));
+    // mstatus.MIE (bit 3): global interrupt enable.
+    __asm__ volatile ("csrsi mstatus, 0x8");
+}
+
+void irq_set_handler(uint32_t irq_no, irq_handler_t handler) {
+    if (irq_no < (uint32_t)IRQ_TABLE_SIZE) {
+        irq_handlers[irq_no] = handler;
+    }
+}
+
+void irq_enable(uint32_t irq_no) {
+    if (irq_no < 20) {
+        volatile uint32_t *ev_enable =
+            (volatile uint32_t *)(irq_array_base[irq_no] + IRQ_EV_ENABLE);
+        *ev_enable = 0xFFFF;
+    }
+    csr_write_mim(csr_read_mim() | (1 << irq_no));
+}
+
+void irq_enable_events(uint32_t irq_no, uint32_t event_mask) {
+    if (irq_no < 20) {
+        volatile uint32_t *ev_enable =
+            (volatile uint32_t *)(irq_array_base[irq_no] + IRQ_EV_ENABLE);
+        *ev_enable |= event_mask;
+    }
+    csr_write_mim(csr_read_mim() | (1 << irq_no));
+}
+
+void irq_disable(uint32_t irq_no) {
+    csr_write_mim(csr_read_mim() & ~(1 << irq_no));
+}
+
+// ---- Fault reporting -------------------------------------------------
+
+// Emit a NUL-terminated string over the REPL UART using only the polled
+// uart_write path (no scheduler, no stdio, no USB).  Safe in trap context.
+static void fault_puts(const char *s) {
+    size_t n = 0;
+    while (s[n] != '\0') {
+        n++;
+    }
+    uart_write(MICROPY_HW_UART_REPL, (const uint8_t *)s, (uint32_t)n);
+}
+
+// Append "<label>0x%08x\n" to the UART.  Self-contained hex formatter so
+// the trap path pulls in no printf machinery.
+static void fault_put_hex(const char *label, uint32_t val) {
+    static const char hexd[] = "0123456789abcdef";
+    char buf[11];
+    buf[0] = '0';
+    buf[1] = 'x';
+    for (int i = 0; i < 8; i++) {
+        buf[2 + i] = hexd[(val >> ((7 - i) * 4)) & 0xf];
+    }
+    buf[10] = '\n';
+    fault_puts(label);
+    uart_write(MICROPY_HW_UART_REPL, (const uint8_t *)buf, sizeof(buf));
+}
+
+// Main trap dispatch, called by crt0's _trap_entry on any trap.
+void trap_dispatch(void) {
+    uint32_t mcause;
+    __asm__ volatile ("csrr %0, mcause" : "=r" (mcause));
+
+    if (mcause == 0x8000000B) {
+        // Machine external interrupt: walk the VexRiscv MIP and dispatch.
+        uint32_t pending = csr_read_mip_vex();
+
+        // Timer0 (bit 30).  No Timer0 handler is registered today; if one
+        // is added it must also clear Timer0's EV_PENDING here (the array
+        // loop below only covers IRQ arrays 0-19).
+        if ((pending & (1 << 30)) && irq_handlers[30]) {
+            irq_handlers[30](1);
+        }
+
+        // IRQ arrays 0-19.
+        for (int i = 0; i < 20; i++) {
+            if (pending & (1 << i)) {
+                volatile uint32_t *ev_pending =
+                    (volatile uint32_t *)(irq_array_base[i] + IRQ_EV_PENDING);
+                uint32_t events = *ev_pending;
+                if (irq_handlers[i]) {
+                    irq_handlers[i](events);
+                }
+                // W1C the pending events AFTER the handler runs.
+                // Mirrors bao1x-hal driver.rs:1556 -- clearing EV_PENDING
+                // before the handler has had a chance to clear the
+                // upstream condition (e.g. USBSTS.EINT / IMAN.IP for the
+                // UDC) leaves an edge-loss window: a new event arriving
+                // during handler dispatch finds EV_PENDING already 0 and
+                // the irqarray's IP-rising edge already consumed, so
+                // when the handler clears IMAN.IP at the end the next
+                // event doesn't re-pulse the irqarray and the IRQ is
+                // lost.  Clearing EV_PENDING last collapses the window
+                // -- any event raised during handling re-sets
+                // EV_PENDING after we clear it here, re-firing the IRQ
+                // on the next dispatch.
+                *ev_pending = events;
+            }
+        }
+
+        // Re-enable machine external interrupts (mie.MEIE).
+        __asm__ volatile ("csrs mie, %0" : : "r" (1 << 11));
+        return;
+    }
+
+    // Unexpected exception: report and halt.  mepc is the faulting PC --
+    // look it up in build-DABAO/firmware.elf to locate the offending
+    // instruction; mcause gives the trap cause, mtval the bad address.
+    uint32_t mepc, mtval;
+    __asm__ volatile ("csrr %0, mepc" : "=r" (mepc));
+    __asm__ volatile ("csrr %0, mtval" : "=r" (mtval));
+
+    // crt0's _trap_entry saved all GPRs to a fixed frame based at
+    // _stack_top: word 0 = ra (x1), word 1 = interrupted sp (x2),
+    // word 8 = s1 (x9), word 31 = mepc.  Read them back to show the
+    // interrupted context (stack depth + return address).
+    extern uint32_t _stack_top;
+    const uint32_t *frame = (const uint32_t *)((uintptr_t)&_stack_top - 34u * 4u);
+
+    fault_puts("\r\n*** baochip TRAP ***\r\n");
+    fault_put_hex("  mcause=", mcause);
+    fault_put_hex("  mepc  =", mepc);
+    fault_put_hex("  mtval =", mtval);
+    fault_put_hex("  ra    =", frame[0]);
+    fault_put_hex("  sp    =", frame[1]);
+    fault_put_hex("  s1    =", frame[8]);
+    fault_puts("  halted\r\n");
+
+    for (volatile int spin = 0; spin == 0; spin = 0) {
+        // Intentional halt: a fault during USB bring-up should stop here
+        // with the dump above, not silently reset into a loop.
+    }
+}

--- a/ports/baochip/crt0.S
+++ b/ports/baochip/crt0.S
@@ -1,0 +1,195 @@
+/*
+ * crt0.S - C runtime startup for the Baochip-1x MicroPython port.
+ *
+ * Derived from the Dabao SDK's runtime/crt0.S (Apache-2.0, Copyright
+ * 2026 Armstrong Subero).  The port owns this copy so the trap entry can
+ * use a dedicated trap stack (_trap_stack_top) instead of carving scratch
+ * space out of the top of the main C stack.  Sharing the main stack let a
+ * deep interrupt handler (the USB DCD event-ring drain) overflow the small
+ * scratch reserve and corrupt the main thread's frames; a separate trap
+ * stack removes that hazard.
+ *
+ * The trap handler saves all 31 GPRs plus mepc/mstatus/orig-sp to the trap
+ * stack, calls the C dispatcher (trap_dispatch), then restores and mret's.
+ * Traps do not nest (mstatus.MIE stays 0 until mret), so a single trap
+ * stack is sufficient.
+ */
+
+    .section .text.start
+    .global _start
+    .type _start, @function
+
+_start:
+    /* Set global pointer (for linker relaxation). */
+    .option push
+    .option norelax
+    la      gp, __global_pointer$
+    .option pop
+
+    /* Main C stack starts at _stack_top (which the linker places just
+     * below the dedicated trap stack) and grows down. */
+    la      sp, _stack_top
+
+    /* Install trap handler. */
+    la      t0, _trap_entry
+    csrw    mtvec, t0
+
+    /* Zero BSS section. */
+    la      t0, _bss_start
+    la      t1, _bss_end
+1:
+    beq     t0, t1, 2f
+    sw      zero, 0(t0)
+    addi    t0, t0, 4
+    j       1b
+2:
+
+    /* Copy .data from RRAM (LMA) to SRAM (VMA). */
+    la      t0, _data_lma
+    la      t1, _data_start
+    la      t2, _data_end
+3:
+    beq     t1, t2, 4f
+    lw      t3, 0(t0)
+    sw      t3, 0(t1)
+    addi    t0, t0, 4
+    addi    t1, t1, 4
+    j       3b
+4:
+
+    /* Call main. */
+    call    main
+
+    /* If main returns, halt. */
+_hang:
+    wfi
+    j       _hang
+
+
+/* ================================================================== */
+/*                        Trap Entry Point                            */
+/* ================================================================== */
+/*
+ * On any interrupt or exception the CPU jumps here.  Save ALL 31 GPRs
+ * (x1-x31) plus mepc / mstatus / the interrupted sp to the dedicated
+ * trap stack, call the C dispatcher, then restore everything and mret.
+ *
+ * mscratch holds the interrupted sp across the save.  The frame and the
+ * C dispatcher both live on the dedicated trap stack (_trap_stack_top),
+ * never on the main stack.
+ */
+
+    .align 4
+    .global _trap_entry
+    .type _trap_entry, @function
+
+_trap_entry:
+    /* Save the interrupted sp, switch to the dedicated trap stack. */
+    csrw    mscratch, sp
+    la      sp, _trap_stack_top
+
+    /* Allocate 34 words: x1-x31 (31) + mepc (1) + mstatus (1) + orig_sp (1). */
+    addi    sp, sp, -(34*4)
+
+    /* Save all general-purpose registers except sp (x2). */
+    sw      x1,   0*4(sp)      /* ra */
+    /* x2 (sp) saved later from mscratch */
+    sw      x3,   2*4(sp)      /* gp */
+    sw      x4,   3*4(sp)      /* tp */
+    sw      x5,   4*4(sp)      /* t0 */
+    sw      x6,   5*4(sp)      /* t1 */
+    sw      x7,   6*4(sp)      /* t2 */
+    sw      x8,   7*4(sp)      /* s0/fp */
+    sw      x9,   8*4(sp)      /* s1 */
+    sw      x10,  9*4(sp)      /* a0 */
+    sw      x11, 10*4(sp)      /* a1 */
+    sw      x12, 11*4(sp)      /* a2 */
+    sw      x13, 12*4(sp)      /* a3 */
+    sw      x14, 13*4(sp)      /* a4 */
+    sw      x15, 14*4(sp)      /* a5 */
+    sw      x16, 15*4(sp)      /* a6 */
+    sw      x17, 16*4(sp)      /* a7 */
+    sw      x18, 17*4(sp)      /* s2 */
+    sw      x19, 18*4(sp)      /* s3 */
+    sw      x20, 19*4(sp)      /* s4 */
+    sw      x21, 20*4(sp)      /* s5 */
+    sw      x22, 21*4(sp)      /* s6 */
+    sw      x23, 22*4(sp)      /* s7 */
+    sw      x24, 23*4(sp)      /* s8 */
+    sw      x25, 24*4(sp)      /* s9 */
+    sw      x26, 25*4(sp)      /* s10 */
+    sw      x27, 26*4(sp)      /* s11 */
+    sw      x28, 27*4(sp)      /* t3 */
+    sw      x29, 28*4(sp)      /* t4 */
+    sw      x30, 29*4(sp)      /* t5 */
+    sw      x31, 30*4(sp)      /* t6 */
+
+    /* Save mepc. */
+    csrr    t0, mepc
+    sw      t0, 31*4(sp)
+
+    /* Save mstatus (to restore MIE state on exit). */
+    csrr    t0, mstatus
+    sw      t0, 32*4(sp)
+
+    /* Save the interrupted sp from mscratch. */
+    csrr    t0, mscratch
+    sw      t0,  1*4(sp)       /* slot 1 = original sp */
+
+    /* Reserve C-dispatcher stack below the register save frame, still
+     * within the dedicated trap stack. */
+    addi    sp, sp, -256
+
+    /* Call the C dispatcher. */
+    call    trap_dispatch
+
+    /* Restore sp to the register save frame. */
+    la      sp, _trap_stack_top
+    addi    sp, sp, -(34*4)
+
+    /* Restore mepc. */
+    lw      t0, 31*4(sp)
+    csrw    mepc, t0
+
+    /* Restore mstatus. */
+    lw      t0, 32*4(sp)
+    csrw    mstatus, t0
+
+    /* Restore all general-purpose registers. */
+    lw      x1,   0*4(sp)
+    /* x2 (sp) restored last */
+    lw      x3,   2*4(sp)
+    lw      x4,   3*4(sp)
+    lw      x5,   4*4(sp)
+    lw      x6,   5*4(sp)
+    lw      x7,   6*4(sp)
+    lw      x8,   7*4(sp)
+    lw      x9,   8*4(sp)
+    lw      x10,  9*4(sp)
+    lw      x11, 10*4(sp)
+    lw      x12, 11*4(sp)
+    lw      x13, 12*4(sp)
+    lw      x14, 13*4(sp)
+    lw      x15, 14*4(sp)
+    lw      x16, 15*4(sp)
+    lw      x17, 16*4(sp)
+    lw      x18, 17*4(sp)
+    lw      x19, 18*4(sp)
+    lw      x20, 19*4(sp)
+    lw      x21, 20*4(sp)
+    lw      x22, 21*4(sp)
+    lw      x23, 22*4(sp)
+    lw      x24, 23*4(sp)
+    lw      x25, 24*4(sp)
+    lw      x26, 25*4(sp)
+    lw      x27, 26*4(sp)
+    lw      x28, 27*4(sp)
+    lw      x29, 28*4(sp)
+    lw      x30, 29*4(sp)
+    lw      x31, 30*4(sp)
+
+    /* Restore the interrupted sp LAST. */
+    lw      x2,   1*4(sp)
+
+    /* Return from trap. */
+    mret

--- a/ports/baochip/main.c
+++ b/ports/baochip/main.c
@@ -31,16 +31,25 @@
 #include "py/gc.h"
 #include "py/lexer.h"
 #include "py/mperrno.h"
+#include "py/mphal.h"
 #include "py/runtime.h"
 #include "py/stackctrl.h"
 #include "shared/runtime/gchelper.h"
 #include "shared/runtime/pyexec.h"
+
+#if MICROPY_HW_ENABLE_USBDEV
+#include "usb/dcd_baochip.h"
+#endif
 
 #include "hardware/irq.h"
 #include "hardware/uart.h"
 
 #include "machine_pin.h"
 #include "mphalport.h"
+
+#if MICROPY_HW_ENABLE_USBDEV
+#include "shared/tinyusb/mp_usbd.h"
+#endif
 
 // Heap and stack bounds defined by the linker script.  _stack_size is
 // the stack reservation size (an absolute value, not an address), so it
@@ -74,6 +83,23 @@ int main(void) {
     mp_stack_set_top(&_stack_top);
     mp_stack_set_limit((size_t)(uintptr_t)&_stack_size - STACK_GUARD_BYTES);
 
+    // Reset the interrupt controller exactly ONCE, before the soft-reset
+    // loop.  irq_init() clears the whole handler table and disables every
+    // MIM line, so it must NOT run per-iteration: the USB DCD interrupt is
+    // registered once (the first mp_usbd_init() -> dcd_init() below) and
+    // tusb_init() is idempotent thereafter, so a per-iteration irq_init()
+    // would silently strip the USB IRQ and leave native USB-CDC input dead
+    // after the first soft reset.  Per-iteration handler (re)registration
+    // happens inside the loop via mp_hal_stdin_uart_irq_init(), which no
+    // longer resets the controller.
+    irq_init();
+    #if MICROPY_HW_ENABLE_USBDEV
+    // Register the UDC IRQ vector once, before the soft-reset loop.
+    // irq_init() cleared the handler table; the DCD itself no longer
+    // registers the vector so we do it here explicitly.
+    dcd_baochip_irq_register();
+    #endif
+
     // Outer loop: each iteration is one full MicroPython session.
     // pyexec_friendly_repl returns non-zero on Ctrl-D, at which point
     // we tear down, re-init, and re-enter -- matching the soft-reset
@@ -88,16 +114,34 @@ int main(void) {
         gc_init(&_heap_start, &_heap_end);
         trace("TRACE:mp_init\r\n");
         mp_init();
-        trace("TRACE:irq_init\r\n");
+        trace("TRACE:uart_irq\r\n");
 
         // UART RX IRQ feeds stdin_ringbuf; the handler may call
         // mp_sched_keyboard_interrupt() on a Ctrl-C byte, which writes
         // into MicroPython scheduler state, so this must run AFTER
-        // mp_init() has initialised that state.  Setting up once per
-        // session iteration is harmless -- irq_init clears the handler
-        // table and re-enables MIE/MEIE each time.
+        // mp_init() has initialised that state.  Re-registering the UART
+        // handler each iteration is harmless and idempotent -- the
+        // controller itself was reset once before the loop, so this only
+        // (re)sets the UART handler slot and re-enables its MIM line; the
+        // USB DCD handler slot is left untouched and survives soft reset.
         mp_hal_stdin_uart_irq_init();
         trace("TRACE:repl\r\n");
+
+        #if MICROPY_HW_ENABLE_USBDEV
+        // TinyUSB stack init.  tusb_init() is idempotent, so on the first
+        // iteration this brings up the DCD (and registers + enables the
+        // USB interrupt); on later iterations it is a no-op and the
+        // already-enumerated device persists across the soft reset.
+        mp_usbd_init();
+        // Re-arm the UDC interrupt for this session.  It was masked
+        // (dcd_baochip_irq_pause) before the previous mp_deinit() so a
+        // USB event couldn't run the DCD ISR -> mp_sched_schedule_node
+        // against a half-rebuilt runtime.  Idempotent on the first
+        // iteration (dcd_init already enabled it).
+        dcd_baochip_irq_resume();
+        #endif
+
+        mp_printf(MP_PYTHON_PRINTER, "\nMicroPython baochip port\n");
 
         for (;;) {
             if (pyexec_mode_kind == PYEXEC_MODE_RAW_REPL) {
@@ -112,7 +156,17 @@ int main(void) {
         }
 
         mp_printf(MP_PYTHON_PRINTER, "MPY: soft reboot\n");
+        // Quiesce the interrupt sources whose handlers touch MicroPython
+        // scheduler state before tearing the runtime down.  The UART RX
+        // handler calls mp_sched_keyboard_interrupt(); the UDC handler
+        // schedules the TinyUSB task.  Both would corrupt a half-torn-down
+        // runtime if they fired during mp_deinit().  The UART line is
+        // re-enabled by mp_hal_stdin_uart_irq_init() and the UDC line by
+        // dcd_baochip_irq_resume(), both on the next loop iteration.
         irq_disable(IRQ_UART);
+        #if MICROPY_HW_ENABLE_USBDEV
+        dcd_baochip_irq_pause();
+        #endif
         mp_deinit();
     }
 }

--- a/ports/baochip/modmachine.c
+++ b/ports/baochip/modmachine.c
@@ -34,8 +34,29 @@
 #include "hardware/gpio.h"
 #include "machine_pin.h"
 
+#if MICROPY_HW_ENABLE_USBDEV
+#include "usb/dcd_baochip.h"
+
+// Manually trigger the deferred USB controller re-bring-up.  Escape hatch
+// for the stochastic native-CDC wedge that leaves no firmware-visible USB
+// signal: the re-init runs on the next scheduler tick and briefly (~0.5 s)
+// stalls the scheduler while the controller re-brings-up and the host
+// re-enumerates.
+static mp_obj_t machine_usb_reinit(void) {
+    dcd_baochip_request_reinit();
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_0(machine_usb_reinit_obj, machine_usb_reinit);
+
 #define MICROPY_PY_MACHINE_EXTRA_GLOBALS \
     { MP_ROM_QSTR(MP_QSTR_Pin), MP_ROM_PTR(&machine_pin_type) }, \
+    { MP_ROM_QSTR(MP_QSTR_usb_reinit), MP_ROM_PTR(&machine_usb_reinit_obj) }, \
+
+#else
+#define MICROPY_PY_MACHINE_EXTRA_GLOBALS \
+    { MP_ROM_QSTR(MP_QSTR_Pin), MP_ROM_PTR(&machine_pin_type) }, \
+
+#endif
 
 static void mp_machine_idle(void) {
     __asm__ volatile ("wfi");
@@ -55,18 +76,29 @@ static mp_int_t mp_machine_reset_cause(void) {
 }
 
 // Drive PC13 (PROG strap) LOW then reset so boot1 enters its CDC REPL.
-// gpio_init tears down any prior alt-function so gpio_set_dir actually
-// takes effect.  PC13 is dual-use: it is BOTH the boot strap AND the
-// 0.85 V regulator feedback path on Dabao, so driving it must be brief
-// (~1 ms) and only at the moment of reset.  Setting the data latch
-// before flipping the direction prevents a high-Z glitch.
+// PC13 is dual-use on Dabao: it is BOTH the boot strap AND the
+// board-level USB SE0 shunt (driving it low forces D+/D- to ground,
+// signalling a real wire-level disconnect to the host).  The DCD
+// teardown below uses that to give the host time to see disconnect
+// before the chip reset, and leaves PC13 driven low so PROG is
+// asserted at reset.  Without the teardown, boot1 inherits a live USB
+// pull-up from our DCD and the host never registers a clean
+// disconnect-then-reconnect transition, which on the tentacle's
+// TinyUSB host manifests as stuck CDC bulk endpoints.
 MP_NORETURN void mp_machine_bootloader(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     (void)args;
+    #if MICROPY_HW_ENABLE_USBDEV
+    // Drives PC13 low, holds 100 ms for SE0 to register, soft-resets the
+    // UDC, zeroes IFRAM.
+    dcd_baochip_teardown();
+    #else
+    // No USB DCD running -- just assert PROG and reset.
     gpio_init(pin_PC13->port, pin_PC13->pin);
     gpio_put(pin_PC13->port, pin_PC13->pin, false);
     gpio_set_dir(pin_PC13->port, pin_PC13->pin, true);
     mp_hal_delay_us(1000);
+    #endif
     bao_software_reset();
     for (;;) {
     }

--- a/ports/baochip/mpconfigport.h
+++ b/ports/baochip/mpconfigport.h
@@ -96,6 +96,14 @@ typedef long mp_off_t;
 #ifndef MICROPY_HW_USB_PID
 #define MICROPY_HW_USB_PID          (0x9802)
 #endif
+// Workaround for the Corigine UDC IRQ-propagation bug
+// (USBSTS.EINT=1 with IMAN.IP=0 / EV_PENDING=0 -- see
+// dcd_baochip_poll_pending_events() in usb/dcd_baochip.h).
+// MICROPY_INTERNAL_EVENT_HOOK is the canonical MicroPython macro called
+// by mp_event_handle_nowait() and mp_event_wait_ms() -- same pattern
+// used by esp8266 (ets_loop_iter()), renesas-ra, etc.
+extern void dcd_baochip_poll_pending_events(void);
+#define MICROPY_INTERNAL_EVENT_HOOK     dcd_baochip_poll_pending_events()
 #endif
 
 // Board-specific overrides.

--- a/ports/baochip/mpconfigport.h
+++ b/ports/baochip/mpconfigport.h
@@ -39,6 +39,8 @@
 #define MICROPY_ALLOC_PATH_MAX      (128)
 #define MICROPY_ALLOC_PARSE_CHUNK_INIT (32)
 #define MICROPY_ENABLE_GC           (1)
+#define MICROPY_ENABLE_SCHEDULER    (1)
+#define MICROPY_SCHEDULER_STATIC_NODES (1)
 #define MICROPY_HELPER_REPL         (1)
 #define MICROPY_REPL_AUTO_INDENT    (1)
 #define MICROPY_KBD_EXCEPTION       (1)
@@ -52,14 +54,11 @@
 #define MICROPY_PY_MACHINE_RESET                (1)
 #define MICROPY_PY_MACHINE_BARE_METAL_FUNCS     (1)
 #define MICROPY_PY_MACHINE_DISABLE_IRQ_ENABLE_IRQ (1)
-#define MICROPY_PY_IO               (1)
-#define MICROPY_PY_SYS              (1)
 #define MICROPY_PY_SYS_PLATFORM     "baochip"
-#define MICROPY_PY_SYS_STDFILES     (1)
-#define MICROPY_PY_OS               (1)
 #define MICROPY_PY_OS_UNAME         (1)
-#define MICROPY_PY_GC               (1)
-#define MICROPY_PY_TIME             (1)
+#ifndef MICROPY_PY_OS_DUPTERM
+#define MICROPY_PY_OS_DUPTERM       (1)
+#endif
 #define MICROPY_PY_TIME_TIME_TIME_NS (0)
 
 // All port-side root pointers live alongside the vm-side ones.
@@ -80,6 +79,23 @@ typedef long mp_off_t;
 #endif
 #ifndef MICROPY_HW_UART_REPL_BAUD
 #define MICROPY_HW_UART_REPL_BAUD   (115200)
+#endif
+
+// Native USB device support.
+#ifndef MICROPY_HW_ENABLE_USBDEV
+#define MICROPY_HW_ENABLE_USBDEV    (1)
+#endif
+
+#if MICROPY_HW_ENABLE_USBDEV
+#ifndef MICROPY_HW_USB_CDC
+#define MICROPY_HW_USB_CDC          (1)
+#endif
+#ifndef MICROPY_HW_USB_VID
+#define MICROPY_HW_USB_VID          (0xf055)
+#endif
+#ifndef MICROPY_HW_USB_PID
+#define MICROPY_HW_USB_PID          (0x9802)
+#endif
 #endif
 
 // Board-specific overrides.

--- a/ports/baochip/mphalport.c
+++ b/ports/baochip/mphalport.c
@@ -40,6 +40,16 @@
 #include "hardware/regs/udma.h"
 #include "hardware/uart.h"
 
+#if MICROPY_HW_ENABLE_USBDEV
+#include "shared/tinyusb/mp_usbd.h"
+#include "shared/tinyusb/mp_usbd_cdc.h"
+#include "usb/dcd_baochip.h"
+#endif
+
+#if MICROPY_PY_OS_DUPTERM
+#include "extmod/misc.h"
+#endif
+
 #ifndef MICROPY_HW_STDIN_BUFFER_LEN
 #define MICROPY_HW_STDIN_BUFFER_LEN 256
 #endif
@@ -87,31 +97,74 @@ static void stdout_flush(void) {
     }
 }
 
-void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
-    bool ends_with_newline = (len > 0) && (str[len - 1] == '\n');
-    mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
-    while (len > 0) {
-        size_t space = STDOUT_TXBUF_SIZE - stdout_txbuf_len;
-        if (len >= space) {
-            memcpy(stdout_txbuf + stdout_txbuf_len, str, space);
-            stdout_txbuf_len = STDOUT_TXBUF_SIZE;
+mp_uint_t mp_hal_stdout_tx_strn(const char *str, size_t len) {
+    mp_uint_t ret = len;
+    bool did_write = false;
+
+    // UART path: buffered, line-flushed for the USB/IP bridge.
+    {
+        const char *uart_str = str;
+        size_t uart_len = len;
+        bool ends_with_newline = (uart_len > 0) && (uart_str[uart_len - 1] == '\n');
+        mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+        while (uart_len > 0) {
+            size_t space = STDOUT_TXBUF_SIZE - stdout_txbuf_len;
+            if (uart_len >= space) {
+                memcpy(stdout_txbuf + stdout_txbuf_len, uart_str, space);
+                stdout_txbuf_len = STDOUT_TXBUF_SIZE;
+                stdout_flush();
+                uart_str += space;
+                uart_len -= space;
+            } else {
+                memcpy(stdout_txbuf + stdout_txbuf_len, uart_str, uart_len);
+                stdout_txbuf_len += uart_len;
+                break;
+            }
+        }
+        // Flush line-buffered: keeps print() output prompt when the REPL is
+        // not blocked on stdin.  Bursts without a trailing newline stay
+        // buffered so the USB/IP bridge sees one TCP segment per logical
+        // message.
+        if (ends_with_newline) {
             stdout_flush();
-            str += space;
-            len -= space;
-        } else {
-            memcpy(stdout_txbuf + stdout_txbuf_len, str, len);
-            stdout_txbuf_len += len;
-            break;
+        }
+        MICROPY_END_ATOMIC_SECTION(atomic_state);
+        did_write = true;
+    }
+
+    #if MICROPY_HW_USB_CDC
+    // tud_rhport_init() in lib/tinyusb/src/device/usbd.c sets
+    // _usbd_rhport BEFORE calling dcd_init, so tusb_inited() returns
+    // true during dcd_init.  mp_usbd_cdc_tx_strn's own guard accepts
+    // that and proceeds to spin tud_task_ext() and tud_cdc_write_flush()
+    // for up to MICROPY_HW_USB_CDC_TX_TIMEOUT (500 ms default) per
+    // call.  Any mp_printf inside dcd_init then recurses into the
+    // very TinyUSB stack that's still bringing itself up, which on
+    // this controller hangs dcd_init before it reaches the final
+    // USBCMD.RUN_STOP write.
+    //
+    // tud_ready() is the right gate: it returns true only when the
+    // device is configured (post SET_CONFIG).  CDC writes before that
+    // would have nowhere to go anyway.
+    //
+    if (tud_ready()) {
+        mp_uint_t cdc_res = mp_usbd_cdc_tx_strn(str, len);
+        if (cdc_res > 0) {
+            did_write = true;
+            ret = MIN(cdc_res, ret);
         }
     }
-    // Flush line-buffered: keeps print() output prompt when the REPL is
-    // not blocked on stdin.  Bursts without a trailing newline stay
-    // buffered so the USB/IP bridge sees one TCP segment per logical
-    // message.
-    if (ends_with_newline) {
-        stdout_flush();
+    #endif
+
+    #if MICROPY_PY_OS_DUPTERM
+    int dupterm_res = mp_os_dupterm_tx_strn(str, len);
+    if (dupterm_res >= 0) {
+        did_write = true;
+        ret = MIN((mp_uint_t)dupterm_res, ret);
     }
-    MICROPY_END_ATOMIC_SECTION(atomic_state);
+    #endif
+
+    return did_write ? ret : 0;
 }
 
 // mp_hal_stdout_tx_str and mp_hal_stdout_tx_strn_cooked come from
@@ -121,11 +174,25 @@ void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
 int mp_hal_stdin_rx_chr(void) {
     stdout_flush();
     for (;;) {
+        #if MICROPY_HW_USB_CDC
+        // Same reasoning as in mp_hal_stdout_tx_strn: only pump CDC
+        // once the device is configured.  Before tud_ready(),
+        // mp_usbd_cdc_poll_interfaces() would call mp_usbd_task()
+        // which could recurse into a half-initialised TinyUSB stack.
+        if (tud_ready()) {
+            mp_usbd_cdc_poll_interfaces(0);
+        }
+        #endif
         int c = ringbuf_get(&stdin_ringbuf);
         if (c != -1) {
             return c;
         }
-        // The RX_CHAR ISR feeds stdin_ringbuf; nothing to poll here.
+        #if MICROPY_PY_OS_DUPTERM
+        int dupterm_c = mp_os_dupterm_rx_chr();
+        if (dupterm_c >= 0) {
+            return dupterm_c;
+        }
+        #endif
         mp_event_handle_nowait();
     }
 }
@@ -138,6 +205,14 @@ uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
     if (poll_flags & MP_STREAM_POLL_WR) {
         ret |= MP_STREAM_POLL_WR;
     }
+    #if MICROPY_HW_USB_CDC
+    if (tud_ready()) {
+        ret |= mp_usbd_cdc_poll_interfaces(poll_flags);
+    }
+    #endif
+    #if MICROPY_PY_OS_DUPTERM
+    ret |= mp_os_dupterm_poll(poll_flags);
+    #endif
     return ret;
 }
 
@@ -194,8 +269,14 @@ void mp_hal_uart_repl_init(void) {
 // irq_enable_events() also enables the IRQ line in MIM; a separate
 // irq_enable() would override EV_ENABLE to 0xFFFF, enabling every
 // event for every UART instance -- specifically not what we want.
+//
+// This must NOT call irq_init(): that resets the whole interrupt
+// controller (clears every handler slot, zeroes MIM), which would strip
+// the USB DCD interrupt registered during the first mp_usbd_init() and
+// leave native USB-CDC input dead after a soft reset.  main() calls
+// irq_init() once before the soft-reset loop; here we only (re)register
+// the UART REPL handler, which is idempotent across iterations.
 void mp_hal_stdin_uart_irq_init(void) {
-    irq_init();
     irq_set_handler(IRQ_UART, uart_repl_irq_handler);
     irq_enable_events(IRQ_UART, REPL_UART_RX_CHAR_EVT | REPL_UART_ERR_EVT);
 }
@@ -242,9 +323,18 @@ void mp_hal_delay_us(mp_uint_t us) {
     }
 }
 
+// Sleeps `ms` milliseconds while pumping the MicroPython event loop.
+// Calling mp_event_handle_nowait() inside the busy-wait is LOAD-BEARING
+// for USB device support: when a SETUP packet arrives in the DCD IRQ,
+// the descriptor response is dispatched via a scheduled callback
+// (mp_sched_schedule_node) so that the work happens in non-ISR
+// context.  If main() ever sits in a busy-wait without pumping
+// scheduled tasks, those callbacks never run and the host times out
+// waiting for the response, so enumeration silently stalls.
 void mp_hal_delay_ms(mp_uint_t ms) {
     uint64_t start = ticktimer_read_us();
     uint64_t target = (uint64_t)ms * 1000U;
     while ((ticktimer_read_us() - start) < target) {
+        mp_event_handle_nowait();
     }
 }

--- a/ports/baochip/mphalport.h
+++ b/ports/baochip/mphalport.h
@@ -54,6 +54,12 @@ static inline void enable_irq(mp_uint_t state) {
 
 #define MICROPY_INTERNAL_WFE(TIMEOUT_MS)   __asm__ volatile ("wfi")
 
+// Required by shared/tinyusb/mp_usbd.c.  No tickless idle on this
+// port yet, so a no-op is correct: the main loop is already
+// polling-style.
+static inline void mp_hal_wake_main_task_from_isr(void) {
+}
+
 #include "hardware/gpio.h"
 #include "machine_pin.h"
 

--- a/ports/baochip/tusb_config.h
+++ b/ports/baochip/tusb_config.h
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 MicroPython contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_BAOCHIP_TUSB_CONFIG_H
+#define MICROPY_INCLUDED_BAOCHIP_TUSB_CONFIG_H
+
+// Corigine UDC IP on Baochip-1x SoC; TUP_DCD_ENDPOINT_MAX and
+// TUP_RHPORT_HIGHSPEED are set by tusb_mcu.h for this MCU.
+#define CFG_TUSB_MCU                OPT_MCU_CORIGINE_BAO1X
+#define CFG_TUSB_OS                 OPT_OS_NONE
+
+// SE0 is driven by PC13, which doubles as the PROG strap on Dabao.
+// Driving it low forces D+/D- to ground (clean disconnect) and holds
+// the PROG pin asserted during a chip reset into boot1.
+#define TUD_CORIGINE_SE0_ASSERT() \
+    do { gpio_set_dir(GPIO_PORT_C, 13, true); gpio_put(GPIO_PORT_C, 13, false); } while (0)
+#define TUD_CORIGINE_SE0_DEASSERT() \
+    do { gpio_put(GPIO_PORT_C, 13, true); gpio_set_dir(GPIO_PORT_C, 13, false); } while (0)
+
+// UDC DMA buffers must be IFRAM-resident on Baochip-1x.
+#define TUD_CORIGINE_DMA_ATTR  __attribute__((section(".dma_buffers"), aligned(64)))
+
+// The Corigine PHY is HS-capable.  DEVCONFIG.MAX_SPEED in
+// dcd_corigine_udc.c must match.
+#define CFG_TUD_ENABLED             1
+#define CFG_TUD_MAX_SPEED           OPT_MODE_HIGH_SPEED
+#define CFG_TUH_ENABLED             0
+
+// Control EP0 size stays at 64 bytes per spec.
+#ifndef CFG_TUD_ENDPOINT0_SIZE
+#define CFG_TUD_ENDPOINT0_SIZE      64
+#endif
+
+// Bulk EP buffer size: keep at HS maximum.  The shared MicroPython
+// tusb_config.h sets RX/TX buffer sizes based on CFG_TUD_MAX_SPEED.
+#define CFG_TUD_CDC_EP_BUFSIZE      512
+
+// MSC and other classes are deferred.  MICROPY_HW_USB_MSC /
+// MICROPY_HW_USB_CDC drive the shared config below; CDC defaults on
+// for this port (set in mpconfigport.h).
+
+// Bring in MicroPython-shared defaults (string descriptors, class
+// gating, endpoint numbering).  Must come after the per-port
+// definitions above so this file can override them when needed.
+#include "shared/tinyusb/tusb_config.h"
+
+#endif // MICROPY_INCLUDED_BAOCHIP_TUSB_CONFIG_H

--- a/ports/baochip/usb/dcd_baochip.h
+++ b/ports/baochip/usb/dcd_baochip.h
@@ -60,4 +60,34 @@ void dcd_baochip_irq_resume(void);
 // dcd_init has run.
 void dcd_baochip_request_reinit(void);
 
+// Workaround for a Corigine UDC hardware bug: occasionally the IRQ
+// chain stops delivering edges while the controller continues to
+// write events to the event ring.  At wedge time we have:
+//
+//   USBSTS.EINT = 1   (controller asserting "event interrupt pending")
+//   IMAN.IE     = 1   (interrupter enable still set)
+//   IMAN.IP     = 0   (NOT asserting -- propagation broken)
+//   EV_PENDING  = 0   (irqarray sees no pending event)
+//
+// Software-level re-arming of IMAN (W1C IP, re-write IE, blanket
+// EV_PENDING clear, EV_ENABLE re-arm) all empirically make the wedge
+// fire faster -- the race is in a layer below software.  See
+// notes/dabao-port-investigation.md (2026-06-14 entries) and
+// notes/captures/usbmon-wedge-2026-06-14.pcap for the wire-level
+// evidence: EP0 control transfers (typically SET_CONTROL_LINE_STATE
+// at CDC port open/close) take 5 s to complete and Linux unlinks them
+// with -ENOENT.
+//
+// This function is the agreed workaround.  It reads USBSTS.EINT and,
+// if set, runs dcd_int_handler() directly.  Wired into the standard
+// MicroPython event pump via MICROPY_INTERNAL_EVENT_HOOK
+// (mpconfigport.h), so it runs on every mp_event_handle_nowait() and
+// mp_event_wait_ms() call -- the same sites where other ports pump
+// port-specific event work.  Cost in the healthy path is one register
+// read.
+//
+// This function must remain; without it the device wedges under sustained
+// CDC churn (see notes/corigine-udc-irq-bug-report.md).
+void dcd_baochip_poll_pending_events(void);
+
 #endif // MICROPY_INCLUDED_BAOCHIP_USB_DCD_BAOCHIP_H

--- a/ports/baochip/usb/dcd_baochip.h
+++ b/ports/baochip/usb/dcd_baochip.h
@@ -1,0 +1,63 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 MicroPython contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_BAOCHIP_USB_DCD_BAOCHIP_H
+#define MICROPY_INCLUDED_BAOCHIP_USB_DCD_BAOCHIP_H
+
+#include <stdint.h>
+#include "dcd_corigine_udc.h"
+
+// Register the UDC IRQ vector and enable its event bits.  Called once
+// after irq_init(), before the TinyUSB stack starts.
+void dcd_baochip_irq_register(void);
+
+// Tear down the Corigine UDC ahead of a chip-level soft reset.
+// Drives the board-level SE0 pin (PC13) low to signal disconnect, masks
+// the UDC IRQ, halts and soft-resets the controller, and zeroes the
+// IFRAM working set so boot1 inherits clean memory.  Leaves PC13
+// driven low; the caller is expected to immediately call
+// bao_software_reset() so the boot strap is asserted at reset.
+//
+// Safe to call when dcd_init has not run -- becomes a no-op aside from
+// driving PC13 low.
+void dcd_baochip_teardown(void);
+
+// Mask / unmask the UDC interrupt at the CPU level across a MicroPython
+// soft reset.  The DCD interrupt persists across soft reset (so the CDC
+// stays enumerated) but its handler touches MicroPython scheduler state,
+// so main() pauses it before mp_deinit() and resumes it after the next
+// mp_usbd_init().  Both are no-ops until dcd_init has run.
+void dcd_baochip_irq_pause(void);
+void dcd_baochip_irq_resume(void);
+
+// Request a deferred full USB controller re-bring-up, run from task
+// context on the next scheduler tick.  Escape hatch for the stochastic
+// native-CDC wedge that leaves no firmware-visible USB signal (see
+// udc_perform_reinit); exposed as machine.usb_reinit().  No-op until
+// dcd_init has run.
+void dcd_baochip_request_reinit(void);
+
+#endif // MICROPY_INCLUDED_BAOCHIP_USB_DCD_BAOCHIP_H

--- a/ports/baochip/usb/dcd_baochip_port.c
+++ b/ports/baochip/usb/dcd_baochip_port.c
@@ -1,0 +1,101 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 MicroPython contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// MicroPython port glue for the Corigine UDC TinyUSB DCD.
+// Handles IRQ registration, MicroPython scheduler integration,
+// and port-supplied callbacks (time source, serial number).
+
+#include "py/mpconfig.h"
+
+#if MICROPY_HW_ENABLE_USBDEV
+
+#include <string.h>
+
+#include "py/mphal.h"
+#include "py/runtime.h"
+
+#include "hardware/irq.h"
+#include "tusb_config.h"
+#include "device/dcd.h"
+
+#include "dcd_baochip.h"
+#include "udc_regs.h"
+
+// IRQ vector: trampoline into the TinyUSB DCD handler.
+static void udc_irq_handler(uint32_t pending) {
+    (void)pending;
+    dcd_int_handler(0);
+}
+
+// Register the UDC IRQ vector and enable its event bits.  Called once
+// after irq_init(), before the TinyUSB stack is started.
+void dcd_baochip_irq_register(void) {
+    irq_set_handler(IRQ_ARRAY1, udc_irq_handler);
+    irq_enable_events(IRQ_ARRAY1, UDC_IRQARRAY_USBC_BIT | UDC_IRQARRAY_SW_BIT);
+}
+
+// Mask / unmask the UDC interrupt across a MicroPython soft reset so
+// the DCD ISR cannot fire against a half-rebuilt runtime.
+void dcd_baochip_irq_pause(void) {
+    dcd_int_disable(0);
+}
+
+void dcd_baochip_irq_resume(void) {
+    dcd_int_enable(0);
+}
+
+// Deferred full controller re-bring-up, scheduled via the MicroPython
+// scheduler so it runs in task context, not inside an ISR.
+static mp_sched_node_t udc_reinit_node;
+static void udc_reinit_sched_cb(mp_sched_node_t *node) {
+    (void)node;
+    dcd_corigine_reinit(0);
+}
+
+void dcd_baochip_request_reinit(void) {
+    mp_sched_schedule_node(&udc_reinit_node, udc_reinit_sched_cb);
+}
+
+// Tear down the UDC ahead of a chip-level soft reset.  Drives SE0,
+// halts and soft-resets the controller, zeroes IFRAM.  SE0 (PC13) is
+// left asserted on return so PROG is held during the chip reset.
+void dcd_baochip_teardown(void) {
+    dcd_corigine_teardown(0);
+}
+
+// TinyUSB time source.
+uint32_t tusb_time_millis_api(void) {
+    return (uint32_t)mp_hal_ticks_ms();
+}
+
+// USB serial number descriptor.  Placeholder until the chip UID
+// register is surfaced.
+void mp_usbd_port_get_serial_number(char *buf) {
+    static const char placeholder[] = "BAOCHIP0000000001";
+    memcpy(buf, placeholder, sizeof(placeholder));
+}
+
+#endif // MICROPY_HW_ENABLE_USBDEV

--- a/ports/baochip/usb/dcd_baochip_port.c
+++ b/ports/baochip/usb/dcd_baochip_port.c
@@ -67,6 +67,12 @@ void dcd_baochip_irq_resume(void) {
     dcd_int_enable(0);
 }
 
+// Poll the UDC for pending events that the IRQ chain may have missed.
+// Wired into MICROPY_INTERNAL_EVENT_HOOK (see mpconfigport.h).
+void dcd_baochip_poll_pending_events(void) {
+    dcd_corigine_poll_pending_events(0);
+}
+
 // Deferred full controller re-bring-up, scheduled via the MicroPython
 // scheduler so it runs in task context, not inside an ISR.
 static mp_sched_node_t udc_reinit_node;


### PR DESCRIPTION
### Summary

Adds USB-CDC support to the baochip port, stacked on the base port PR (#47).

The Corigine UDC DCD is implemented as a proper TinyUSB portable driver under `src/portable/corigine/udc/` in a TinyUSB fork ([andrewleech/tinyusb:corigine-udc](https://github.com/andrewleech/tinyusb/tree/corigine-udc)). `OPT_MCU_CORIGINE_BAO1X = 2700` is registered as the new MCU identifier; the port supplies SE0 pin macros and the IFRAM DMA section attribute via `tusb_config.h`. IRQ wiring, scheduler integration, soft-reset pause/resume, and the deferred reinit helper live in `dcd_baochip_port.c`.

A second commit wires in a workaround for a Corigine UDC hardware bug: `USBSTS.EINT=1` can be set while `IMAN.IP=0` and `EV_PENDING=0`, stalling the IRQ chain under sustained CDC open/close churn. The fix polls USBSTS.EINT directly on every `MICROPY_INTERNAL_EVENT_HOOK` invocation; cost on the healthy path is one register read. The bug and the fix are documented in `notes/corigine-udc-irq-bug-report.md` (a vendor bug report ready to send).

`MICROPY_HW_ENABLE_USBDEV=0` continues to build cleanly for UART-only mode.

The TinyUSB fork PR will need to be submitted upstream to hathach/tinyusb separately before this lands.

### Testing

Tested on the Dabao board. USB-CDC enumerates as `f055:9802`, REPL accessible via `mpremote connect`, soft reset (Ctrl-D) survives without USB disconnection. `MICROPY_HW_ENABLE_USBDEV=0` build confirmed.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the description above.

---
For conveneient testing here's a copy of firmware built from this branch: 
[firmware.zip](https://github.com/user-attachments/files/29429866/firmware.zip)

Unzip that to get the uf2 file.

On the dabao hold the PROG button as you plug the usb cable into computer.
Flash with drag and drop to the flash drive that pops up, after the copy has completed tap the prog button again to reboot into application (micropython).

Instead of the drag a drop, the  SDK serial flash tool can be used in the same bootloader mode:
```
python dabao-sdk/tools/serial_flash.py <port> firmware-DABAO.uf2
```
After flashing, micropython with USB-CDC enumerates as f055:9802. Connect with `mpremote connect <port>`.

