### PR TITLE
tools/mpremote: Add a debug command for running code under debugpy.

### DIFF
--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -72,6 +72,7 @@ The full list of supported commands are:
 - `eval <mpremote_command_eval>`
 - `exec <mpremote_command_exec>`
 - `run <mpremote_command_run>`
+- `debug <mpremote_command_debug>`
 - `fs <mpremote_command_fs>`
 - `df <mpremote_command_df>`
 - `edit <mpremote_command_edit>`
@@ -214,6 +215,31 @@ The full list of supported commands are:
   By default, ``mpremote run`` will display any output from the script until it
   terminates. The ``--no-follow`` flag can be specified to return immediately and leave
   the device running the script in the background.
+
+.. _mpremote_command_debug:
+
+- **debug** -- debug a script on the device with a DAP client:
+
+  .. code-block:: bash
+
+      $ mpremote debug <target> [module[:method]]
+
+  ``target`` is a connect string as accepted by ``mpremote connect`` (``unix``
+  is accepted but not yet implemented). ``module[:method]`` names the code to
+  run under the debugger and defaults to ``target:main``. The device reports
+  its debug-server endpoint and firmware capabilities as soon as it has bound
+  the listening socket, before any DAP client attaches; a DAP client then
+  connects to that endpoint. ``--port`` sets the listening port; left unset,
+  the device applies its own default. ``--port 0`` is rejected: it asks the
+  system to choose, which the device can only report back through
+  ``getsockname()``, and no port currently binds it. ``--timeout`` sets how long
+  to wait for the device's report. ``--dap-log`` is accepted but not yet
+  implemented. The command returns once it has printed the endpoint, leaving
+  the device waiting for a client to attach; note that a board with no network
+  interface reports the wildcard ``0.0.0.0``, which is not an address to
+  connect to. As with any other mpremote option,
+  ``--port``/``--timeout``/``--dap-log`` must come before
+  ``target``/``module[:method]``.
 
 .. _mpremote_command_fs:
 

--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -236,10 +236,12 @@ The full list of supported commands are:
   it asks the system to choose, which the device can only report back
   through ``getsockname()``, and no port currently binds it. ``--timeout``
   sets how long to wait for the device's report. ``--dap-log`` is accepted
-  but not yet implemented. The command returns once it has printed the
-  endpoint, leaving the device waiting for a client to attach; note that a
-  board with no network interface reports the wildcard ``0.0.0.0``, which is
-  not an address to connect to. As with any other mpremote option,
+  but not yet implemented. A device reporting a real address prints it
+  verbatim and the command returns, leaving the device waiting for a client
+  to attach; a board with no address to report (no network interface, or one
+  the firmware can't read) reports the wildcard ``0.0.0.0``, which is not an
+  address to connect to, so the command errors instead of printing an
+  endpoint. As with any other mpremote option,
   ``--port``/``--timeout``/``--dap-log`` must come before
   ``target``/``module[:method]``.
 

--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -226,7 +226,7 @@ The full list of supported commands are:
 
   ``target`` is either the name of a target defined in a project's
   ``mpdebug.toml`` (see below), a connect string as accepted by ``mpremote
-  connect``, or ``unix`` (accepted but not yet implemented). ``module[:method]``
+  connect``, or ``unix`` (a local unix-port build). ``module[:method]``
   names the code to run under the debugger; it defaults to the resolved
   target's own ``program``, or ``target:main`` if there is none. The device
   reports its debug-server endpoint and firmware capabilities as soon as it
@@ -235,15 +235,37 @@ The full list of supported commands are:
   left unset, the device applies its own default. ``--port 0`` is rejected:
   it asks the system to choose, which the device can only report back
   through ``getsockname()``, and no port currently binds it. ``--timeout``
-  sets how long to wait for the device's report. ``--dap-log`` is accepted
-  but not yet implemented. A device reporting a real address prints it
-  verbatim and the command returns, leaving the device waiting for a client
-  to attach; a board with no address to report (no network interface, or one
-  the firmware can't read) reports the wildcard ``0.0.0.0``, which is not an
-  address to connect to, so the command errors instead of printing an
-  endpoint. As with any other mpremote option,
-  ``--port``/``--timeout``/``--dap-log`` must come before
+  sets how long to wait for the device's report; it does not bound anything
+  after that - a session with ``--dap-log`` stays attached, waiting for its
+  one client, for as long as it takes. A device reporting a real address
+  prints it verbatim and the command returns, leaving the device waiting
+  for a client to attach; a board with no address to report (no network
+  interface, or one the firmware can't read) reports the wildcard
+  ``0.0.0.0``, which is not an address to connect to, so the command errors
+  instead of printing an endpoint. As with any other mpremote option,
+  ``--port``/``--timeout``/``--dap-log``/``--dap-log-file`` must come before
   ``target``/``module[:method]``.
+
+  ``--dap-log`` records every DAP message (timestamp, direction, decoded
+  JSON) as JSONL. mpremote never sits in the data path a plain ``debug``
+  reports, so logging works by interposing a local proxy, bound to
+  loopback only, and reporting the proxy's endpoint instead of the
+  device's. Without ``--port``, the proxy binds an OS-assigned port; with
+  it, ``--port`` pins the proxy's (client-facing) port instead of the
+  device's, so a launch.json with a fixed port still goes through the
+  logger - the device is given a separate, freshly reserved port of its
+  own. Once a client attaches, the proxy connects through to the device and
+  pumps both directions. The proxy serves that one client session and does
+  not re-arm afterwards; a second client attaching to the same reported
+  endpoint hangs rather than reaching the device. ``--dap-log-file FILE``
+  names the JSONL path (an error unless ``--dap-log`` is also given);
+  omitted, it defaults to a timestamped file in the current directory.
+  Because a proxy has to keep running for the client to reach the device
+  through it, ``--dap-log`` changes the command's lifetime on a serial or
+  network target: instead of reporting and returning immediately, it stays
+  attached for the one client session the proxy serves, until that session
+  ends or Ctrl-C/SIGTERM ends it. The unix target already stays attached to
+  supervise its subprocess, so it is unaffected.
 
   A project-level ``mpdebug.toml``, discovered by searching the current
   directory and its parents (stopping at a ``.git`` directory or ``$HOME``),

--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -222,24 +222,61 @@ The full list of supported commands are:
 
   .. code-block:: bash
 
-      $ mpremote debug <target> [module[:method]]
+      $ mpremote debug [target] [module[:method]]
 
-  ``target`` is a connect string as accepted by ``mpremote connect`` (``unix``
-  is accepted but not yet implemented). ``module[:method]`` names the code to
-  run under the debugger and defaults to ``target:main``. The device reports
-  its debug-server endpoint and firmware capabilities as soon as it has bound
-  the listening socket, before any DAP client attaches; a DAP client then
-  connects to that endpoint. ``--port`` sets the listening port; left unset,
-  the device applies its own default. ``--port 0`` is rejected: it asks the
-  system to choose, which the device can only report back through
-  ``getsockname()``, and no port currently binds it. ``--timeout`` sets how long
-  to wait for the device's report. ``--dap-log`` is accepted but not yet
-  implemented. The command returns once it has printed the endpoint, leaving
-  the device waiting for a client to attach; note that a board with no network
-  interface reports the wildcard ``0.0.0.0``, which is not an address to
-  connect to. As with any other mpremote option,
+  ``target`` is either the name of a target defined in a project's
+  ``mpdebug.toml`` (see below), a connect string as accepted by ``mpremote
+  connect``, or ``unix`` (accepted but not yet implemented). ``module[:method]``
+  names the code to run under the debugger; it defaults to the resolved
+  target's own ``program``, or ``target:main`` if there is none. The device
+  reports its debug-server endpoint and firmware capabilities as soon as it
+  has bound the listening socket, before any DAP client attaches; a DAP
+  client then connects to that endpoint. ``--port`` sets the listening port;
+  left unset, the device applies its own default. ``--port 0`` is rejected:
+  it asks the system to choose, which the device can only report back
+  through ``getsockname()``, and no port currently binds it. ``--timeout``
+  sets how long to wait for the device's report. ``--dap-log`` is accepted
+  but not yet implemented. The command returns once it has printed the
+  endpoint, leaving the device waiting for a client to attach; note that a
+  board with no network interface reports the wildcard ``0.0.0.0``, which is
+  not an address to connect to. As with any other mpremote option,
   ``--port``/``--timeout``/``--dap-log`` must come before
   ``target``/``module[:method]``.
+
+  A project-level ``mpdebug.toml``, discovered by searching the current
+  directory and its parents (stopping at a ``.git`` directory or ``$HOME``),
+  replaces per-invocation connect strings and capability bookkeeping with
+  named targets:
+
+  .. code-block:: toml
+
+      [target.pico]
+      kind = "serial"
+      device = "/dev/serial/by-id/usb-MicroPython_Board_in_FS_mode_XXXX-if00"
+      requires = ["settrace", "save_names"]
+      program = "app:run"
+
+  ``kind`` is one of ``unix``, ``serial``, ``network``. ``device`` is a
+  connect string, required for ``serial`` and optional for ``network``
+  (where it names the control-plane device used for the pre-boot handshake -
+  the debug endpoint itself is always reported by the device, never written
+  here); prefer a stable ``/dev/serial/by-id/...`` path over ``/dev/ttyACMn``,
+  which can renumber on replug (using one prints a warning but still works).
+  ``firmware`` names a firmware variant id, for tooling outside mpremote that
+  fetches or builds it. ``program`` is this target's ``module[:method]``
+  default. ``requires`` lists capability names that must appear (and be
+  true) in the device's handshake; an unrecognised name is rejected when the
+  file is read, and a missing capability is a hard error once the device has
+  connected, both before any client attaches.
+
+  Omitting ``target`` resolves to the file's only target if it defines
+  exactly one, or lists the available names as an error if it defines
+  several. A ``target`` naming an entry in the file resolves to it; anything
+  else is passed to the transport as a connect string, exactly as
+  ``mpremote connect`` would take it, so device paths, ``id:``/``port:``
+  selectors and bare names such as ``COM4`` keep working. A mistyped target
+  name therefore fails as a device, and the error then names the targets the
+  file defines.
 
 .. _mpremote_command_fs:
 

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -2,8 +2,12 @@ import binascii
 import codecs
 import errno
 import hashlib
+import json
 import os
 import pkgutil
+import shutil
+import signal
+import subprocess
 import sys
 import tempfile
 import time
@@ -14,7 +18,7 @@ import serial.tools.list_ports
 from .transport import TransportError, TransportExecError, stdout_write_bytes
 from .transport_serial import SerialTransport
 from .romfs import make_romfs, VfsRomWriter
-from .mpdebug_config import resolve_target, target_hint, warn_if_tty_device
+from .mpdebug_config import find_config, resolve_target, target_hint, warn_if_tty_device
 from . import mpdebug_handshake
 
 
@@ -610,6 +614,294 @@ def _read_mpdbg_ready(
         raise CommandError(str(er))
 
 
+def _check_requires(resolved, caps):
+    if resolved is not None and resolved.requires:
+        missing = [c for c in resolved.requires if caps.get(c) is not True]
+        if missing:
+            raise CommandError(
+                f"target {resolved.name!r} requires {', '.join(missing)}, which this "
+                f"firmware does not provide (probed caps: {caps})"
+            )
+
+
+def _report_debug_result(handshake):
+    # flush=True: a caller reading this over a pipe (s7.1's extension, a test
+    # harness) must see it as soon as it's printed, not whenever Python's
+    # block-buffering (the default for a non-tty stdout) next drains.
+    host, port, caps = handshake["host"], handshake["port"], handshake["caps"]
+    print("debug server listening on {}:{}".format(host, port), flush=True)
+    print("capabilities:", caps, flush=True)
+    # The device's own MPDBG-READY line (raw bind address, possibly a
+    # wildcard) is consumed by the handshake parser and never echoed; re-emit
+    # it with the resolved host as the one line a tool watching this
+    # process's stdout (e.g. s7.1's extension) can parse.
+    print(
+        mpdebug_handshake.PREFIX + json.dumps({"host": host, "port": port, "caps": caps}),
+        flush=True,
+    )
+    return handshake
+
+
+def _resolve_unix_binary(resolved):
+    env_path = os.environ.get("MPY_DEBUG_FIRMWARE")
+    if env_path:
+        if not os.path.isfile(env_path):
+            raise CommandError(f"MPY_DEBUG_FIRMWARE={env_path!r} does not exist")
+        return env_path
+
+    firmware = resolved.firmware if resolved is not None else None
+    if not firmware:
+        raise CommandError(
+            "no unix debug binary found: set MPY_DEBUG_FIRMWARE to a built "
+            "micropython binary, or build one (e.g. `make -C ports/unix`) and "
+            "point the target's 'firmware' at it in mpdebug.toml"
+        )
+    if firmware == "system":
+        found = shutil.which("micropython")
+        if not found:
+            raise CommandError(
+                f"target {resolved.name!r} firmware is 'system' but no 'micropython' is on PATH"
+            )
+        return found
+    # A relative path (one containing a separator) is resolved against the
+    # config file's directory, not the cwd, so the same mpdebug.toml works
+    # regardless of where mpremote is invoked from - matching how the config
+    # file itself is found. A bare name with no separator that isn't a file
+    # relative to the cwd is assumed to be a firmware.toml variant id (e.g.
+    # "fw-f9d7c96b96"), which this tool cannot fetch - firmware/firmware.toml
+    # and its verify/fetch machinery are part of the wrapper repo, out of
+    # reach from inside micropython/tools/mpremote.
+    if os.sep in firmware and not os.path.isabs(firmware):
+        config_path = find_config()
+        if config_path:
+            firmware = os.path.join(os.path.dirname(config_path), firmware)
+    elif os.sep not in firmware and not os.path.isfile(firmware):
+        raise CommandError(
+            f"target {resolved.name!r} firmware {firmware!r} names a "
+            "firmware-manifest variant, which this tool cannot fetch; build it "
+            "(e.g. `make -C ports/unix`), or set MPY_DEBUG_FIRMWARE to a built "
+            "micropython binary"
+        )
+    if not os.path.isfile(firmware):
+        raise CommandError(f"target {resolved.name!r} firmware {firmware!r} does not exist")
+    return firmware
+
+
+# ports/unix/mpconfigport.h's MICROPY_PY_SYS_PATH_DEFAULT: what the unix port
+# puts on sys.path when MICROPYPATH is unset. Setting MICROPYPATH at all
+# suppresses these, so they are appended explicitly below rather than relied
+# on implicitly - debugpy may live in any of them (frozen, mip-installed) or
+# in a path the caller already put on MICROPYPATH.
+_UNIX_SYS_PATH_DEFAULT = (".frozen", "~/.micropython/lib", "/usr/lib/micropython")
+
+
+def _unix_env():
+    # MICROPYPATH is rebuilt rather than inherited verbatim: the target
+    # module's project directory goes on the front, and the port's own
+    # defaults go on the back, with whatever the caller already set kept in
+    # between - so this always reaches the project's modules and never
+    # silently drops the caller's or the port's own module locations.
+    config_path = find_config()
+    project_dir = os.path.dirname(config_path) if config_path else os.getcwd()
+    env = dict(os.environ)
+    caller_parts = [p for p in env.get("MICROPYPATH", "").split(":") if p]
+    parts = [project_dir] + caller_parts + list(_UNIX_SYS_PATH_DEFAULT)
+    seen = set()
+    deduped = []
+    for p in parts:
+        if p not in seen:
+            seen.add(p)
+            deduped.append(p)
+    env["MICROPYPATH"] = ":".join(deduped)
+    return env
+
+
+def _reap(proc):
+    # terminate -> kill ladder: an unreaped subprocess keeps its debug-server
+    # port bound, and the next run collides with it. SIGINT is ignored for
+    # the duration so a second Ctrl-C during the ladder can't abandon it
+    # half-done.
+    if proc.poll() is not None:
+        return
+    try:
+        old_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
+    except ValueError:
+        old_handler = None  # not called from the main thread
+    try:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=2)
+    finally:
+        if old_handler is not None:
+            signal.signal(signal.SIGINT, old_handler)
+
+
+_UNIX_EOF_MARKER = "\x00mpremote-debug-unix-eof\x00"  # never appears in real program output
+
+
+def _do_debug_unix(resolved, module, method, port, timeout):
+    try:
+        # The non-blocking fd handling below is POSIX-only, unlike the rest of
+        # mpremote, which supports Windows.
+        import fcntl
+    except ImportError:
+        raise CommandError(
+            "'debug' with a unix target needs a POSIX host (no fcntl here)"
+        ) from None
+
+    binary = _resolve_unix_binary(resolved)
+
+    # The boot script ships as a package resource, not a path into this repo
+    # (s5.1); write it out so the subprocess, which needs a real file to
+    # run, can read it.
+    tmpdir = tempfile.mkdtemp(prefix="mpremote-debug-unix-")
+    try:
+        script_path = os.path.join(tmpdir, "mpy_launch_debugpy.py")
+        with open(script_path, "wb") as f:
+            f.write(pkgutil.get_data(__package__, "mpy_launch_debugpy.py"))
+    except Exception:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+        raise
+
+    argv = [binary, script_path, module, method]
+    if port is not None:
+        argv.append(str(port))
+
+    try:
+        proc = subprocess.Popen(
+            argv, env=_unix_env(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )
+    except OSError as er:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+        raise CommandError(f"failed to launch {binary!r}: {er}")
+
+    def cleanup():
+        # SIGINT ignored for the whole ladder, not just _reap's: a second
+        # Ctrl-C landing during rmtree must not abandon cleanup half-done.
+        try:
+            old_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
+        except ValueError:
+            old_handler = None  # not called from the main thread
+        try:
+            _reap(proc)
+            shutil.rmtree(tmpdir, ignore_errors=True)
+        finally:
+            if old_handler is not None:
+                signal.signal(signal.SIGINT, old_handler)
+
+    # A live child now exists, so every signal that would otherwise kill this
+    # process outright has to reap it first: SIGTERM (what Node's
+    # child.kill(), `timeout`, systemd and CI teardown send) and SIGHUP (what
+    # the kernel sends the foreground group when a terminal window closes on a
+    # running session). Turned into SystemExit so they land in the same
+    # BaseException handler below as any other escape path.
+    _reaping_signals = [signal.SIGTERM]
+    if hasattr(signal, "SIGHUP"):  # POSIX-only, keep Windows imports clean
+        _reaping_signals.append(signal.SIGHUP)
+    old_handlers = {}
+    for _sig in _reaping_signals:
+        try:
+            old_handlers[_sig] = signal.signal(_sig, lambda *_a: sys.exit(1))
+        except ValueError:
+            pass  # not called from the main thread
+    try:
+        # Everything from here on runs against a live child: any exception
+        # that isn't handled below (a raw OSError out of a read, a
+        # BrokenPipeError from a downstream reader going away, ...) must
+        # still reap it rather than leaving it bound to its port forever.
+        try:
+            fl = fcntl.fcntl(proc.stdout.fileno(), fcntl.F_GETFL)
+            fcntl.fcntl(proc.stdout.fileno(), fcntl.F_SETFL, fl | os.O_NONBLOCK)
+            decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+            deadline = time.monotonic() + timeout
+            ended = False
+
+            def read_chunk():
+                nonlocal ended
+                if ended:
+                    return ""
+                poll = max(0.0, min(_POLL_S, deadline - time.monotonic()))
+                try:
+                    chunk = os.read(proc.stdout.fileno(), 4096)
+                except BlockingIOError:
+                    time.sleep(poll)
+                    return ""
+                if chunk == b"":
+                    # A pipe read only ever returns b"" at true EOF (every write
+                    # end closed) - the subprocess exited without printing a
+                    # handshake.
+                    ended = True
+                    return _UNIX_EOF_MARKER
+                return decoder.decode(chunk)
+
+            def on_eof(rest):
+                try:
+                    code = proc.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    return "; process closed stdout without exiting"
+                return f"; process exited with code {code}"
+
+            try:
+                handshake = mpdebug_handshake.read_handshake(
+                    read_chunk,
+                    timeout,
+                    mpdebug_handshake.CONTROL_KIND_UNIX,
+                    on_line=lambda line: stdout_write_bytes(line.encode()),
+                    eof=_UNIX_EOF_MARKER,
+                    on_eof=on_eof,
+                )
+            except mpdebug_handshake.HandshakeError as er:
+                raise CommandError(str(er)) from None
+
+            _check_requires(resolved, handshake["caps"])
+
+            # The interpreter compiles the whole script before executing any of
+            # it (same as CPython), so by the time a handshake or an error has
+            # come back the temp file has already been fully read and is no
+            # longer needed.
+            shutil.rmtree(tmpdir, ignore_errors=True)
+            _report_debug_result(handshake)
+
+            # Unlike the serial/network paths, where the firmware runs
+            # independently of the host tool, mpremote owns this child: stay
+            # attached to its console until it exits on its own (the debug
+            # session ran to completion) or the user ends it with Ctrl-C.
+            fcntl.fcntl(proc.stdout.fileno(), fcntl.F_SETFL, fl)
+            while True:
+                chunk = os.read(proc.stdout.fileno(), 4096)
+                if not chunk:
+                    break
+                stdout_write_bytes(chunk)
+            # EOF means every write end of the pipe closed, which normally
+            # means the child has exited too; wait() picks up its exit status
+            # so a crashing debuggee is reported as a failure, not silently
+            # swallowed.
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+        except KeyboardInterrupt:
+            cleanup()
+            sys.exit(1)
+        except BrokenPipeError:
+            cleanup()
+            sys.exit(1)
+        except BaseException:
+            cleanup()
+            raise
+
+        _reap(proc)
+        if proc.returncode:
+            sys.exit(proc.returncode)
+        return handshake
+    finally:
+        for _sig, _old in old_handlers.items():
+            signal.signal(_sig, _old)
+
+
 def do_debug(state, args):
     resolved = resolve_target(args.target)
 
@@ -617,21 +909,6 @@ def do_debug(state, args):
     if program_spec is None:
         program_spec = (resolved.program if resolved is not None else None) or "target:main"
     module, method = _parse_program_spec(program_spec)
-
-    if resolved is None:
-        # No mpdebug.toml matched (or none exists): args.target is a literal
-        # connect string, as it was before named targets existed.
-        if args.target == "unix":
-            raise CommandError("target 'unix' is not supported yet")
-        if args.target == "list":
-            raise CommandError("target 'list' is not a debuggable device")
-        connect_device = args.target
-        warn_if_tty_device(connect_device, "device")
-    elif resolved.kind == "unix":
-        raise CommandError(f"target {resolved.name!r} has kind 'unix', which is not supported yet")
-    else:
-        connect_device = resolved.device or "auto"
-        warn_if_tty_device(connect_device, f"target {resolved.name!r}")
 
     if args.dap_log:
         raise CommandError("--dap-log is not implemented yet")
@@ -644,6 +921,24 @@ def do_debug(state, args):
         )
     if args.port is not None and not 1 <= args.port <= 65535:
         raise CommandError(f"--port must be between 1 and 65535, got {args.port}")
+
+    is_unix = resolved.kind == "unix" if resolved is not None else args.target == "unix"
+    if is_unix:
+        state.did_action()
+        # Reports the endpoint and supervises the child itself (unlike the
+        # serial/network path below, mpremote owns this process).
+        return _do_debug_unix(resolved, module, method, args.port, args.timeout)
+
+    if resolved is None:
+        # No mpdebug.toml matched (or none exists): args.target is a literal
+        # connect string, as it was before named targets existed.
+        if args.target == "list":
+            raise CommandError("target 'list' is not a debuggable device")
+        connect_device = args.target
+        warn_if_tty_device(connect_device, "device")
+    else:
+        connect_device = resolved.device or "auto"
+        warn_if_tty_device(connect_device, f"target {resolved.name!r}")
 
     if state.transport is None or state.transport.device_name != connect_device:
         try:
@@ -671,20 +966,8 @@ def do_debug(state, args):
     except KeyboardInterrupt:
         sys.exit(1)
 
-    host, port, caps = handshake["host"], handshake["port"], handshake["caps"]
-
-    if resolved is not None and resolved.requires:
-        missing = [c for c in resolved.requires if caps.get(c) is not True]
-        if missing:
-            raise CommandError(
-                f"target {resolved.name!r} requires {', '.join(missing)}, which this "
-                f"firmware does not provide (probed caps: {caps})"
-            )
-
-    print("debug server listening on {}:{}".format(host, port))
-    print("capabilities:", caps)
-    # Returned for the flows that act on the endpoint rather than print it.
-    return handshake
+    _check_requires(resolved, handshake["caps"])
+    return _report_debug_result(handshake)
 
 
 def do_mount(state, args):

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -539,17 +539,25 @@ def _parse_program_spec(spec):
     return module, method
 
 
-def _debug_boot_script(module, method, port):
+def _debug_boot_script(module, method, port, dap_stream=None):
     # Raw REPL exec has no OS argv, so sys.argv is injected here to preserve
-    # mpy_launch_debugpy.py's own argv contract ([module] [method] [port]).
+    # mpy_launch_debugpy.py's own argv contract ([module] [method] [port]
+    # [dap_stream]).
     # sys.argv is rebound in place (not reassigned): the `sys` module dict is
     # read-only on MicroPython, so `sys.argv = [...]` raises AttributeError.
     # port=None omits the argv element so the device applies its own default
-    # port instead of the host choosing one.
+    # port instead of the host choosing one - unless a dap_stream follows it,
+    # since argv is positional. The placeholder is harmless: the stream path
+    # never binds a port, and a device that cannot produce the requested
+    # stream raises instead of falling back to TCP.
     script = pkgutil.get_data(__package__, "mpy_launch_debugpy.py").decode()
     argv = ["mpy_launch_debugpy.py", module, method]
     if port is not None:
         argv.append(str(port))
+    elif dap_stream is not None:
+        argv.append("0")
+    if dap_stream is not None:
+        argv.append(dap_stream)
     preamble = "import sys\nsys.argv[:] = [{}]\n".format(", ".join(repr(a) for a in argv))
     return preamble + script
 
@@ -1137,8 +1145,19 @@ def do_debug(state, args):
     state.ensure_raw_repl()
     state.did_action()
 
+    # A `dap_device` target is asking for DAP over the board's own dedicated
+    # interface, so the device is told to take that channel rather than
+    # binding a port. It is told "board", not the host's path: the host names
+    # the interface by tty node, the device by runtime object, and only the
+    # device can map one to the other. Without this the two ends disagree by
+    # construction - the device would report a TCP endpoint while the bridge
+    # below waits on a stream that never carries anything.
+    dap_stream = "board" if (resolved is not None and resolved.dap_device) else None
+
     try:
-        state.transport.exec_raw_no_follow(_debug_boot_script(module, method, device_port))
+        state.transport.exec_raw_no_follow(
+            _debug_boot_script(module, method, device_port, dap_stream)
+        )
         print("waiting for the device to report its debug-server endpoint...", flush=True)
         # A pty peer is a local process by construction (a unix build or QEMU
         # behind a pty pair), so a wildcard bind on it is reachable at the

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -14,6 +14,7 @@ import serial.tools.list_ports
 from .transport import TransportError, TransportExecError, stdout_write_bytes
 from .transport_serial import SerialTransport
 from .romfs import make_romfs, VfsRomWriter
+from .mpdebug_config import resolve_target, target_hint, warn_if_tty_device
 
 
 class CommandError(Exception):
@@ -619,12 +620,28 @@ def _read_mpdbg_ready(transport, timeout):
 
 
 def do_debug(state, args):
-    module, method = _parse_program_spec(args.program)
+    resolved = resolve_target(args.target)
 
-    if args.target == "unix":
-        raise CommandError("target 'unix' is not supported yet")
-    if args.target == "list":
-        raise CommandError("target 'list' is not a debuggable device")
+    program_spec = args.program
+    if program_spec is None:
+        program_spec = (resolved.program if resolved is not None else None) or "target:main"
+    module, method = _parse_program_spec(program_spec)
+
+    if resolved is None:
+        # No mpdebug.toml matched (or none exists): args.target is a literal
+        # connect string, as it was before named targets existed.
+        if args.target == "unix":
+            raise CommandError("target 'unix' is not supported yet")
+        if args.target == "list":
+            raise CommandError("target 'list' is not a debuggable device")
+        connect_device = args.target
+        warn_if_tty_device(connect_device, "device")
+    elif resolved.kind == "unix":
+        raise CommandError(f"target {resolved.name!r} has kind 'unix', which is not supported yet")
+    else:
+        connect_device = resolved.device or "auto"
+        warn_if_tty_device(connect_device, f"target {resolved.name!r}")
+
     if args.dap_log:
         raise CommandError("--dap-log is not implemented yet")
     # Both checked here rather than after a full raw-REPL round trip.
@@ -637,8 +654,13 @@ def do_debug(state, args):
     if args.port is not None and not 1 <= args.port <= 65535:
         raise CommandError(f"--port must be between 1 and 65535, got {args.port}")
 
-    if state.transport is None or state.transport.device_name != args.target:
-        do_connect(state, device=args.target)
+    if state.transport is None or state.transport.device_name != connect_device:
+        try:
+            do_connect(state, device=connect_device)
+        except CommandError as er:
+            # A name that is not a configured target is handed to the transport
+            # as a connect string, so a mistyped target name surfaces here.
+            raise CommandError(f"{er}{target_hint(args.target)}") from None
     state.ensure_raw_repl()
     state.did_action()
 
@@ -652,10 +674,24 @@ def do_debug(state, args):
         sys.exit(1)
 
     try:
-        print("debug server listening on {}:{}".format(handshake["host"], handshake["port"]))
-        print("capabilities:", handshake["caps"])
+        host, port, caps = handshake["host"], handshake["port"], handshake["caps"]
     except KeyError as er:
         raise CommandError(f"malformed handshake payload from the device, missing key {er}")
+    if not isinstance(caps, dict):
+        raise CommandError(
+            f"malformed handshake payload from the device, 'caps' is not a table: {caps!r}"
+        )
+
+    if resolved is not None and resolved.requires:
+        missing = [c for c in resolved.requires if caps.get(c) is not True]
+        if missing:
+            raise CommandError(
+                f"target {resolved.name!r} requires {', '.join(missing)}, which this "
+                f"firmware does not provide (probed caps: {caps})"
+            )
+
+    print("debug server listening on {}:{}".format(host, port))
+    print("capabilities:", caps)
 
 
 def do_mount(state, args):

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -24,6 +24,7 @@ from .romfs import make_romfs, VfsRomWriter
 from .mpdebug_config import find_config, resolve_target, target_hint, warn_if_tty_device
 from . import mpdebug_handshake
 from . import dap_log
+from . import repl_dap
 
 
 class CommandError(Exception):
@@ -734,6 +735,75 @@ def _start_dap_log(dap_log_arg, handshake, bind_port=0):
     return proxy, reported
 
 
+def _start_repl_dap(state, handshake, dap_log_arg, bind_port):
+    """Split the REPL's own stream and bridge a DAP client onto its framed half.
+
+    The single-UART channel: there is no second interface and no network, so
+    the debug traffic rides the stream `mpremote` is already holding, marked
+    apart from the program's output by `repl_dap`'s framing. The device's own
+    `caps["repl_dap"]` is checked rather than trusted from the request:
+    STORY-3.3's rule that a claimed capability never outranks the runtime
+    probe applies to the caller's own request too.
+
+    From here on nothing else may read `state.transport`: the channel's reader
+    thread owns the port for the length of the session, and a second reader
+    would take bytes out of the middle of a frame.
+    """
+    if not handshake["caps"].get("repl_dap"):
+        raise CommandError(
+            f"the device did not take the REPL stream for DAP (probed caps: {handshake['caps']})"
+        )
+    if dap_log_arg:
+        path = dap_log_arg if isinstance(dap_log_arg, str) else dap_log.default_log_path()
+        try:
+            logger = dap_log.DapLogger(path)
+        except OSError as er:
+            raise CommandError(f"--dap-log could not open {path!r}: {er}") from None
+        log_msg = f"logging DAP traffic to {path!r}"
+    else:
+        logger = dap_log.NullLogger()
+        log_msg = None
+    channel = repl_dap.ReplDapChannel(state.transport.serial)
+    channel.start()
+    try:
+        proxy = repl_dap.ReplDapBridge(channel, logger, bind_port=bind_port)
+    except OSError as er:
+        channel.close()
+        logger.close()
+        raise CommandError(f"could not bind a DAP bridge port: {er}") from None
+    proxy.start()
+    if log_msg:
+        print(log_msg, flush=True)
+    reported = dict(handshake, host=proxy.host, port=proxy.port)
+    return channel, proxy, reported
+
+
+def _repl_dap_lost(channel):
+    """Raise for a REPL-stream DAP channel that stopped being readable.
+
+    A board reset always ends the session with this error rather than
+    reconnecting. The rebooted device runs a fresh `debugpy` with no memory
+    of the session the client still believes it is in - no breakpoints, no
+    frames, no sequence numbers - so a revived byte pump would hand the
+    client a peer that never received its `initialize`.
+
+    A code the demux has no handler for is reported as its own failure. On a
+    shared stream that means the two ends disagree about the framing - most
+    likely a device running an older boot script - and every byte after it is
+    suspect, which is worse than a lost connection, not better.
+    """
+    if channel.unknown_code is not None:
+        raise CommandError(
+            f"the device sent framing code {channel.unknown_code} on the REPL "
+            "stream, which this mpremote has no handler for; the two ends "
+            "disagree about the protocol, so the session cannot be trusted"
+        )
+    raise CommandError(
+        "the DAP channel sharing the REPL stream was lost (board reset?); "
+        "reset the device and run 'mpremote debug' again"
+    ) from channel.error
+
+
 @contextlib.contextmanager
 def _exit_on_signal(exit_code=1):
     """Make SIGTERM/SIGHUP (where the platform has one) exit like Ctrl-C.
@@ -745,7 +815,7 @@ def _exit_on_signal(exit_code=1):
     `hasattr` guard.
 
     `exit_code` is 1 by default: for a wait that watches a live client
-    session (a `--dap-log` proxy), a signal cutting it
+    session (a `--dap-repl` bridge, a `--dap-log` proxy), a signal cutting it
     off early is an interruption, not the session's own natural end. A wait
     with nothing of the kind to watch - `_stay_attached_mount` - passes 0
     instead, since a signal is the *only* way it ever returns.
@@ -766,10 +836,10 @@ def _exit_on_signal(exit_code=1):
             signal.signal(sig, old)
 
 
-def _stay_attached(proxy, message, pump_failed=None):
+def _stay_attached(proxy, message, pump_failed=None, device_gone=None):
     """Block until `proxy`'s one client session ends, reaping it on every exit path.
 
-    Used by `--dap-log`'s own proxy, which is a
+    Shared by `--dap-log`'s own proxy and a `--dap-repl` bridge - both are a
     `dap_log.PumpingProxy` mpremote must stay alive for, since unlike the
     plain network path nothing else keeps the client's real endpoint
     listening once this process exits.
@@ -782,6 +852,12 @@ def _stay_attached(proxy, message, pump_failed=None):
     mount_local's docstring) independently of whatever the proxy itself
     still reports, so this stops waiting on the proxy's own end-of-session
     signal.
+
+    `device_gone` is a third: a callable reporting that the device's end of
+    the channel is over. The proxy's own end-of-session signal needs a client
+    to have connected first, so without this a device that finishes while
+    nothing is attached - a run whose client never arrived - would leave this
+    waiting for one that is not coming.
     """
     print(message, flush=True)
 
@@ -801,6 +877,8 @@ def _stay_attached(proxy, message, pump_failed=None):
             while not proxy.wait(_POLL_S):
                 if pump_failed is not None and pump_failed.is_set():
                     break
+                if device_gone is not None and device_gone():
+                    break
         except KeyboardInterrupt:
             cleanup()
             sys.exit(1)
@@ -813,7 +891,7 @@ def _stay_attached(proxy, message, pump_failed=None):
 def _stay_attached_mount(message, pump_failed=None):
     """Block until Ctrl-C or a reaping signal, for a mount with no proxy to watch.
 
-    A mounted session with no `--dap-log`
+    A mounted session with neither a `--dap-repl` bridge nor a `--dap-log`
     proxy has no client-facing object of its own whose end marks the debug
     session as over - the DAP client talks straight to the device's TCP
     endpoint - so this just waits to be interrupted. The `_pump_mount`
@@ -1312,6 +1390,20 @@ def do_debug(state, args):
     # target's own 'source' has already been resolved to an absolute path by
     # mpdebug.toml loading; a literal --source has not, so it gets the same
     # treatment here.
+    # --dap-repl on the command line overrides a target's configured
+    # 'dap_repl'; either one asks for the DAP channel to share the stream
+    # carrying the REPL, which is what a board with one UART and no network
+    # has. A target that also configures a dedicated DAP interface is
+    # rejected at config load, but the flag can reach one, so the same
+    # conflict is refused here rather than one of the two silently winning.
+    dap_repl = args.dap_repl or (resolved.dap_repl if resolved is not None else False)
+    if dap_repl:
+        if is_unix:
+            raise CommandError(
+                "--dap-repl is not valid for a unix target: it reaches its debug "
+                "channel over the loopback interface, with no stream to share"
+            )
+
     if args.source is not None:
         if is_unix:
             raise CommandError(
@@ -1321,6 +1413,26 @@ def do_debug(state, args):
         source_root = os.path.realpath(args.source)
     else:
         source_root = resolved.source if resolved is not None else None
+
+    # A mount and a REPL-stream DAP session are two protocols wanting the same
+    # marker byte on the same wire, and each end of each one assumes it is the
+    # only demux point. Making them coexist is a follow-up story (the framing
+    # is chosen so it can be: mount's codes 1..13 are untouched and DAP sits
+    # at 14); until then the combination is refused rather than run into a
+    # desync that only a power cycle clears.
+    if dap_repl and source_root is not None:
+        origin = (
+            f"--source {args.source!r}"
+            if args.source is not None
+            else f"target {resolved.name!r} source {source_root!r}"
+        )
+        raise CommandError(
+            f"{origin} cannot be combined with --dap-repl: mounting and the "
+            "REPL-stream DAP channel both frame the same stream, and running "
+            "them together would desync it. Put the program on the device's "
+            "own filesystem for this session, or use a target with a network "
+            "or dedicated DAP interface"
+        )
 
     # Both checks below depend only on host state - the source root and the
     # module name - so they run before the device is touched at all: a
@@ -1378,8 +1490,10 @@ def do_debug(state, args):
     state.ensure_raw_repl()
     state.did_action()
 
-    # No stream channel on this path: the device binds a port and reports it.
-    dap_stream = None
+    # "repl" tells the device to split the stream mpremote is already
+    # holding rather than bind a port, and the bridge below reads the DAP
+    # half back out of it.
+    dap_stream = "repl" if dap_repl else None
 
     # Everything from here on that touches a mounted device - establishing
     # it, running the boot script, staying attached, tearing it down - has
@@ -1475,6 +1589,37 @@ def do_debug(state, args):
                     daemon=True,
                 )
                 pump_thread.start()
+
+            # The client-facing port for a bridge this process runs itself.
+            serial_bind_port = dap_log_bind_port if dap_log_arg else (args.port or 0)
+
+            if dap_repl:
+                # The whole DAP channel runs through mpremote here, so this
+                # always stays attached. The channel is the transport's own
+                # port, so it is closed
+                # before returning rather than left to the transport's own
+                # teardown: the reader thread has to stop touching the port
+                # while this function still owns it.
+                channel, proxy, reported = _start_repl_dap(
+                    state, handshake, dap_log_arg, serial_bind_port
+                )
+                try:
+                    _report_debug_result(reported, path_mappings)
+                    _stay_attached(
+                        proxy,
+                        "staying attached to run the REPL-stream DAP bridge; Ctrl-C ends it",
+                        pump_failed=pump_failed,
+                        device_gone=lambda: channel.finished,
+                    )
+                finally:
+                    channel.close()
+                if (
+                    channel.unknown_code is not None
+                    or channel.error is not None
+                    or proxy.target_error is not None
+                ):
+                    _repl_dap_lost(channel)
+                return reported
 
             if not dap_log_arg:
                 _report_debug_result(handshake, path_mappings)

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -1,5 +1,6 @@
 import binascii
 import codecs
+import contextlib
 import errno
 import hashlib
 import json
@@ -11,6 +12,7 @@ import socket
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import zlib
 
@@ -92,10 +94,12 @@ def do_disconnect(state, _args=None):
             state.transport.umount_local()
         if state.transport.in_raw_repl:
             state.transport.exit_raw_repl()
-    except OSError:
-        # Ignore any OSError exceptions when shutting down, eg:
+    except (OSError, TransportError):
+        # Ignore these when shutting down, eg:
         # - filesystem_command will close the connection if it had an error
         # - umounting will fail if serial port disappeared
+        # - a mount whose device stopped responding raises TransportError,
+        #   not OSError, out of enter_raw_repl/umount_local above
         pass
     state.transport.close()
     state.transport = None
@@ -538,22 +542,65 @@ def _parse_program_spec(spec):
     return module, method
 
 
-def _debug_boot_script(module, method, port):
+def _debug_boot_script(module, method, port, dap_stream=None, mount_point=None):
     # Raw REPL exec has no OS argv, so sys.argv is injected here to preserve
-    # mpy_launch_debugpy.py's own argv contract ([module] [method] [port]).
+    # mpy_launch_debugpy.py's own argv contract ([module] [method] [port]
+    # [dap_stream]).
     # sys.argv is rebound in place (not reassigned): the `sys` module dict is
     # read-only on MicroPython, so `sys.argv = [...]` raises AttributeError.
     # port=None omits the argv element so the device applies its own default
-    # port instead of the host choosing one.
+    # port instead of the host choosing one - unless a dap_stream follows it,
+    # since argv is positional. The placeholder is harmless: the stream path
+    # never binds a port, and a device that cannot produce the requested
+    # stream raises instead of falling back to TCP.
     script = pkgutil.get_data(__package__, "mpy_launch_debugpy.py").decode()
     argv = ["mpy_launch_debugpy.py", module, method]
     if port is not None:
         argv.append(str(port))
+    elif dap_stream is not None:
+        argv.append("0")
+    if dap_stream is not None:
+        argv.append(dap_stream)
     preamble = "import sys\nsys.argv[:] = [{}]\n".format(", ".join(repr(a) for a in argv))
+    if mount_point is not None:
+        # The fs hook os.chdir()s into the mount point, so plain __import__
+        # would already find the target module there via sys.path's default
+        # '' (cwd) entry - but that entry also makes the import machinery
+        # record every such module's filename relative to cwd (e.g.
+        # "app.py"), not rooted at the mount point ("/remote/app.py"). The
+        # generated pathMappings translate absolute device paths back to the
+        # host source tree; a relative one matches no mapping, so no
+        # breakpoint ever binds under a mount. Removing '' and mounting the
+        # search path at the mount point explicitly makes every filename the
+        # import machinery records absolute, which is what the mapping was
+        # built to translate.
+        preamble += "while '' in sys.path: sys.path.remove('')\nsys.path.insert(0, {!r})\n".format(
+            mount_point
+        )
     return preamble + script
 
 
 _POLL_S = 0.2  # read_until() poll cadence for both the handshake scan and the error drain below
+_MOUNT_TEARDOWN_TIMEOUT_S = 10  # bounds each of the two round trips in _teardown_mount
+
+
+def _one_line(value):
+    """`value` reduced to one line, for interpolating into a one-line warning.
+
+    A device-side error arrives as a whole traceback: several lines of frames
+    followed by the line that names the exception. The warnings below are one
+    line each and are read as one line, so only that last line is kept - a
+    multi-line interpolation turns a warning into a wall of text whose first
+    line, the one a reader actually sees, says nothing but "Traceback (most
+    recent call last):". `value` is an exception, or the raw `error_output`
+    that a `TransportExecError` carries.
+    """
+    if isinstance(value, (bytes, bytearray)):
+        text = value.decode(errors="replace")
+    else:
+        text = str(value)
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return lines[-1] if lines else ""
 
 
 def _mpdbg_error(transport, rest):
@@ -593,7 +640,13 @@ def _read_mpdbg_ready(
 
     def read_chunk():
         poll = max(0.0, min(_POLL_S, deadline - time.monotonic()))
-        chunk = transport.read_until(1, b"\n", timeout=poll, timeout_overall=poll)
+        # timeout_overall_strict: the docstring's "can't overshoot it by a full
+        # poll window" only holds if a single call can't itself run long past
+        # `poll` - which read_until's default (non-strict) timeout_overall
+        # allows for as long as the boot script keeps printing without a gap.
+        chunk = transport.read_until(
+            1, b"\n", timeout=poll, timeout_overall=poll, timeout_overall_strict=True
+        )
         raw.extend(chunk)
         return decoder.decode(chunk)
 
@@ -626,7 +679,7 @@ def _check_requires(resolved, caps):
             )
 
 
-def _report_debug_result(handshake):
+def _report_debug_result(handshake, path_mappings=None):
     # flush=True: a caller reading this over a pipe (s7.1's extension, a test
     # harness) must see it as soon as it's printed, not whenever Python's
     # block-buffering (the default for a non-tty stdout) next drains.
@@ -636,11 +689,17 @@ def _report_debug_result(handshake):
     # The device's own MPDBG-READY line (raw bind address, possibly a
     # wildcard) is consumed by the handshake parser and never echoed; re-emit
     # it with the resolved host as the one line a tool watching this
-    # process's stdout (e.g. s7.1's extension) can parse.
-    print(
-        mpdebug_handshake.PREFIX + json.dumps({"host": host, "port": port, "caps": caps}),
-        flush=True,
-    )
+    # process's stdout (e.g. s7.1's extension) can parse. path_mappings is
+    # this host's own knowledge of how remote paths map to local ones (a
+    # unix target's identity mapping, or a mount's source root); the device
+    # never reports it and never sees it. Omitted when there is no mapping
+    # to report (a device-resident target with nothing mounted), rather than
+    # sent as an empty list, so an older extension's "key absent" fallback
+    # keeps working unchanged.
+    payload = {"host": host, "port": port, "caps": caps}
+    if path_mappings:
+        payload["pathMappings"] = path_mappings
+    print(mpdebug_handshake.PREFIX + json.dumps(payload), flush=True)
     return handshake
 
 
@@ -664,6 +723,237 @@ def _start_dap_log(dap_log_arg, handshake, bind_port=0):
     print(f"logging DAP traffic to {path!r}", flush=True)
     reported = dict(handshake, host=proxy.host, port=proxy.port)
     return proxy, reported
+
+
+@contextlib.contextmanager
+def _exit_on_signal(exit_code=1):
+    """Make SIGTERM/SIGHUP (where the platform has one) exit like Ctrl-C.
+
+    Shared by every blocking "stay attached" wait below, so a supervisor's
+    kill - not just an interactive Ctrl-C - still unwinds through the
+    caller's own exception handling and `finally` cleanup instead of a bare
+    process kill that skips it. SIGHUP has no Windows equivalent, hence the
+    `hasattr` guard.
+
+    `exit_code` is 1 by default: for a wait that watches a live client
+    session (a `--dap-log` proxy), a signal cutting it
+    off early is an interruption, not the session's own natural end. A wait
+    with nothing of the kind to watch - `_stay_attached_mount` - passes 0
+    instead, since a signal is the *only* way it ever returns.
+    """
+    reaping_signals = [signal.SIGTERM]
+    if hasattr(signal, "SIGHUP"):
+        reaping_signals.append(signal.SIGHUP)
+    old_handlers = {}
+    for sig in reaping_signals:
+        try:
+            old_handlers[sig] = signal.signal(sig, lambda *_a: sys.exit(exit_code))
+        except ValueError:
+            pass  # not called from the main thread
+    try:
+        yield
+    finally:
+        for sig, old in old_handlers.items():
+            signal.signal(sig, old)
+
+
+def _stay_attached(proxy, message, pump_failed=None):
+    """Block until `proxy`'s one client session ends, reaping it on every exit path.
+
+    Used by `--dap-log`'s own proxy, which is a
+    `dap_log.PumpingProxy` mpremote must stay alive for, since unlike the
+    plain network path nothing else keeps the client's real endpoint
+    listening once this process exits.
+
+    `pump_failed`, when this session also has a mount, is a second thing
+    this waits on besides the proxy: the mount's filesystem RPC rides the
+    board's primary REPL connection, an entirely different one from
+    whichever tty or socket `proxy` watches, so a mount pump dying does not
+    reach the proxy at all. Once it is set, the device is wedged (see
+    mount_local's docstring) independently of whatever the proxy itself
+    still reports, so this stops waiting on the proxy's own end-of-session
+    signal.
+    """
+    print(message, flush=True)
+
+    def cleanup():
+        try:
+            old_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
+        except ValueError:
+            old_handler = None  # not called from the main thread
+        try:
+            proxy.close()
+        finally:
+            if old_handler is not None:
+                signal.signal(signal.SIGINT, old_handler)
+
+    with _exit_on_signal():
+        try:
+            while not proxy.wait(_POLL_S):
+                if pump_failed is not None and pump_failed.is_set():
+                    break
+        except KeyboardInterrupt:
+            cleanup()
+            sys.exit(1)
+        except BaseException:
+            cleanup()
+            raise
+        cleanup()
+
+
+def _stay_attached_mount(message, pump_failed=None):
+    """Block until Ctrl-C or a reaping signal, for a mount with no proxy to watch.
+
+    A mounted session with no `--dap-log`
+    proxy has no client-facing object of its own whose end marks the debug
+    session as over - the DAP client talks straight to the device's TCP
+    endpoint - so this just waits to be interrupted. The `_pump_mount`
+    thread started alongside it is what actually keeps the mount's
+    filesystem RPC serviced while this blocks; `pump_failed` is that
+    thread's own signal that it stopped for a reason other than this
+    function's normal teardown, so a wedged device (see mount_local's
+    docstring) ends this wait instead of leaving it stuck until a user
+    notices and reaches for Ctrl-C themselves.
+
+    Ending this wait is always the normal, expected way a mounted
+    plain-network session finishes - there is no client-session end for
+    mpremote to observe instead, unlike `_stay_attached`'s proxy wait - so
+    both Ctrl-C and a reaping signal return normally (exit 0) rather than
+    treating the interruption as a fault. A `pump_failed` end is different:
+    it is reported by `_pump_mount` itself before this returns, so nothing
+    further is printed here.
+    """
+    print(message, flush=True)
+    with _exit_on_signal(exit_code=0):
+        try:
+            while True:
+                if pump_failed is not None and pump_failed.is_set():
+                    return
+                time.sleep(_POLL_S)
+        except KeyboardInterrupt:
+            return
+
+
+def _pump_mount(transport, stop_event, failed_event):
+    """Background thread: keep a mounted transport's filesystem RPC serviced.
+
+    `SerialIntercept.read` (installed on `transport.serial` by `mount_local`)
+    answers `\\x18`-prefixed filesystem RPC from any read of the wrapped
+    serial object, but nothing else reads this particular connection once
+    the boot script is running - the DAP traffic the client drives rides a
+    separate TCP endpoint. Without something to keep
+    calling read on it, an RPC request the device makes on its next
+    filesystem access would sit unanswered and the device would block on it
+    indefinitely. Ordinary console bytes collected between RPC commands are
+    discarded, matching every other "stay attached" path here: none of them
+    surface the primary connection's console output while attached.
+
+    A read raising while `stop_event` is not set means the device stopped
+    answering an RPC command mid-exchange, not that the caller asked this
+    thread to stop - unrecoverable, per mount_local's docstring, since a
+    half-answered filesystem RPC leaves the device with no way back to a
+    prompt on its own. `failed_event` reports that to whichever "stay
+    attached" wait is running alongside this thread, so it stops waiting on
+    a session that is already over in every way that matters; a plain
+    return with nothing set is only reached when `stop_event` itself asked
+    for it.
+    """
+    while not stop_event.is_set():
+        try:
+            # timeout_overall_strict: a single filesystem RPC command can
+            # stream bytes continuously for close to a whole _POLL_S window
+            # (a large file read), and this loop's only cadence for noticing
+            # stop_event is between read_until calls - non-strict semantics
+            # would let such a command's read_until run well past _POLL_S
+            # before this loop gets another chance to check.
+            transport.read_until(
+                1, b"\x04", timeout=_POLL_S, timeout_overall=_POLL_S, timeout_overall_strict=True
+            )
+        except Exception as er:
+            if not stop_event.is_set():
+                print(
+                    f"warning: the mount's filesystem RPC for "
+                    f"{transport.device_name!r} stopped unexpectedly "
+                    f"({_one_line(er)}); only a power cycle clears it",
+                    file=sys.stderr,
+                )
+                failed_event.set()
+            return
+
+
+def _teardown_mount(transport):
+    """Best-effort unmount at session end, when the device may still be mid-program.
+
+    `do_debug` reaches this after a normal return, an exception, or a
+    signal - none of which puts the device back at a raw-REPL prompt on its
+    own, since the debugged program was started with `exec_raw_no_follow`
+    and was never expected to return one. The interrupt below runs
+    unconditionally rather than being guarded by `transport.in_raw_repl`:
+    that flag only records mpremote's own last requested mode switch, not
+    the device's live state, and stays stale-True for as long as the
+    debugged program keeps running after `exec_raw_no_follow` started it -
+    a guard on it would skip the interrupt in exactly the case it exists to
+    handle. Both calls are bounded by `_MOUNT_TEARDOWN_TIMEOUT_S`, strictly -
+    read_until's default leniency (a peer that keeps producing bytes is never
+    cut off) is right for an interactive `mpremote` session but wrong here,
+    since the debugged program `exec_raw_no_follow` started may still be
+    printing when teardown begins - so a device that never responds, or one
+    that responds by talking forever, both fail this function within a fixed
+    time instead of hanging it indefinitely.
+
+    `mounted` is cleared and the transport's serial object unwrapped back
+    to the raw port in every case, success or failure, so a caller's own
+    later teardown (`do_disconnect`) never repeats a doomed umount against
+    a device already known not to be responding.
+
+    Nothing here is allowed to propagate silently: a mount that survives
+    teardown leaves the device in the state `mount_local`'s docstring
+    warns about - blocked in a filesystem RPC with no software recovery -
+    and the user has to be told that in terms they can act on, not left to
+    discover it from an unrelated "could not enter raw repl" on their next
+    command. `KeyboardInterrupt`/`SystemExit` (a second Ctrl-C, or a signal
+    landing mid-teardown) are reported the same way and then re-raised, so
+    an impatient second interrupt still ends the process instead of being
+    swallowed here.
+
+    The two failures are told apart rather than reported alike, because they
+    call for opposite things from the user. `TransportExecError` is the
+    device answering: it took the statement and handed back an error from
+    running it, which proves the raw REPL is alive and makes "only a power
+    cycle clears it" false. Anything else - a timeout, a transport-level
+    error - is a device that did not answer within
+    `_MOUNT_TEARDOWN_TIMEOUT_S`, which is the case that really does need
+    the power cord.
+    """
+    try:
+        transport.enter_raw_repl(
+            soft_reset=False,
+            timeout_overall=_MOUNT_TEARDOWN_TIMEOUT_S,
+            timeout_overall_strict=True,
+        )
+        transport.umount_local(
+            timeout_overall=_MOUNT_TEARDOWN_TIMEOUT_S, timeout_overall_strict=True
+        )
+    except TransportExecError as er:
+        print(
+            f"warning: unmounting {transport.fs_hook_mount} on "
+            f"{transport.device_name!r} reported: {_one_line(er.error_output)}; the "
+            "device is still answering, so reconnect and umount by hand if a mount "
+            "was left behind",
+            file=sys.stderr,
+        )
+    except BaseException as er:
+        print(
+            f"warning: could not unmount {transport.device_name!r} cleanly "
+            f"({_one_line(er)}); the device may no longer respond to anything - "
+            "only a power cycle clears it",
+            file=sys.stderr,
+        )
+        if isinstance(er, (KeyboardInterrupt, SystemExit)):
+            raise
+    finally:
+        transport.mounted = False
+        transport.serial = getattr(transport.serial, "orig_serial", transport.serial)
 
 
 def _dap_log_ports(port, dap_log_arg):
@@ -921,7 +1211,11 @@ def _do_debug_unix(resolved, module, method, port, timeout, dap_log_arg, dap_log
                 proxy, reported = _start_dap_log(dap_log_arg, handshake, dap_log_bind_port)
             else:
                 reported = handshake
-            _report_debug_result(reported)
+            # The child was spawned with no cwd= override, so it imports the
+            # program from the same directory mpremote itself is running in:
+            # local and remote are one and the same absolute path.
+            cwd = os.getcwd()
+            _report_debug_result(reported, [{"localRoot": cwd, "remoteRoot": cwd}])
 
             # Unlike the serial/network paths, where the firmware runs
             # independently of the host tool, mpremote owns this child: stay
@@ -962,6 +1256,18 @@ def _do_debug_unix(resolved, module, method, port, timeout, dap_log_arg, dap_log
             signal.signal(_sig, _old)
 
 
+def _module_source_path(source_root, module):
+    """The two paths `module` (a dotted module name) could resolve to under `source_root`.
+
+    Mirrors Python's own module/package resolution: a leaf module lives at
+    `<source_root>/a/b/c.py`, a package at `<source_root>/a/b/c/__init__.py`.
+    Returns both candidates so a caller that finds neither can name exactly
+    what it looked for.
+    """
+    base = os.path.join(source_root, *module.split("."))
+    return base + ".py", os.path.join(base, "__init__.py")
+
+
 def do_debug(state, args):
     resolved = resolve_target(args.target)
 
@@ -989,6 +1295,44 @@ def do_debug(state, args):
     device_port, dap_log_bind_port = _dap_log_ports(args.port, dap_log_arg)
 
     is_unix = resolved.kind == "unix" if resolved is not None else args.target == "unix"
+
+    # --source on the command line overrides a target's configured 'source';
+    # neither one given means the program's module already lives on the
+    # device's own filesystem (the hardware-in-the-loop targets that run
+    # /flash/target.py want exactly this), so nothing gets mounted below. A
+    # target's own 'source' has already been resolved to an absolute path by
+    # mpdebug.toml loading; a literal --source has not, so it gets the same
+    # treatment here.
+    if args.source is not None:
+        if is_unix:
+            raise CommandError(
+                "--source is not valid for a unix target: it already runs the "
+                "program straight from the host filesystem, there is nothing to mount"
+            )
+        source_root = os.path.realpath(args.source)
+    else:
+        source_root = resolved.source if resolved is not None else None
+
+    # Both checks below depend only on host state - the source root and the
+    # module name - so they run before the device is touched at all: a
+    # target whose module can't possibly resolve, or whose configured source
+    # has gone missing since mpdebug.toml was loaded, fails here rather than
+    # after connecting and putting the device in the raw REPL for nothing.
+    if source_root is not None:
+        if not os.path.isdir(source_root):
+            origin = (
+                f"--source {args.source!r}"
+                if args.source is not None
+                else f"target {resolved.name!r} source {source_root!r}"
+            )
+            raise CommandError(f"{origin} is not a directory")
+        module_path, package_path = _module_source_path(source_root, module)
+        if not os.path.isfile(module_path) and not os.path.isfile(package_path):
+            raise CommandError(
+                f"module {module!r} does not resolve under source root "
+                f"{source_root!r} (looked for {module_path!r} and {package_path!r})"
+            )
+
     if is_unix:
         state.did_action()
         # Reports the endpoint and supervises the child itself (unlike the
@@ -1018,73 +1362,169 @@ def do_debug(state, args):
     state.ensure_raw_repl()
     state.did_action()
 
-    try:
-        state.transport.exec_raw_no_follow(_debug_boot_script(module, method, device_port))
-        print("waiting for the device to report its debug-server endpoint...", flush=True)
-        # A pty peer is a local process by construction (a unix build or QEMU
-        # behind a pty pair), so a wildcard bind on it is reachable at the
-        # loopback address. Anything else gets no known_host: a
-        # socket://host:port or rfc2217://host:port host may be the device
-        # itself (esp-link and similar) or a bridge in front of it (ser2net),
-        # and guessing wrong points the client at the wrong machine.
-        known_host = "127.0.0.1" if getattr(state.transport, "is_pty", False) else None
-        handshake = _read_mpdbg_ready(state.transport, timeout=args.timeout, known_host=known_host)
-    except TransportError as er:
-        raise CommandError(er.args[0])
-    except KeyboardInterrupt:
-        sys.exit(1)
+    # No stream channel on this path: the device binds a port and reports it.
+    dap_stream = None
 
-    _check_requires(resolved, handshake["caps"])
-
-    if not dap_log_arg:
-        return _report_debug_result(handshake)
-
-    # Unlike the plain report-and-return above: the device runs independently
-    # of mpremote on this path, but the proxy --dap-log inserts does not, so
-    # returning now would tear down the very thing the client is about to
-    # connect to. Stay attached until the one client session it serves ends,
-    # or the user/environment ends it first.
-    proxy, reported = _start_dap_log(dap_log_arg, handshake, dap_log_bind_port)
-    _report_debug_result(reported)
-    print("staying attached to run the --dap-log proxy; Ctrl-C ends it", flush=True)
-
-    def cleanup():
+    # Everything from here on that touches a mounted device - establishing
+    # it, running the boot script, staying attached, tearing it down - has
+    # to unwind through this function's own `finally` rather than a bare
+    # process kill: an aborted mount, or a signal landing mid-teardown,
+    # leaves `/remote` mounted with the REPL desynced, which only a power
+    # cycle clears (see mount_local's docstring). The guard is requested
+    # from `source_root` alone, not whether the mount actually succeeds, so
+    # it is already active for the `mount_local` call itself. An unmounted
+    # run has nothing of the kind to protect, so it keeps the narrower,
+    # pre-existing behaviour of only the "stay attached" calls below being
+    # signal-safe on their own.
+    signal_guard = _exit_on_signal() if source_root is not None else contextlib.nullcontext()
+    mounted = False
+    pump_stop = pump_thread = pump_failed = None
+    with signal_guard:
         try:
-            old_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
-        except ValueError:
-            old_handler = None  # not called from the main thread
-        try:
-            proxy.close()
+            if source_root is not None:
+                try:
+                    state.transport.mount_local(source_root)
+                    mounted = True
+                except (KeyboardInterrupt, SystemExit):
+                    # Control-flow signals, not a mount failure to report as
+                    # one: propagate as themselves so the outer finally's
+                    # teardown and main()'s own top-level handling see the
+                    # interruption they actually are, the same as every
+                    # other raw-REPL round trip in this function.
+                    raise
+                except BaseException as er:
+                    raise CommandError(
+                        f"mounting {source_root!r} failed ({er}); if the device no "
+                        "longer responds to anything, only a power cycle clears it"
+                    ) from er
+
+            try:
+                state.transport.exec_raw_no_follow(
+                    _debug_boot_script(
+                        module,
+                        method,
+                        device_port,
+                        dap_stream,
+                        mount_point=SerialTransport.fs_hook_mount if mounted else None,
+                    )
+                )
+                print("waiting for the device to report its debug-server endpoint...", flush=True)
+                # A pty peer is a local process by construction (a unix build
+                # or QEMU behind a pty pair), so a wildcard bind on it is
+                # reachable at the loopback address. Anything else gets no
+                # known_host: a socket://host:port or rfc2217://host:port
+                # host may be the device itself (esp-link and similar) or a
+                # bridge in front of it (ser2net), and guessing wrong points
+                # the client at the wrong machine.
+                known_host = "127.0.0.1" if getattr(state.transport, "is_pty", False) else None
+                handshake = _read_mpdbg_ready(
+                    state.transport, timeout=args.timeout, known_host=known_host
+                )
+            except TransportError as er:
+                msg = er.args[0]
+                if mounted:
+                    msg += "; if the device no longer responds, only a power cycle clears it"
+                raise CommandError(msg)
+            except KeyboardInterrupt:
+                sys.exit(1)
+
+            _check_requires(resolved, handshake["caps"])
+
+            # The host's own knowledge of how the remote path maps to a local
+            # one - the device never reports this, since it has no notion of
+            # the host filesystem at all.
+            path_mappings = (
+                [{"localRoot": source_root, "remoteRoot": SerialTransport.fs_hook_mount}]
+                if mounted
+                else None
+            )
+
+            if mounted:
+                # Nothing else reads state.transport once the boot script is
+                # running - the client's DAP traffic rides a separate TCP
+                # endpoint - so a background thread has to
+                # pump it for as long as this function stays attached below,
+                # whichever of the three shapes that takes. `pump_failed` is
+                # set by the thread itself if it ever stops for a reason
+                # other than the `pump_stop` this function requests, so the
+                # "stay attached" call below can tell an unrecoverably wedged
+                # device (see mount_local's docstring) apart from a normal
+                # end of session and stop waiting on it.
+                pump_stop = threading.Event()
+                pump_failed = threading.Event()
+                pump_thread = threading.Thread(
+                    target=_pump_mount,
+                    args=(state.transport, pump_stop, pump_failed),
+                    daemon=True,
+                )
+                pump_thread.start()
+
+            if not dap_log_arg:
+                _report_debug_result(handshake, path_mappings)
+                if mounted:
+                    _stay_attached_mount(
+                        "staying attached to service the mounted filesystem; Ctrl-C ends it",
+                        pump_failed=pump_failed,
+                    )
+                return handshake
+
+            # Unlike the plain report-and-return above: the device runs
+            # independently of mpremote on this path, but the proxy
+            # --dap-log inserts does not, so returning now would tear down
+            # the very thing the client is about to connect to. Stay
+            # attached until the one client session it serves ends, or the
+            # user/environment ends it first.
+            proxy, reported = _start_dap_log(dap_log_arg, handshake, dap_log_bind_port)
+            _report_debug_result(reported, path_mappings)
+            _stay_attached(
+                proxy,
+                "staying attached to run the --dap-log proxy; Ctrl-C ends it",
+                pump_failed=pump_failed,
+            )
+            return reported
         finally:
-            if old_handler is not None:
-                signal.signal(signal.SIGINT, old_handler)
-
-    # Same reap-on-every-exit-path ladder as _do_debug_unix's child, applied
-    # to the proxy instead of a subprocess.
-    _reaping_signals = [signal.SIGTERM]
-    if hasattr(signal, "SIGHUP"):
-        _reaping_signals.append(signal.SIGHUP)
-    old_handlers = {}
-    for _sig in _reaping_signals:
-        try:
-            old_handlers[_sig] = signal.signal(_sig, lambda *_a: sys.exit(1))
-        except ValueError:
-            pass  # not called from the main thread
-    try:
-        try:
-            while not proxy.wait(_POLL_S):
-                pass
-        except KeyboardInterrupt:
-            cleanup()
-            sys.exit(1)
-        except BaseException:
-            cleanup()
-            raise
-        cleanup()
-        return reported
-    finally:
-        for _sig, _old in old_handlers.items():
-            signal.signal(_sig, _old)
+            if pump_stop is not None:
+                pump_stop.set()
+            pump_alive = False
+            if pump_thread is not None:
+                pump_thread.join(timeout=2)
+                pump_alive = pump_thread.is_alive()
+            # getattr, not the local `mounted` flag: a `mount_local` that
+            # raised after already setting the transport's own flag (a
+            # signal landing in its narrow window between marking itself
+            # mounted and finishing setup) still needs tearing down, even
+            # though the `except` above turned that into a CommandError
+            # before `mounted` was ever set here. This runs inside
+            # `signal_guard`, not after it, so a signal landing mid-teardown
+            # is still caught by the custom handler rather than killing
+            # mpremote with the device left mounted and desynced.
+            if getattr(state.transport, "mounted", False):
+                if pump_alive:
+                    # The pump thread still owns the port: calling umount_local
+                    # now would give it a second, concurrent reader. Leaving the
+                    # mount up is the safer of two bad outcomes, since a stuck
+                    # pump means the port is already in a state only a power
+                    # cycle reliably clears. `mounted` is still cleared, though
+                    # (the port itself is left alone) - otherwise
+                    # `do_disconnect`'s own unmount attempt at process exit
+                    # would give the still-running pump a second reader too.
+                    state.transport.mounted = False
+                    print(
+                        f"warning: the mount's filesystem pump for "
+                        f"{state.transport.device_name!r} did not stop in time; leaving "
+                        f"{state.transport.fs_hook_mount} mounted rather than risk a "
+                        "second reader on the port - a power cycle is what clears it",
+                        file=sys.stderr,
+                    )
+                elif pump_failed is not None and pump_failed.is_set():
+                    # _pump_mount already reported this on stderr before
+                    # setting the event: the RPC channel that a clean
+                    # umount needs is exactly what just died, so retrying
+                    # it here would only wait out _MOUNT_TEARDOWN_TIMEOUT_S
+                    # before failing the same way.
+                    state.transport.mounted = False
+                else:
+                    _teardown_mount(state.transport)
 
 
 def do_mount(state, args):

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -542,25 +542,34 @@ def _parse_program_spec(spec):
     return module, method
 
 
-def _debug_boot_script(module, method, port, dap_stream=None, mount_point=None):
+def _debug_argv(module, method, port, dap_stream=None, loop=False):
+    """mpy_launch_debugpy.py's arguments, in its own positional order.
+
+    Its contract is `[module] [method] [port] [dap_stream] [loop]`, all
+    positional, so an argument that is not given but is followed by one that is
+    has to be passed as the empty string - which the launcher reads as "not
+    given" (its own default port, and the TCP channel rather than a stream).
+    Trailing empties are dropped so the common cases produce the shortest argv.
+    """
+    argv = [
+        module,
+        method,
+        "" if port is None else str(port),
+        dap_stream or "",
+        "loop" if loop else "",
+    ]
+    while argv and argv[-1] == "":
+        argv.pop()
+    return argv
+
+
+def _debug_boot_script(module, method, port, dap_stream=None, mount_point=None, loop=False):
     # Raw REPL exec has no OS argv, so sys.argv is injected here to preserve
-    # mpy_launch_debugpy.py's own argv contract ([module] [method] [port]
-    # [dap_stream]).
+    # mpy_launch_debugpy.py's own argv contract (see _debug_argv).
     # sys.argv is rebound in place (not reassigned): the `sys` module dict is
     # read-only on MicroPython, so `sys.argv = [...]` raises AttributeError.
-    # port=None omits the argv element so the device applies its own default
-    # port instead of the host choosing one - unless a dap_stream follows it,
-    # since argv is positional. The placeholder is harmless: the stream path
-    # never binds a port, and a device that cannot produce the requested
-    # stream raises instead of falling back to TCP.
     script = pkgutil.get_data(__package__, "mpy_launch_debugpy.py").decode()
-    argv = ["mpy_launch_debugpy.py", module, method]
-    if port is not None:
-        argv.append(str(port))
-    elif dap_stream is not None:
-        argv.append("0")
-    if dap_stream is not None:
-        argv.append(dap_stream)
+    argv = ["mpy_launch_debugpy.py"] + _debug_argv(module, method, port, dap_stream, loop)
     preamble = "import sys\nsys.argv[:] = [{}]\n".format(", ".join(repr(a) for a in argv))
     if mount_point is not None:
         # The fs hook os.chdir()s into the mount point, so plain __import__
@@ -1082,7 +1091,7 @@ def _reap(proc):
 _UNIX_EOF_MARKER = "\x00mpremote-debug-unix-eof\x00"  # never appears in real program output
 
 
-def _do_debug_unix(resolved, module, method, port, timeout, dap_log_arg, dap_log_bind_port):
+def _do_debug_unix(resolved, module, method, port, timeout, dap_log_arg, dap_log_bind_port, loop):
     proxy = None  # set once the handshake is in, if --dap-log was given
     try:
         # The non-blocking fd handling below is POSIX-only, unlike the rest of
@@ -1107,9 +1116,9 @@ def _do_debug_unix(resolved, module, method, port, timeout, dap_log_arg, dap_log
         shutil.rmtree(tmpdir, ignore_errors=True)
         raise
 
-    argv = [binary, script_path, module, method]
-    if port is not None:
-        argv.append(str(port))
+    # No dap_stream: a unix target's DAP channel is TCP on the loopback
+    # interface, which needs no second interface to carry it.
+    argv = [binary, script_path] + _debug_argv(module, method, port, loop=loop)
 
     try:
         proc = subprocess.Popen(
@@ -1338,7 +1347,14 @@ def do_debug(state, args):
         # Reports the endpoint and supervises the child itself (unlike the
         # serial/network path below, mpremote owns this process).
         return _do_debug_unix(
-            resolved, module, method, device_port, args.timeout, dap_log_arg, dap_log_bind_port
+            resolved,
+            module,
+            method,
+            device_port,
+            args.timeout,
+            dap_log_arg,
+            dap_log_bind_port,
+            args.loop,
         )
 
     if resolved is None:
@@ -1406,6 +1422,7 @@ def do_debug(state, args):
                         device_port,
                         dap_stream,
                         mount_point=SerialTransport.fs_hook_mount if mounted else None,
+                        loop=args.loop,
                     )
                 )
                 print("waiting for the device to report its debug-server endpoint...", flush=True)

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -1,5 +1,6 @@
 import binascii
 import codecs
+import collections
 import contextlib
 import errno
 import hashlib
@@ -593,6 +594,7 @@ def _debug_boot_script(module, method, port, dap_stream=None, mount_point=None, 
 _POLL_S = 0.2  # read_until() poll cadence for both the handshake scan and the error drain below
 _MOUNT_TEARDOWN_TIMEOUT_S = 10  # bounds each of the two round trips in _teardown_mount
 _CONSOLE_POLL_S = 0.05  # how often _pump_console looks again at an idle console
+_CONSOLE_BUFFER_BYTES = 256 * 1024  # what _pump_console holds for a stalled consumer
 
 
 def _one_line(value):
@@ -999,22 +1001,68 @@ def _pump_console(transport, stop_event):
     the debugged program's own output and this process holds the only port
     they can arrive on.
 
+    Reading and printing are separate threads on purpose. Writing to a stdout
+    nobody is reading blocks once the pipe fills, and a reader that blocks is
+    a console that is not being emptied - the same fault one level up, with
+    64 kB of pipe instead of 4 kB of tty in front of it. The reader therefore
+    only ever hands bytes to a bounded buffer, which drops the oldest when a
+    stalled consumer lets it fill. Losing console output is a cost; stopping
+    the board being debugged is a defect.
+
     Reads only what has already arrived: the port is opened blocking, so
     asking for a fixed count would wait for bytes that a program between
     prints has no reason to send, and `stop_event` would not be looked at
     again until they came.
     """
+    buffered = collections.deque()
+    buffered_bytes = [0]
+    dropped = [0]
+    lock = threading.Lock()
+
+    def emit():
+        while True:
+            with lock:
+                chunk = buffered.popleft() if buffered else None
+                if chunk is not None:
+                    buffered_bytes[0] -= len(chunk)
+            if chunk is None:
+                if stop_event.is_set():
+                    return
+                stop_event.wait(_CONSOLE_POLL_S)
+                continue
+            try:
+                sys.stdout.write(chunk.decode("utf-8", "replace"))
+                sys.stdout.flush()
+            except Exception:
+                return  # a consumer that closed the pipe, not a device problem
+
+    writer = threading.Thread(target=emit, daemon=True)
+    writer.start()
+
     while not stop_event.is_set():
         try:
             waiting = transport.serial.in_waiting
             data = transport.serial.read(waiting) if waiting else b""
         except Exception:
-            return
-        if data:
-            sys.stdout.write(data.decode("utf-8", "replace"))
-            sys.stdout.flush()
-        else:
+            break
+        if not data:
             stop_event.wait(_CONSOLE_POLL_S)
+            continue
+        with lock:
+            buffered.append(data)
+            buffered_bytes[0] += len(data)
+            while buffered_bytes[0] > _CONSOLE_BUFFER_BYTES and len(buffered) > 1:
+                dropped[0] += len(buffered[0])
+                buffered_bytes[0] -= len(buffered.popleft())
+
+    stop_event.set()
+    writer.join(timeout=1)
+    if dropped[0]:
+        print(
+            f"warning: dropped {dropped[0]} bytes of the board's console output; "
+            "whatever is reading this command's output did not keep up",
+            file=sys.stderr,
+        )
 
 
 def _teardown_mount(transport):
@@ -1539,9 +1587,11 @@ def do_debug(state, args):
     state.ensure_raw_repl()
     state.did_action()
 
-    # "repl" tells the device to split the stream mpremote is already
-    # holding rather than bind a port, and the bridge below reads the DAP
-    # half back out of it.
+    # "repl" tells the device to split the stream mpremote is already holding
+    # rather than bind a port, and the bridge below reads the DAP half back
+    # out of it. The device is told which channel to take, never a host path:
+    # the host names an interface by tty node and the device by runtime
+    # object, and only the device can map one to the other.
     dap_stream = "repl" if dap_repl else None
 
     # Everything from here on that touches a mounted device - establishing
@@ -1622,9 +1672,9 @@ def do_debug(state, args):
             if mounted:
                 # Nothing else reads state.transport once the boot script is
                 # running - the client's DAP traffic rides a separate TCP
-                # endpoint - so a background thread has to
-                # pump it for as long as this function stays attached below,
-                # whichever of the three shapes that takes. `pump_failed` is
+                # endpoint - so a background thread has to pump it for as
+                # long as this function stays attached below, whichever
+                # shape that takes. `pump_failed` is
                 # set by the thread itself if it ever stops for a reason
                 # other than the `pump_stop` this function requests, so the
                 # "stay attached" call below can tell an unrecoverably wedged
@@ -1640,17 +1690,20 @@ def do_debug(state, args):
                 pump_thread.start()
 
             # The client-facing port for a bridge this process runs itself.
-            serial_bind_port = dap_log_bind_port if dap_log_arg else (args.port or 0)
+            dap_bind_port = dap_log_bind_port if dap_log_arg else (args.port or 0)
 
             if dap_repl:
-                # The whole DAP channel runs through mpremote here, so this
-                # always stays attached. The channel is the transport's own
-                # port, so it is closed
+                # The whole DAP channel runs through mpremote here - there is
+                # no device-side TCP endpoint to report at all - so this
+                # always stays attached, with or without --dap-log, where the
+                # plain network path below only does that when --dap-log adds
+                # its own proxy or when a mount needs pumping. The channel is
+                # the transport's own port, so it is closed
                 # before returning rather than left to the transport's own
                 # teardown: the reader thread has to stop touching the port
                 # while this function still owns it.
                 channel, proxy, reported = _start_repl_dap(
-                    state, handshake, dap_log_arg, serial_bind_port
+                    state, handshake, dap_log_arg, dap_bind_port
                 )
                 try:
                     _report_debug_result(reported, path_mappings)

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -592,6 +592,7 @@ def _debug_boot_script(module, method, port, dap_stream=None, mount_point=None, 
 
 _POLL_S = 0.2  # read_until() poll cadence for both the handshake scan and the error drain below
 _MOUNT_TEARDOWN_TIMEOUT_S = 10  # bounds each of the two round trips in _teardown_mount
+_CONSOLE_POLL_S = 0.05  # how often _pump_console looks again at an idle console
 
 
 def _one_line(value):
@@ -836,7 +837,7 @@ def _exit_on_signal(exit_code=1):
             signal.signal(sig, old)
 
 
-def _stay_attached(proxy, message, pump_failed=None, device_gone=None):
+def _stay_attached(proxy, message, pump_failed=None, device_gone=None, console=None):
     """Block until `proxy`'s one client session ends, reaping it on every exit path.
 
     Shared by `--dap-log`'s own proxy and a `--dap-repl` bridge - both are a
@@ -858,10 +859,21 @@ def _stay_attached(proxy, message, pump_failed=None, device_gone=None):
     to have connected first, so without this a device that finishes while
     nothing is attached - a run whose client never arrived - would leave this
     waiting for one that is not coming.
+
+    `console` is the transport whose primary connection this process is
+    holding open with nothing else reading it, and it is drained for exactly
+    as long as this waits - see `_pump_console` for what an unread console
+    does to the board. A caller passes None when something already reads that
+    connection: a mount's own RPC pump, or a `repl_dap` channel, whose reader
+    owns the port and would lose frames to a second one.
     """
     print(message, flush=True)
+    console_stop = threading.Event()
+    if console is not None:
+        threading.Thread(target=_pump_console, args=(console, console_stop), daemon=True).start()
 
     def cleanup():
+        console_stop.set()
         try:
             old_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
         except ValueError:
@@ -932,8 +944,10 @@ def _pump_mount(transport, stop_event, failed_event):
     calling read on it, an RPC request the device makes on its next
     filesystem access would sit unanswered and the device would block on it
     indefinitely. Ordinary console bytes collected between RPC commands are
-    discarded, matching every other "stay attached" path here: none of them
-    surface the primary connection's console output while attached.
+    discarded rather than printed, unlike `_pump_console`: this loop reads
+    the RPC framing itself, so what is left over is whatever fell between
+    two commands rather than a clean stream of the program's output. Both
+    keep the console emptied, which is what the device needs of them.
 
     A read raising while `stop_event` is not set means the device stopped
     answering an RPC command mid-exchange, not that the caller asked this
@@ -966,6 +980,41 @@ def _pump_mount(transport, stop_event, failed_event):
                 )
                 failed_event.set()
             return
+
+
+def _pump_console(transport, stop_event):
+    """Background thread: keep the board's console drained while attached.
+
+    A console this process holds open but never reads back-pressures all the
+    way into the device. The tty's line discipline stops accepting once its
+    own buffer fills, the board's transmit buffer fills behind it, and
+    `print` then waits for room - on a stm32 USB CDC, up to 500ms for each
+    byte it cannot place. The debugged program stops making progress, and so
+    does the DAP channel, while the board's networking keeps acknowledging
+    from interrupt context: it looks like a link that has gone quiet rather
+    than like a console nobody is emptying.
+
+    So every path that stays attached and owns the primary connection reads
+    it. The bytes go to stdout rather than being discarded, because they are
+    the debugged program's own output and this process holds the only port
+    they can arrive on.
+
+    Reads only what has already arrived: the port is opened blocking, so
+    asking for a fixed count would wait for bytes that a program between
+    prints has no reason to send, and `stop_event` would not be looked at
+    again until they came.
+    """
+    while not stop_event.is_set():
+        try:
+            waiting = transport.serial.in_waiting
+            data = transport.serial.read(waiting) if waiting else b""
+        except Exception:
+            return
+        if data:
+            sys.stdout.write(data.decode("utf-8", "replace"))
+            sys.stdout.flush()
+        else:
+            stop_event.wait(_CONSOLE_POLL_S)
 
 
 def _teardown_mount(transport):
@@ -1642,6 +1691,7 @@ def do_debug(state, args):
                 proxy,
                 "staying attached to run the --dap-log proxy; Ctrl-C ends it",
                 pump_failed=pump_failed,
+                console=None if mounted else state.transport,
             )
             return reported
         finally:

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -543,25 +543,34 @@ def _parse_program_spec(spec):
     return module, method
 
 
-def _debug_boot_script(module, method, port, dap_stream=None, mount_point=None):
+def _debug_argv(module, method, port, dap_stream=None, loop=False):
+    """mpy_launch_debugpy.py's arguments, in its own positional order.
+
+    Its contract is `[module] [method] [port] [dap_stream] [loop]`, all
+    positional, so an argument that is not given but is followed by one that is
+    has to be passed as the empty string - which the launcher reads as "not
+    given" (its own default port, and the TCP channel rather than a stream).
+    Trailing empties are dropped so the common cases produce the shortest argv.
+    """
+    argv = [
+        module,
+        method,
+        "" if port is None else str(port),
+        dap_stream or "",
+        "loop" if loop else "",
+    ]
+    while argv and argv[-1] == "":
+        argv.pop()
+    return argv
+
+
+def _debug_boot_script(module, method, port, dap_stream=None, mount_point=None, loop=False):
     # Raw REPL exec has no OS argv, so sys.argv is injected here to preserve
-    # mpy_launch_debugpy.py's own argv contract ([module] [method] [port]
-    # [dap_stream]).
+    # mpy_launch_debugpy.py's own argv contract (see _debug_argv).
     # sys.argv is rebound in place (not reassigned): the `sys` module dict is
     # read-only on MicroPython, so `sys.argv = [...]` raises AttributeError.
-    # port=None omits the argv element so the device applies its own default
-    # port instead of the host choosing one - unless a dap_stream follows it,
-    # since argv is positional. The placeholder is harmless: the stream path
-    # never binds a port, and a device that cannot produce the requested
-    # stream raises instead of falling back to TCP.
     script = pkgutil.get_data(__package__, "mpy_launch_debugpy.py").decode()
-    argv = ["mpy_launch_debugpy.py", module, method]
-    if port is not None:
-        argv.append(str(port))
-    elif dap_stream is not None:
-        argv.append("0")
-    if dap_stream is not None:
-        argv.append(dap_stream)
+    argv = ["mpy_launch_debugpy.py"] + _debug_argv(module, method, port, dap_stream, loop)
     preamble = "import sys\nsys.argv[:] = [{}]\n".format(", ".join(repr(a) for a in argv))
     if mount_point is not None:
         # The fs hook os.chdir()s into the mount point, so plain __import__
@@ -1153,7 +1162,7 @@ def _reap(proc):
 _UNIX_EOF_MARKER = "\x00mpremote-debug-unix-eof\x00"  # never appears in real program output
 
 
-def _do_debug_unix(resolved, module, method, port, timeout, dap_log_arg, dap_log_bind_port):
+def _do_debug_unix(resolved, module, method, port, timeout, dap_log_arg, dap_log_bind_port, loop):
     proxy = None  # set once the handshake is in, if --dap-log was given
     try:
         # The non-blocking fd handling below is POSIX-only, unlike the rest of
@@ -1178,9 +1187,9 @@ def _do_debug_unix(resolved, module, method, port, timeout, dap_log_arg, dap_log
         shutil.rmtree(tmpdir, ignore_errors=True)
         raise
 
-    argv = [binary, script_path, module, method]
-    if port is not None:
-        argv.append(str(port))
+    # No dap_stream: a unix target's DAP channel is TCP on the loopback
+    # interface, which needs no second interface to carry it.
+    argv = [binary, script_path] + _debug_argv(module, method, port, loop=loop)
 
     try:
         proc = subprocess.Popen(
@@ -1409,7 +1418,14 @@ def do_debug(state, args):
         # Reports the endpoint and supervises the child itself (unlike the
         # serial/network path below, mpremote owns this process).
         return _do_debug_unix(
-            resolved, module, method, device_port, args.timeout, dap_log_arg, dap_log_bind_port
+            resolved,
+            module,
+            method,
+            device_port,
+            args.timeout,
+            dap_log_arg,
+            dap_log_bind_port,
+            args.loop,
         )
 
     if resolved is None:
@@ -1483,6 +1499,7 @@ def do_debug(state, args):
                         device_port,
                         dap_stream,
                         mount_point=SerialTransport.fs_hook_mount if mounted else None,
+                        loop=args.loop,
                     )
                 )
                 print("waiting for the device to report its debug-server endpoint...", flush=True)

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -7,6 +7,7 @@ import os
 import pkgutil
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import tempfile
@@ -20,6 +21,7 @@ from .transport_serial import SerialTransport
 from .romfs import make_romfs, VfsRomWriter
 from .mpdebug_config import find_config, resolve_target, target_hint, warn_if_tty_device
 from . import mpdebug_handshake
+from . import dap_log
 
 
 class CommandError(Exception):
@@ -642,6 +644,54 @@ def _report_debug_result(handshake):
     return handshake
 
 
+def _start_dap_log(dap_log_arg, handshake, bind_port=0):
+    # Neither transport puts the byte stream through mpremote, so logging
+    # means interposing a proxy in front of the device's real endpoint and
+    # reporting *its* host/port instead - a client that got the device's own
+    # endpoint would attach straight past the logger.
+    # dap_log_arg is True for --dap-log with no --dap-log-file, else the path.
+    path = dap_log_arg if isinstance(dap_log_arg, str) else dap_log.default_log_path()
+    try:
+        logger = dap_log.DapLogger(path)
+    except OSError as er:
+        raise CommandError(f"--dap-log could not open {path!r}: {er}") from None
+    try:
+        proxy = dap_log.DapProxy(handshake["host"], handshake["port"], logger, bind_port=bind_port)
+    except OSError as er:
+        logger.close()
+        raise CommandError(f"--dap-log could not bind a proxy port: {er}") from None
+    proxy.start()
+    print(f"logging DAP traffic to {path!r}", flush=True)
+    reported = dict(handshake, host=proxy.host, port=proxy.port)
+    return proxy, reported
+
+
+def _dap_log_ports(port, dap_log_arg):
+    """Split a single `--port` between the device and the `--dap-log` proxy.
+
+    Without `--dap-log`, `port` is what the device binds, unchanged. With
+    it, `--port` names the endpoint a client connects to (so a launch.json
+    pinning a port still goes through the logger): the device gets a freshly
+    reserved port of its own, and the requested port becomes the proxy's
+    bind port instead of an OS-assigned one. Returns (device_port,
+    proxy_bind_port).
+
+    With no `--port`, the device is still moved off its own default rather
+    than left there: otherwise it stays reachable on the conventional port
+    while the proxy sits somewhere else, and a client aimed at that
+    conventional port connects straight to the device and is logged nowhere.
+    Moving it means such a client fails to connect instead - loudly wrong
+    rather than quietly unlogged - and the endpoint to use is the one
+    reported.
+    """
+    if not dap_log_arg:
+        return port, 0
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        device_port = s.getsockname()[1]
+    return device_port, (port or 0)
+
+
 def _resolve_unix_binary(resolved):
     env_path = os.environ.get("MPY_DEBUG_FIRMWARE")
     if env_path:
@@ -742,7 +792,8 @@ def _reap(proc):
 _UNIX_EOF_MARKER = "\x00mpremote-debug-unix-eof\x00"  # never appears in real program output
 
 
-def _do_debug_unix(resolved, module, method, port, timeout):
+def _do_debug_unix(resolved, module, method, port, timeout, dap_log_arg, dap_log_bind_port):
+    proxy = None  # set once the handshake is in, if --dap-log was given
     try:
         # The non-blocking fd handling below is POSIX-only, unlike the rest of
         # mpremote, which supports Windows.
@@ -787,6 +838,8 @@ def _do_debug_unix(resolved, module, method, port, timeout):
             old_handler = None  # not called from the main thread
         try:
             _reap(proc)
+            if proxy is not None:
+                proxy.close()
             shutil.rmtree(tmpdir, ignore_errors=True)
         finally:
             if old_handler is not None:
@@ -863,7 +916,12 @@ def _do_debug_unix(resolved, module, method, port, timeout):
             # come back the temp file has already been fully read and is no
             # longer needed.
             shutil.rmtree(tmpdir, ignore_errors=True)
-            _report_debug_result(handshake)
+
+            if dap_log_arg:
+                proxy, reported = _start_dap_log(dap_log_arg, handshake, dap_log_bind_port)
+            else:
+                reported = handshake
+            _report_debug_result(reported)
 
             # Unlike the serial/network paths, where the firmware runs
             # independently of the host tool, mpremote owns this child: stay
@@ -893,10 +951,12 @@ def _do_debug_unix(resolved, module, method, port, timeout):
             cleanup()
             raise
 
+        if proxy is not None:
+            proxy.close()
         _reap(proc)
         if proc.returncode:
             sys.exit(proc.returncode)
-        return handshake
+        return reported
     finally:
         for _sig, _old in old_handlers.items():
             signal.signal(_sig, _old)
@@ -910,8 +970,6 @@ def do_debug(state, args):
         program_spec = (resolved.program if resolved is not None else None) or "target:main"
     module, method = _parse_program_spec(program_spec)
 
-    if args.dap_log:
-        raise CommandError("--dap-log is not implemented yet")
     # Both checked here rather than after a full raw-REPL round trip.
     if args.port == 0:
         raise CommandError(
@@ -922,12 +980,22 @@ def do_debug(state, args):
     if args.port is not None and not 1 <= args.port <= 65535:
         raise CommandError(f"--port must be between 1 and 65535, got {args.port}")
 
+    if args.dap_log_file is not None and not args.dap_log:
+        raise CommandError("--dap-log-file requires --dap-log")
+    # False (no logging), True (log to the default path), or an explicit path.
+    dap_log_arg = (args.dap_log_file or True) if args.dap_log else False
+    # With --dap-log, --port pins the proxy's (client-facing) port instead of
+    # the device's; the device gets a freshly reserved port of its own.
+    device_port, dap_log_bind_port = _dap_log_ports(args.port, dap_log_arg)
+
     is_unix = resolved.kind == "unix" if resolved is not None else args.target == "unix"
     if is_unix:
         state.did_action()
         # Reports the endpoint and supervises the child itself (unlike the
         # serial/network path below, mpremote owns this process).
-        return _do_debug_unix(resolved, module, method, args.port, args.timeout)
+        return _do_debug_unix(
+            resolved, module, method, device_port, args.timeout, dap_log_arg, dap_log_bind_port
+        )
 
     if resolved is None:
         # No mpdebug.toml matched (or none exists): args.target is a literal
@@ -951,7 +1019,7 @@ def do_debug(state, args):
     state.did_action()
 
     try:
-        state.transport.exec_raw_no_follow(_debug_boot_script(module, method, args.port))
+        state.transport.exec_raw_no_follow(_debug_boot_script(module, method, device_port))
         print("waiting for the device to report its debug-server endpoint...", flush=True)
         # A pty peer is a local process by construction (a unix build or QEMU
         # behind a pty pair), so a wildcard bind on it is reachable at the
@@ -967,7 +1035,56 @@ def do_debug(state, args):
         sys.exit(1)
 
     _check_requires(resolved, handshake["caps"])
-    return _report_debug_result(handshake)
+
+    if not dap_log_arg:
+        return _report_debug_result(handshake)
+
+    # Unlike the plain report-and-return above: the device runs independently
+    # of mpremote on this path, but the proxy --dap-log inserts does not, so
+    # returning now would tear down the very thing the client is about to
+    # connect to. Stay attached until the one client session it serves ends,
+    # or the user/environment ends it first.
+    proxy, reported = _start_dap_log(dap_log_arg, handshake, dap_log_bind_port)
+    _report_debug_result(reported)
+    print("staying attached to run the --dap-log proxy; Ctrl-C ends it", flush=True)
+
+    def cleanup():
+        try:
+            old_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
+        except ValueError:
+            old_handler = None  # not called from the main thread
+        try:
+            proxy.close()
+        finally:
+            if old_handler is not None:
+                signal.signal(signal.SIGINT, old_handler)
+
+    # Same reap-on-every-exit-path ladder as _do_debug_unix's child, applied
+    # to the proxy instead of a subprocess.
+    _reaping_signals = [signal.SIGTERM]
+    if hasattr(signal, "SIGHUP"):
+        _reaping_signals.append(signal.SIGHUP)
+    old_handlers = {}
+    for _sig in _reaping_signals:
+        try:
+            old_handlers[_sig] = signal.signal(_sig, lambda *_a: sys.exit(1))
+        except ValueError:
+            pass  # not called from the main thread
+    try:
+        try:
+            while not proxy.wait(_POLL_S):
+                pass
+        except KeyboardInterrupt:
+            cleanup()
+            sys.exit(1)
+        except BaseException:
+            cleanup()
+            raise
+        cleanup()
+        return reported
+    finally:
+        for _sig, _old in old_handlers.items():
+            signal.signal(_sig, _old)
 
 
 def do_mount(state, args):

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -1,7 +1,7 @@
 import binascii
+import codecs
 import errno
 import hashlib
-import json
 import os
 import pkgutil
 import sys
@@ -15,6 +15,7 @@ from .transport import TransportError, TransportExecError, stdout_write_bytes
 from .transport_serial import SerialTransport
 from .romfs import make_romfs, VfsRomWriter
 from .mpdebug_config import resolve_target, target_hint, warn_if_tty_device
+from . import mpdebug_handshake
 
 
 class CommandError(Exception):
@@ -546,77 +547,67 @@ def _debug_boot_script(module, method, port):
     return preamble + script
 
 
-def _mpdbg_tail(output):
-    # Quote whatever the device printed before it stopped, if anything.
-    text = output.decode(errors="replace").strip()
-    return f"; last output: {text!r}" if text else ""
-
-
-_MPDBG_POLL_S = 0.2  # read_until window; keeps EOF-without-newline detection prompt
+_POLL_S = 0.2  # read_until() poll cadence for both the handshake scan and the error drain below
 
 
 def _mpdbg_error(transport, rest):
     # The raw REPL frames output as <stdout> \x04 <exception> \x04>, so the
     # traceback follows the marker that ends stdout: collect it, since a script
     # that dies on import prints nothing to stdout and the exception is the
-    # only useful thing to report.
+    # only useful thing to report. `rest` is the raw bytes already read past
+    # the marker, not text decoded by the handshake scan, so a non-ASCII
+    # exception message isn't put through a second decode/encode round trip.
     eof = b"\x04"
     deadline = time.monotonic() + 1
     while eof not in rest and time.monotonic() < deadline:
         try:
-            rest += transport.read_until(
-                1, eof, timeout=_MPDBG_POLL_S, timeout_overall=_MPDBG_POLL_S
-            )
+            rest += transport.read_until(1, eof, timeout=_POLL_S, timeout_overall=_POLL_S)
         except Exception:
             break
     text = rest.partition(eof)[0].decode(errors="replace").strip()
     return f"; device error: {text}" if text else ""
 
 
-def _read_mpdbg_ready(transport, timeout):
+def _read_mpdbg_ready(
+    transport, timeout, control_kind=mpdebug_handshake.CONTROL_KIND_SERIAL, known_host=None
+):
     # Boot script output is normal print()s until its one handshake line;
     # echo everything else and stop at the line carrying the JSON payload.
-    # Polled in short windows rather than one read_until(..., timeout=timeout)
-    # call so a device that exits without a trailing newline (raw REPL's
-    # `\x04\x04` with no `\n`) is caught within one poll instead of stalling
-    # for the whole `timeout`.
-    prefix = b"MPDBG-READY "  # single machine-readable line, see mpy_launch_debugpy.py
-    eof = b"\x04"  # raw-REPL end-of-output marker: script exited, nothing more is coming
+    # read_chunk polls in short windows rather than blocking for the whole
+    # `timeout` so a device that exits without a trailing newline (raw REPL's
+    # `\x04\x04` with no `\n`) is caught within one poll instead of stalling.
+    # Each poll is clamped to what's left of `timeout` so the wait can't
+    # overshoot it by a full poll window.
     deadline = time.monotonic() + timeout
-    buf = b""
-    last_line = b""
-    while True:
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            raise CommandError(
-                "timed out waiting for a {!r} line from the device{}".format(
-                    prefix.decode(), _mpdbg_tail(last_line + buf)
-                )
-            )
-        poll = min(remaining, _MPDBG_POLL_S)
-        buf += transport.read_until(1, b"\n", timeout=poll, timeout_overall=poll)
-        if eof in buf:
-            seen, _, rest = buf.partition(eof)
-            raise CommandError(
-                "device exited before printing a {!r} line{}{}".format(
-                    prefix.decode(),
-                    _mpdbg_tail(last_line + seen),
-                    _mpdbg_error(transport, rest),
-                )
-            )
-        if not buf.endswith(b"\n"):
-            continue
-        line, buf = buf, b""
-        if line.startswith(prefix):
-            payload = line[len(prefix) :]
-            try:
-                return json.loads(payload)
-            except json.JSONDecodeError as er:
-                raise CommandError(
-                    f"malformed {prefix.decode()!r} line from the device: {payload!r} ({er})"
-                )
-        stdout_write_bytes(line)
-        last_line = line
+    # An incremental decoder carries an incomplete multi-byte UTF-8 sequence
+    # across poll boundaries instead of decoding each raw chunk in isolation,
+    # which would turn a split character into two separate replacement chars.
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+    raw = bytearray()  # mirrors what's been decoded, for _mpdbg_error below
+
+    def read_chunk():
+        poll = max(0.0, min(_POLL_S, deadline - time.monotonic()))
+        chunk = transport.read_until(1, b"\n", timeout=poll, timeout_overall=poll)
+        raw.extend(chunk)
+        return decoder.decode(chunk)
+
+    def on_eof(rest):
+        # Recover the bytes after the marker from `raw` rather than
+        # re-encoding `rest` (see _mpdbg_error).
+        return _mpdbg_error(transport, bytes(raw[raw.index(b"\x04") + 1 :]))
+
+    try:
+        return mpdebug_handshake.read_handshake(
+            read_chunk,
+            timeout,
+            control_kind,
+            known_host=known_host,
+            on_line=lambda line: stdout_write_bytes(line.encode()),
+            eof="\x04",  # raw-REPL end-of-output marker: script exited, nothing more coming
+            on_eof=on_eof,
+        )
+    except mpdebug_handshake.HandshakeError as er:
+        raise CommandError(str(er))
 
 
 def do_debug(state, args):
@@ -667,20 +658,20 @@ def do_debug(state, args):
     try:
         state.transport.exec_raw_no_follow(_debug_boot_script(module, method, args.port))
         print("waiting for the device to report its debug-server endpoint...", flush=True)
-        handshake = _read_mpdbg_ready(state.transport, timeout=args.timeout)
+        # A pty peer is a local process by construction (a unix build or QEMU
+        # behind a pty pair), so a wildcard bind on it is reachable at the
+        # loopback address. Anything else gets no known_host: a
+        # socket://host:port or rfc2217://host:port host may be the device
+        # itself (esp-link and similar) or a bridge in front of it (ser2net),
+        # and guessing wrong points the client at the wrong machine.
+        known_host = "127.0.0.1" if getattr(state.transport, "is_pty", False) else None
+        handshake = _read_mpdbg_ready(state.transport, timeout=args.timeout, known_host=known_host)
     except TransportError as er:
         raise CommandError(er.args[0])
     except KeyboardInterrupt:
         sys.exit(1)
 
-    try:
-        host, port, caps = handshake["host"], handshake["port"], handshake["caps"]
-    except KeyError as er:
-        raise CommandError(f"malformed handshake payload from the device, missing key {er}")
-    if not isinstance(caps, dict):
-        raise CommandError(
-            f"malformed handshake payload from the device, 'caps' is not a table: {caps!r}"
-        )
+    host, port, caps = handshake["host"], handshake["port"], handshake["caps"]
 
     if resolved is not None and resolved.requires:
         missing = [c for c in resolved.requires if caps.get(c) is not True]
@@ -692,6 +683,8 @@ def do_debug(state, args):
 
     print("debug server listening on {}:{}".format(host, port))
     print("capabilities:", caps)
+    # Returned for the flows that act on the endpoint rather than print it.
+    return handshake
 
 
 def do_mount(state, args):

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -1,9 +1,12 @@
 import binascii
 import errno
 import hashlib
+import json
 import os
+import pkgutil
 import sys
 import tempfile
+import time
 import zlib
 
 import serial.tools.list_ports
@@ -17,8 +20,8 @@ class CommandError(Exception):
     pass
 
 
-def do_connect(state, args=None):
-    dev = args.device[0] if args else "auto"
+def do_connect(state, args=None, device=None):
+    dev = device if device is not None else (args.device[0] if args else "auto")
     do_disconnect(state)
 
     try:
@@ -513,6 +516,146 @@ def do_run(state, args):
     except OSError:
         raise CommandError(f"could not read file '{filename}'")
     _do_execbuffer(state, buf, args.follow)
+
+
+def _parse_program_spec(spec):
+    # "module[:method]", method defaults to "main" as advertised in --help.
+    parts = spec.split(":")
+    if len(parts) > 2 or not parts[0] or not parts[-1]:
+        raise CommandError(f"invalid program {spec!r}: expected 'module[:method]'")
+    module = parts[0]
+    method = parts[1] if len(parts) == 2 else "main"
+    if module.endswith(".py") or "/" in module or "\\" in module:
+        raise CommandError(f"invalid program {spec!r}: expected an import name, not a path")
+    return module, method
+
+
+def _debug_boot_script(module, method, port):
+    # Raw REPL exec has no OS argv, so sys.argv is injected here to preserve
+    # mpy_launch_debugpy.py's own argv contract ([module] [method] [port]).
+    # sys.argv is rebound in place (not reassigned): the `sys` module dict is
+    # read-only on MicroPython, so `sys.argv = [...]` raises AttributeError.
+    # port=None omits the argv element so the device applies its own default
+    # port instead of the host choosing one.
+    script = pkgutil.get_data(__package__, "mpy_launch_debugpy.py").decode()
+    argv = ["mpy_launch_debugpy.py", module, method]
+    if port is not None:
+        argv.append(str(port))
+    preamble = "import sys\nsys.argv[:] = [{}]\n".format(", ".join(repr(a) for a in argv))
+    return preamble + script
+
+
+def _mpdbg_tail(output):
+    # Quote whatever the device printed before it stopped, if anything.
+    text = output.decode(errors="replace").strip()
+    return f"; last output: {text!r}" if text else ""
+
+
+_MPDBG_POLL_S = 0.2  # read_until window; keeps EOF-without-newline detection prompt
+
+
+def _mpdbg_error(transport, rest):
+    # The raw REPL frames output as <stdout> \x04 <exception> \x04>, so the
+    # traceback follows the marker that ends stdout: collect it, since a script
+    # that dies on import prints nothing to stdout and the exception is the
+    # only useful thing to report.
+    eof = b"\x04"
+    deadline = time.monotonic() + 1
+    while eof not in rest and time.monotonic() < deadline:
+        try:
+            rest += transport.read_until(
+                1, eof, timeout=_MPDBG_POLL_S, timeout_overall=_MPDBG_POLL_S
+            )
+        except Exception:
+            break
+    text = rest.partition(eof)[0].decode(errors="replace").strip()
+    return f"; device error: {text}" if text else ""
+
+
+def _read_mpdbg_ready(transport, timeout):
+    # Boot script output is normal print()s until its one handshake line;
+    # echo everything else and stop at the line carrying the JSON payload.
+    # Polled in short windows rather than one read_until(..., timeout=timeout)
+    # call so a device that exits without a trailing newline (raw REPL's
+    # `\x04\x04` with no `\n`) is caught within one poll instead of stalling
+    # for the whole `timeout`.
+    prefix = b"MPDBG-READY "  # single machine-readable line, see mpy_launch_debugpy.py
+    eof = b"\x04"  # raw-REPL end-of-output marker: script exited, nothing more is coming
+    deadline = time.monotonic() + timeout
+    buf = b""
+    last_line = b""
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise CommandError(
+                "timed out waiting for a {!r} line from the device{}".format(
+                    prefix.decode(), _mpdbg_tail(last_line + buf)
+                )
+            )
+        poll = min(remaining, _MPDBG_POLL_S)
+        buf += transport.read_until(1, b"\n", timeout=poll, timeout_overall=poll)
+        if eof in buf:
+            seen, _, rest = buf.partition(eof)
+            raise CommandError(
+                "device exited before printing a {!r} line{}{}".format(
+                    prefix.decode(),
+                    _mpdbg_tail(last_line + seen),
+                    _mpdbg_error(transport, rest),
+                )
+            )
+        if not buf.endswith(b"\n"):
+            continue
+        line, buf = buf, b""
+        if line.startswith(prefix):
+            payload = line[len(prefix) :]
+            try:
+                return json.loads(payload)
+            except json.JSONDecodeError as er:
+                raise CommandError(
+                    f"malformed {prefix.decode()!r} line from the device: {payload!r} ({er})"
+                )
+        stdout_write_bytes(line)
+        last_line = line
+
+
+def do_debug(state, args):
+    module, method = _parse_program_spec(args.program)
+
+    if args.target == "unix":
+        raise CommandError("target 'unix' is not supported yet")
+    if args.target == "list":
+        raise CommandError("target 'list' is not a debuggable device")
+    if args.dap_log:
+        raise CommandError("--dap-log is not implemented yet")
+    # Both checked here rather than after a full raw-REPL round trip.
+    if args.port == 0:
+        raise CommandError(
+            "--port 0 is rejected: it asks the system to choose, which the "
+            "device can only report back through getsockname(), and no port "
+            "in this tree binds it"
+        )
+    if args.port is not None and not 1 <= args.port <= 65535:
+        raise CommandError(f"--port must be between 1 and 65535, got {args.port}")
+
+    if state.transport is None or state.transport.device_name != args.target:
+        do_connect(state, device=args.target)
+    state.ensure_raw_repl()
+    state.did_action()
+
+    try:
+        state.transport.exec_raw_no_follow(_debug_boot_script(module, method, args.port))
+        print("waiting for the device to report its debug-server endpoint...", flush=True)
+        handshake = _read_mpdbg_ready(state.transport, timeout=args.timeout)
+    except TransportError as er:
+        raise CommandError(er.args[0])
+    except KeyboardInterrupt:
+        sys.exit(1)
+
+    try:
+        print("debug server listening on {}:{}".format(handshake["host"], handshake["port"]))
+        print("capabilities:", handshake["caps"])
+    except KeyError as er:
+        raise CommandError(f"malformed handshake payload from the device, missing key {er}")
 
 
 def do_mount(state, args):

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -1,5 +1,6 @@
 import binascii
 import codecs
+import contextlib
 import errno
 import hashlib
 import json
@@ -11,6 +12,7 @@ import socket
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import zlib
 
@@ -93,10 +95,12 @@ def do_disconnect(state, _args=None):
             state.transport.umount_local()
         if state.transport.in_raw_repl:
             state.transport.exit_raw_repl()
-    except OSError:
-        # Ignore any OSError exceptions when shutting down, eg:
+    except (OSError, TransportError):
+        # Ignore these when shutting down, eg:
         # - filesystem_command will close the connection if it had an error
         # - umounting will fail if serial port disappeared
+        # - a mount whose device stopped responding raises TransportError,
+        #   not OSError, out of enter_raw_repl/umount_local above
         pass
     state.transport.close()
     state.transport = None
@@ -539,7 +543,7 @@ def _parse_program_spec(spec):
     return module, method
 
 
-def _debug_boot_script(module, method, port, dap_stream=None):
+def _debug_boot_script(module, method, port, dap_stream=None, mount_point=None):
     # Raw REPL exec has no OS argv, so sys.argv is injected here to preserve
     # mpy_launch_debugpy.py's own argv contract ([module] [method] [port]
     # [dap_stream]).
@@ -559,10 +563,45 @@ def _debug_boot_script(module, method, port, dap_stream=None):
     if dap_stream is not None:
         argv.append(dap_stream)
     preamble = "import sys\nsys.argv[:] = [{}]\n".format(", ".join(repr(a) for a in argv))
+    if mount_point is not None:
+        # The fs hook os.chdir()s into the mount point, so plain __import__
+        # would already find the target module there via sys.path's default
+        # '' (cwd) entry - but that entry also makes the import machinery
+        # record every such module's filename relative to cwd (e.g.
+        # "app.py"), not rooted at the mount point ("/remote/app.py"). The
+        # generated pathMappings translate absolute device paths back to the
+        # host source tree; a relative one matches no mapping, so no
+        # breakpoint ever binds under a mount. Removing '' and mounting the
+        # search path at the mount point explicitly makes every filename the
+        # import machinery records absolute, which is what the mapping was
+        # built to translate.
+        preamble += "while '' in sys.path: sys.path.remove('')\nsys.path.insert(0, {!r})\n".format(
+            mount_point
+        )
     return preamble + script
 
 
 _POLL_S = 0.2  # read_until() poll cadence for both the handshake scan and the error drain below
+_MOUNT_TEARDOWN_TIMEOUT_S = 10  # bounds each of the two round trips in _teardown_mount
+
+
+def _one_line(value):
+    """`value` reduced to one line, for interpolating into a one-line warning.
+
+    A device-side error arrives as a whole traceback: several lines of frames
+    followed by the line that names the exception. The warnings below are one
+    line each and are read as one line, so only that last line is kept - a
+    multi-line interpolation turns a warning into a wall of text whose first
+    line, the one a reader actually sees, says nothing but "Traceback (most
+    recent call last):". `value` is an exception, or the raw `error_output`
+    that a `TransportExecError` carries.
+    """
+    if isinstance(value, (bytes, bytearray)):
+        text = value.decode(errors="replace")
+    else:
+        text = str(value)
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return lines[-1] if lines else ""
 
 
 def _mpdbg_error(transport, rest):
@@ -602,7 +641,13 @@ def _read_mpdbg_ready(
 
     def read_chunk():
         poll = max(0.0, min(_POLL_S, deadline - time.monotonic()))
-        chunk = transport.read_until(1, b"\n", timeout=poll, timeout_overall=poll)
+        # timeout_overall_strict: the docstring's "can't overshoot it by a full
+        # poll window" only holds if a single call can't itself run long past
+        # `poll` - which read_until's default (non-strict) timeout_overall
+        # allows for as long as the boot script keeps printing without a gap.
+        chunk = transport.read_until(
+            1, b"\n", timeout=poll, timeout_overall=poll, timeout_overall_strict=True
+        )
         raw.extend(chunk)
         return decoder.decode(chunk)
 
@@ -635,7 +680,7 @@ def _check_requires(resolved, caps):
             )
 
 
-def _report_debug_result(handshake):
+def _report_debug_result(handshake, path_mappings=None):
     # flush=True: a caller reading this over a pipe (s7.1's extension, a test
     # harness) must see it as soon as it's printed, not whenever Python's
     # block-buffering (the default for a non-tty stdout) next drains.
@@ -645,11 +690,17 @@ def _report_debug_result(handshake):
     # The device's own MPDBG-READY line (raw bind address, possibly a
     # wildcard) is consumed by the handshake parser and never echoed; re-emit
     # it with the resolved host as the one line a tool watching this
-    # process's stdout (e.g. s7.1's extension) can parse.
-    print(
-        mpdebug_handshake.PREFIX + json.dumps({"host": host, "port": port, "caps": caps}),
-        flush=True,
-    )
+    # process's stdout (e.g. s7.1's extension) can parse. path_mappings is
+    # this host's own knowledge of how remote paths map to local ones (a
+    # unix target's identity mapping, or a mount's source root); the device
+    # never reports it and never sees it. Omitted when there is no mapping
+    # to report (a device-resident target with nothing mounted), rather than
+    # sent as an empty list, so an older extension's "key absent" fallback
+    # keeps working unchanged.
+    payload = {"host": host, "port": port, "caps": caps}
+    if path_mappings:
+        payload["pathMappings"] = path_mappings
+    print(mpdebug_handshake.PREFIX + json.dumps(payload), flush=True)
     return handshake
 
 
@@ -745,13 +796,54 @@ def _serial_dap_lost(device, cause):
     ) from cause
 
 
-def _stay_attached(proxy, message):
+@contextlib.contextmanager
+def _exit_on_signal(exit_code=1):
+    """Make SIGTERM/SIGHUP (where the platform has one) exit like Ctrl-C.
+
+    Shared by every blocking "stay attached" wait below, so a supervisor's
+    kill - not just an interactive Ctrl-C - still unwinds through the
+    caller's own exception handling and `finally` cleanup instead of a bare
+    process kill that skips it. SIGHUP has no Windows equivalent, hence the
+    `hasattr` guard.
+
+    `exit_code` is 1 by default: for a wait that watches a live client
+    session (a `serial_dap` bridge, a `--dap-log` proxy), a signal cutting it
+    off early is an interruption, not the session's own natural end. A wait
+    with nothing of the kind to watch - `_stay_attached_mount` - passes 0
+    instead, since a signal is the *only* way it ever returns.
+    """
+    reaping_signals = [signal.SIGTERM]
+    if hasattr(signal, "SIGHUP"):
+        reaping_signals.append(signal.SIGHUP)
+    old_handlers = {}
+    for sig in reaping_signals:
+        try:
+            old_handlers[sig] = signal.signal(sig, lambda *_a: sys.exit(exit_code))
+        except ValueError:
+            pass  # not called from the main thread
+    try:
+        yield
+    finally:
+        for sig, old in old_handlers.items():
+            signal.signal(sig, old)
+
+
+def _stay_attached(proxy, message, pump_failed=None):
     """Block until `proxy`'s one client session ends, reaping it on every exit path.
 
     Shared by `--dap-log`'s own proxy and a `serial_dap` bridge - both are a
     `dap_log.PumpingProxy` mpremote must stay alive for, since unlike the
     plain network path nothing else keeps the client's real endpoint
     listening once this process exits.
+
+    `pump_failed`, when this session also has a mount, is a second thing
+    this waits on besides the proxy: the mount's filesystem RPC rides the
+    board's primary REPL connection, an entirely different one from
+    whichever tty or socket `proxy` watches, so a mount pump dying does not
+    reach the proxy at all. Once it is set, the device is wedged (see
+    mount_local's docstring) independently of whatever the proxy itself
+    still reports, so this stops waiting on the proxy's own end-of-session
+    signal.
     """
     print(message, flush=True)
 
@@ -766,21 +858,11 @@ def _stay_attached(proxy, message):
             if old_handler is not None:
                 signal.signal(signal.SIGINT, old_handler)
 
-    # Same reap-on-every-exit-path ladder as _do_debug_unix's child, applied
-    # to the proxy instead of a subprocess.
-    _reaping_signals = [signal.SIGTERM]
-    if hasattr(signal, "SIGHUP"):
-        _reaping_signals.append(signal.SIGHUP)
-    old_handlers = {}
-    for _sig in _reaping_signals:
-        try:
-            old_handlers[_sig] = signal.signal(_sig, lambda *_a: sys.exit(1))
-        except ValueError:
-            pass  # not called from the main thread
-    try:
+    with _exit_on_signal():
         try:
             while not proxy.wait(_POLL_S):
-                pass
+                if pump_failed is not None and pump_failed.is_set():
+                    break
         except KeyboardInterrupt:
             cleanup()
             sys.exit(1)
@@ -788,9 +870,161 @@ def _stay_attached(proxy, message):
             cleanup()
             raise
         cleanup()
+
+
+def _stay_attached_mount(message, pump_failed=None):
+    """Block until Ctrl-C or a reaping signal, for a mount with no proxy to watch.
+
+    A mounted session with neither a `serial_dap` bridge nor a `--dap-log`
+    proxy has no client-facing object of its own whose end marks the debug
+    session as over - the DAP client talks straight to the device's TCP
+    endpoint - so this just waits to be interrupted. The `_pump_mount`
+    thread started alongside it is what actually keeps the mount's
+    filesystem RPC serviced while this blocks; `pump_failed` is that
+    thread's own signal that it stopped for a reason other than this
+    function's normal teardown, so a wedged device (see mount_local's
+    docstring) ends this wait instead of leaving it stuck until a user
+    notices and reaches for Ctrl-C themselves.
+
+    Ending this wait is always the normal, expected way a mounted
+    plain-network session finishes - there is no client-session end for
+    mpremote to observe instead, unlike `_stay_attached`'s proxy wait - so
+    both Ctrl-C and a reaping signal return normally (exit 0) rather than
+    treating the interruption as a fault. A `pump_failed` end is different:
+    it is reported by `_pump_mount` itself before this returns, so nothing
+    further is printed here.
+    """
+    print(message, flush=True)
+    with _exit_on_signal(exit_code=0):
+        try:
+            while True:
+                if pump_failed is not None and pump_failed.is_set():
+                    return
+                time.sleep(_POLL_S)
+        except KeyboardInterrupt:
+            return
+
+
+def _pump_mount(transport, stop_event, failed_event):
+    """Background thread: keep a mounted transport's filesystem RPC serviced.
+
+    `SerialIntercept.read` (installed on `transport.serial` by `mount_local`)
+    answers `\\x18`-prefixed filesystem RPC from any read of the wrapped
+    serial object, but nothing else reads this particular connection once
+    the boot script is running - the DAP traffic the client drives rides a
+    separate TCP endpoint or `dap_device` tty. Without something to keep
+    calling read on it, an RPC request the device makes on its next
+    filesystem access would sit unanswered and the device would block on it
+    indefinitely. Ordinary console bytes collected between RPC commands are
+    discarded, matching every other "stay attached" path here: none of them
+    surface the primary connection's console output while attached.
+
+    A read raising while `stop_event` is not set means the device stopped
+    answering an RPC command mid-exchange, not that the caller asked this
+    thread to stop - unrecoverable, per mount_local's docstring, since a
+    half-answered filesystem RPC leaves the device with no way back to a
+    prompt on its own. `failed_event` reports that to whichever "stay
+    attached" wait is running alongside this thread, so it stops waiting on
+    a session that is already over in every way that matters; a plain
+    return with nothing set is only reached when `stop_event` itself asked
+    for it.
+    """
+    while not stop_event.is_set():
+        try:
+            # timeout_overall_strict: a single filesystem RPC command can
+            # stream bytes continuously for close to a whole _POLL_S window
+            # (a large file read), and this loop's only cadence for noticing
+            # stop_event is between read_until calls - non-strict semantics
+            # would let such a command's read_until run well past _POLL_S
+            # before this loop gets another chance to check.
+            transport.read_until(
+                1, b"\x04", timeout=_POLL_S, timeout_overall=_POLL_S, timeout_overall_strict=True
+            )
+        except Exception as er:
+            if not stop_event.is_set():
+                print(
+                    f"warning: the mount's filesystem RPC for "
+                    f"{transport.device_name!r} stopped unexpectedly "
+                    f"({_one_line(er)}); only a power cycle clears it",
+                    file=sys.stderr,
+                )
+                failed_event.set()
+            return
+
+
+def _teardown_mount(transport):
+    """Best-effort unmount at session end, when the device may still be mid-program.
+
+    `do_debug` reaches this after a normal return, an exception, or a
+    signal - none of which puts the device back at a raw-REPL prompt on its
+    own, since the debugged program was started with `exec_raw_no_follow`
+    and was never expected to return one. The interrupt below runs
+    unconditionally rather than being guarded by `transport.in_raw_repl`:
+    that flag only records mpremote's own last requested mode switch, not
+    the device's live state, and stays stale-True for as long as the
+    debugged program keeps running after `exec_raw_no_follow` started it -
+    a guard on it would skip the interrupt in exactly the case it exists to
+    handle. Both calls are bounded by `_MOUNT_TEARDOWN_TIMEOUT_S`, strictly -
+    read_until's default leniency (a peer that keeps producing bytes is never
+    cut off) is right for an interactive `mpremote` session but wrong here,
+    since the debugged program `exec_raw_no_follow` started may still be
+    printing when teardown begins - so a device that never responds, or one
+    that responds by talking forever, both fail this function within a fixed
+    time instead of hanging it indefinitely.
+
+    `mounted` is cleared and the transport's serial object unwrapped back
+    to the raw port in every case, success or failure, so a caller's own
+    later teardown (`do_disconnect`) never repeats a doomed umount against
+    a device already known not to be responding.
+
+    Nothing here is allowed to propagate silently: a mount that survives
+    teardown leaves the device in the state `mount_local`'s docstring
+    warns about - blocked in a filesystem RPC with no software recovery -
+    and the user has to be told that in terms they can act on, not left to
+    discover it from an unrelated "could not enter raw repl" on their next
+    command. `KeyboardInterrupt`/`SystemExit` (a second Ctrl-C, or a signal
+    landing mid-teardown) are reported the same way and then re-raised, so
+    an impatient second interrupt still ends the process instead of being
+    swallowed here.
+
+    The two failures are told apart rather than reported alike, because they
+    call for opposite things from the user. `TransportExecError` is the
+    device answering: it took the statement and handed back an error from
+    running it, which proves the raw REPL is alive and makes "only a power
+    cycle clears it" false. Anything else - a timeout, a transport-level
+    error - is a device that did not answer within
+    `_MOUNT_TEARDOWN_TIMEOUT_S`, which is the case that really does need
+    the power cord.
+    """
+    try:
+        transport.enter_raw_repl(
+            soft_reset=False,
+            timeout_overall=_MOUNT_TEARDOWN_TIMEOUT_S,
+            timeout_overall_strict=True,
+        )
+        transport.umount_local(
+            timeout_overall=_MOUNT_TEARDOWN_TIMEOUT_S, timeout_overall_strict=True
+        )
+    except TransportExecError as er:
+        print(
+            f"warning: unmounting {transport.fs_hook_mount} on "
+            f"{transport.device_name!r} reported: {_one_line(er.error_output)}; the "
+            "device is still answering, so reconnect and umount by hand if a mount "
+            "was left behind",
+            file=sys.stderr,
+        )
+    except BaseException as er:
+        print(
+            f"warning: could not unmount {transport.device_name!r} cleanly "
+            f"({_one_line(er)}); the device may no longer respond to anything - "
+            "only a power cycle clears it",
+            file=sys.stderr,
+        )
+        if isinstance(er, (KeyboardInterrupt, SystemExit)):
+            raise
     finally:
-        for _sig, _old in old_handlers.items():
-            signal.signal(_sig, _old)
+        transport.mounted = False
+        transport.serial = getattr(transport.serial, "orig_serial", transport.serial)
 
 
 def _dap_log_ports(port, dap_log_arg):
@@ -1048,7 +1282,11 @@ def _do_debug_unix(resolved, module, method, port, timeout, dap_log_arg, dap_log
                 proxy, reported = _start_dap_log(dap_log_arg, handshake, dap_log_bind_port)
             else:
                 reported = handshake
-            _report_debug_result(reported)
+            # The child was spawned with no cwd= override, so it imports the
+            # program from the same directory mpremote itself is running in:
+            # local and remote are one and the same absolute path.
+            cwd = os.getcwd()
+            _report_debug_result(reported, [{"localRoot": cwd, "remoteRoot": cwd}])
 
             # Unlike the serial/network paths, where the firmware runs
             # independently of the host tool, mpremote owns this child: stay
@@ -1089,6 +1327,18 @@ def _do_debug_unix(resolved, module, method, port, timeout, dap_log_arg, dap_log
             signal.signal(_sig, _old)
 
 
+def _module_source_path(source_root, module):
+    """The two paths `module` (a dotted module name) could resolve to under `source_root`.
+
+    Mirrors Python's own module/package resolution: a leaf module lives at
+    `<source_root>/a/b/c.py`, a package at `<source_root>/a/b/c/__init__.py`.
+    Returns both candidates so a caller that finds neither can name exactly
+    what it looked for.
+    """
+    base = os.path.join(source_root, *module.split("."))
+    return base + ".py", os.path.join(base, "__init__.py")
+
+
 def do_debug(state, args):
     resolved = resolve_target(args.target)
 
@@ -1116,6 +1366,44 @@ def do_debug(state, args):
     device_port, dap_log_bind_port = _dap_log_ports(args.port, dap_log_arg)
 
     is_unix = resolved.kind == "unix" if resolved is not None else args.target == "unix"
+
+    # --source on the command line overrides a target's configured 'source';
+    # neither one given means the program's module already lives on the
+    # device's own filesystem (the hardware-in-the-loop targets that run
+    # /flash/target.py want exactly this), so nothing gets mounted below. A
+    # target's own 'source' has already been resolved to an absolute path by
+    # mpdebug.toml loading; a literal --source has not, so it gets the same
+    # treatment here.
+    if args.source is not None:
+        if is_unix:
+            raise CommandError(
+                "--source is not valid for a unix target: it already runs the "
+                "program straight from the host filesystem, there is nothing to mount"
+            )
+        source_root = os.path.realpath(args.source)
+    else:
+        source_root = resolved.source if resolved is not None else None
+
+    # Both checks below depend only on host state - the source root and the
+    # module name - so they run before the device is touched at all: a
+    # target whose module can't possibly resolve, or whose configured source
+    # has gone missing since mpdebug.toml was loaded, fails here rather than
+    # after connecting and putting the device in the raw REPL for nothing.
+    if source_root is not None:
+        if not os.path.isdir(source_root):
+            origin = (
+                f"--source {args.source!r}"
+                if args.source is not None
+                else f"target {resolved.name!r} source {source_root!r}"
+            )
+            raise CommandError(f"{origin} is not a directory")
+        module_path, package_path = _module_source_path(source_root, module)
+        if not os.path.isfile(module_path) and not os.path.isfile(package_path):
+            raise CommandError(
+                f"module {module!r} does not resolve under source root "
+                f"{source_root!r} (looked for {module_path!r} and {package_path!r})"
+            )
+
     if is_unix:
         state.did_action()
         # Reports the endpoint and supervises the child itself (unlike the
@@ -1154,52 +1442,188 @@ def do_debug(state, args):
     # below waits on a stream that never carries anything.
     dap_stream = "board" if (resolved is not None and resolved.dap_device) else None
 
-    try:
-        state.transport.exec_raw_no_follow(
-            _debug_boot_script(module, method, device_port, dap_stream)
-        )
-        print("waiting for the device to report its debug-server endpoint...", flush=True)
-        # A pty peer is a local process by construction (a unix build or QEMU
-        # behind a pty pair), so a wildcard bind on it is reachable at the
-        # loopback address. Anything else gets no known_host: a
-        # socket://host:port or rfc2217://host:port host may be the device
-        # itself (esp-link and similar) or a bridge in front of it (ser2net),
-        # and guessing wrong points the client at the wrong machine.
-        known_host = "127.0.0.1" if getattr(state.transport, "is_pty", False) else None
-        handshake = _read_mpdbg_ready(state.transport, timeout=args.timeout, known_host=known_host)
-    except TransportError as er:
-        raise CommandError(er.args[0])
-    except KeyboardInterrupt:
-        sys.exit(1)
+    # Everything from here on that touches a mounted device - establishing
+    # it, running the boot script, staying attached, tearing it down - has
+    # to unwind through this function's own `finally` rather than a bare
+    # process kill: an aborted mount, or a signal landing mid-teardown,
+    # leaves `/remote` mounted with the REPL desynced, which only a power
+    # cycle clears (see mount_local's docstring). The guard is requested
+    # from `source_root` alone, not whether the mount actually succeeds, so
+    # it is already active for the `mount_local` call itself. An unmounted
+    # run has nothing of the kind to protect, so it keeps the narrower,
+    # pre-existing behaviour of only the "stay attached" calls below being
+    # signal-safe on their own.
+    signal_guard = _exit_on_signal() if source_root is not None else contextlib.nullcontext()
+    mounted = False
+    pump_stop = pump_thread = pump_failed = None
+    with signal_guard:
+        try:
+            if source_root is not None:
+                try:
+                    state.transport.mount_local(source_root)
+                    mounted = True
+                except (KeyboardInterrupt, SystemExit):
+                    # Control-flow signals, not a mount failure to report as
+                    # one: propagate as themselves so the outer finally's
+                    # teardown and main()'s own top-level handling see the
+                    # interruption they actually are, the same as every
+                    # other raw-REPL round trip in this function.
+                    raise
+                except BaseException as er:
+                    raise CommandError(
+                        f"mounting {source_root!r} failed ({er}); if the device no "
+                        "longer responds to anything, only a power cycle clears it"
+                    ) from er
 
-    _check_requires(resolved, handshake["caps"])
+            try:
+                state.transport.exec_raw_no_follow(
+                    _debug_boot_script(
+                        module,
+                        method,
+                        device_port,
+                        dap_stream,
+                        mount_point=SerialTransport.fs_hook_mount if mounted else None,
+                    )
+                )
+                print("waiting for the device to report its debug-server endpoint...", flush=True)
+                # A pty peer is a local process by construction (a unix build
+                # or QEMU behind a pty pair), so a wildcard bind on it is
+                # reachable at the loopback address. Anything else gets no
+                # known_host: a socket://host:port or rfc2217://host:port
+                # host may be the device itself (esp-link and similar) or a
+                # bridge in front of it (ser2net), and guessing wrong points
+                # the client at the wrong machine.
+                known_host = "127.0.0.1" if getattr(state.transport, "is_pty", False) else None
+                handshake = _read_mpdbg_ready(
+                    state.transport, timeout=args.timeout, known_host=known_host
+                )
+            except TransportError as er:
+                msg = er.args[0]
+                if mounted:
+                    msg += "; if the device no longer responds, only a power cycle clears it"
+                raise CommandError(msg)
+            except KeyboardInterrupt:
+                sys.exit(1)
 
-    # A dap_device target puts the whole DAP channel through mpremote (there
-    # is no device-side TCP endpoint to report at all), so this always stays
-    # attached, with or without --dap-log; the plain network path below only
-    # does that when --dap-log adds its own proxy in front of the device.
-    serial_bind_port = dap_log_bind_port if dap_log_arg else (args.port or 0)
-    serial_bridge = _maybe_start_serial_dap(resolved, handshake, dap_log_arg, serial_bind_port)
-    if serial_bridge is not None:
-        proxy, reported = serial_bridge
-        _report_debug_result(reported)
-        _stay_attached(proxy, "staying attached to run the serial DAP bridge; Ctrl-C ends it")
-        if proxy.target_error is not None:
-            _serial_dap_lost(resolved.dap_device, proxy.target_error)
-        return reported
+            _check_requires(resolved, handshake["caps"])
 
-    if not dap_log_arg:
-        return _report_debug_result(handshake)
+            # The host's own knowledge of how the remote path maps to a local
+            # one - the device never reports this, since it has no notion of
+            # the host filesystem at all.
+            path_mappings = (
+                [{"localRoot": source_root, "remoteRoot": SerialTransport.fs_hook_mount}]
+                if mounted
+                else None
+            )
 
-    # Unlike the plain report-and-return above: the device runs independently
-    # of mpremote on this path, but the proxy --dap-log inserts does not, so
-    # returning now would tear down the very thing the client is about to
-    # connect to. Stay attached until the one client session it serves ends,
-    # or the user/environment ends it first.
-    proxy, reported = _start_dap_log(dap_log_arg, handshake, dap_log_bind_port)
-    _report_debug_result(reported)
-    _stay_attached(proxy, "staying attached to run the --dap-log proxy; Ctrl-C ends it")
-    return reported
+            if mounted:
+                # Nothing else reads state.transport once the boot script is
+                # running - the client's DAP traffic rides a separate TCP
+                # endpoint or dap_device tty - so a background thread has to
+                # pump it for as long as this function stays attached below,
+                # whichever of the three shapes that takes. `pump_failed` is
+                # set by the thread itself if it ever stops for a reason
+                # other than the `pump_stop` this function requests, so the
+                # "stay attached" call below can tell an unrecoverably wedged
+                # device (see mount_local's docstring) apart from a normal
+                # end of session and stop waiting on it.
+                pump_stop = threading.Event()
+                pump_failed = threading.Event()
+                pump_thread = threading.Thread(
+                    target=_pump_mount,
+                    args=(state.transport, pump_stop, pump_failed),
+                    daemon=True,
+                )
+                pump_thread.start()
+
+            # A dap_device target puts the whole DAP channel through mpremote
+            # (there is no device-side TCP endpoint to report at all), so
+            # this always stays attached, with or without --dap-log; the
+            # plain network path below only does that when --dap-log adds
+            # its own proxy in front of the device, or when a mount needs
+            # pumping.
+            serial_bind_port = dap_log_bind_port if dap_log_arg else (args.port or 0)
+            serial_bridge = _maybe_start_serial_dap(
+                resolved, handshake, dap_log_arg, serial_bind_port
+            )
+            if serial_bridge is not None:
+                proxy, reported = serial_bridge
+                _report_debug_result(reported, path_mappings)
+                _stay_attached(
+                    proxy,
+                    "staying attached to run the serial DAP bridge; Ctrl-C ends it",
+                    pump_failed=pump_failed,
+                )
+                if proxy.target_error is not None:
+                    _serial_dap_lost(resolved.dap_device, proxy.target_error)
+                return reported
+
+            if not dap_log_arg:
+                _report_debug_result(handshake, path_mappings)
+                if mounted:
+                    _stay_attached_mount(
+                        "staying attached to service the mounted filesystem; Ctrl-C ends it",
+                        pump_failed=pump_failed,
+                    )
+                return handshake
+
+            # Unlike the plain report-and-return above: the device runs
+            # independently of mpremote on this path, but the proxy
+            # --dap-log inserts does not, so returning now would tear down
+            # the very thing the client is about to connect to. Stay
+            # attached until the one client session it serves ends, or the
+            # user/environment ends it first.
+            proxy, reported = _start_dap_log(dap_log_arg, handshake, dap_log_bind_port)
+            _report_debug_result(reported, path_mappings)
+            _stay_attached(
+                proxy,
+                "staying attached to run the --dap-log proxy; Ctrl-C ends it",
+                pump_failed=pump_failed,
+            )
+            return reported
+        finally:
+            if pump_stop is not None:
+                pump_stop.set()
+            pump_alive = False
+            if pump_thread is not None:
+                pump_thread.join(timeout=2)
+                pump_alive = pump_thread.is_alive()
+            # getattr, not the local `mounted` flag: a `mount_local` that
+            # raised after already setting the transport's own flag (a
+            # signal landing in its narrow window between marking itself
+            # mounted and finishing setup) still needs tearing down, even
+            # though the `except` above turned that into a CommandError
+            # before `mounted` was ever set here. This runs inside
+            # `signal_guard`, not after it, so a signal landing mid-teardown
+            # is still caught by the custom handler rather than killing
+            # mpremote with the device left mounted and desynced.
+            if getattr(state.transport, "mounted", False):
+                if pump_alive:
+                    # The pump thread still owns the port: calling umount_local
+                    # now would give it a second, concurrent reader. Leaving the
+                    # mount up is the safer of two bad outcomes, since a stuck
+                    # pump means the port is already in a state only a power
+                    # cycle reliably clears. `mounted` is still cleared, though
+                    # (the port itself is left alone) - otherwise
+                    # `do_disconnect`'s own unmount attempt at process exit
+                    # would give the still-running pump a second reader too.
+                    state.transport.mounted = False
+                    print(
+                        f"warning: the mount's filesystem pump for "
+                        f"{state.transport.device_name!r} did not stop in time; leaving "
+                        f"{state.transport.fs_hook_mount} mounted rather than risk a "
+                        "second reader on the port - a power cycle is what clears it",
+                        file=sys.stderr,
+                    )
+                elif pump_failed is not None and pump_failed.is_set():
+                    # _pump_mount already reported this on stderr before
+                    # setting the event: the RPC channel that a clean
+                    # umount needs is exactly what just died, so retrying
+                    # it here would only wait out _MOUNT_TEARDOWN_TIMEOUT_S
+                    # before failing the same way.
+                    state.transport.mounted = False
+                else:
+                    _teardown_mount(state.transport)
 
 
 def do_mount(state, args):

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -22,6 +22,7 @@ from .romfs import make_romfs, VfsRomWriter
 from .mpdebug_config import find_config, resolve_target, target_hint, warn_if_tty_device
 from . import mpdebug_handshake
 from . import dap_log
+from . import serial_dap
 
 
 class CommandError(Exception):
@@ -666,6 +667,124 @@ def _start_dap_log(dap_log_arg, handshake, bind_port=0):
     return proxy, reported
 
 
+def _maybe_start_serial_dap(resolved, handshake, dap_log_arg, bind_port):
+    """Start the localhost<->serial bridge for a `serial_dap`-capable target.
+
+    None (no bridging - the plain network/handshake path applies) unless the
+    target configures a `dap_device`; one configured without the probe
+    confirming `serial_dap: true` is a hard error, not a silent fallback -
+    STORY-3.3's rule that a claimed capability is never trusted over the
+    runtime probe applies to the caller's own config too.
+
+    `--dap-log`, if given, logs through this bridge rather than through a
+    second proxy stacked in front of it: unlike the network path, there is
+    no device-side TCP endpoint here for a separate `DapProxy` to forward to
+    and log.
+    """
+    device = resolved.dap_device if resolved is not None else None
+    if device is None:
+        return None
+    warn_if_tty_device(device, f"target {resolved.name!r} dap_device")
+    if not handshake["caps"].get("serial_dap"):
+        raise CommandError(
+            f"target {resolved.name!r} configures dap_device {device!r} but the "
+            f"device does not report serial_dap (probed caps: {handshake['caps']})"
+        )
+    try:
+        serial_dap.check_device(device)
+    except OSError as er:
+        raise CommandError(
+            f"target {resolved.name!r} dap_device {device!r} could not be opened: {er}"
+        ) from None
+    if dap_log_arg:
+        path = dap_log_arg if isinstance(dap_log_arg, str) else dap_log.default_log_path()
+        try:
+            logger = dap_log.DapLogger(path)
+        except OSError as er:
+            raise CommandError(f"--dap-log could not open {path!r}: {er}") from None
+        log_msg = f"logging DAP traffic to {path!r}"
+    else:
+        logger = dap_log.NullLogger()
+        log_msg = None
+    try:
+        proxy = serial_dap.SerialDapBridge(device, logger, bind_port=bind_port)
+    except OSError as er:
+        logger.close()
+        raise CommandError(f"could not bind a DAP bridge port: {er}") from None
+    proxy.start()
+    if log_msg:
+        print(log_msg, flush=True)
+    reported = dict(handshake, host=proxy.host, port=proxy.port)
+    return proxy, reported
+
+
+def _serial_dap_lost(device, cause):
+    """Raise for a dead serial DAP bridge.
+
+    A board reset always ends the session with this error rather than
+    reconnecting. The rebooted device runs a fresh `debugpy` with no memory
+    of the session the client still believes it is in - no breakpoints, no
+    frames, no sequence numbers - so a revived byte pump would hand the
+    client a peer that never received its `initialize`. Ending and saying so
+    is the only answer that leaves the two ends agreeing about what exists;
+    the next `mpremote debug` builds both from scratch. (ampremote's
+    `do_reconnect(state)`, present when this file is composed onto its tree
+    per STORY-8.1, restores only the primary REPL connection in any case.)
+    """
+    raise CommandError(
+        f"the serial DAP connection to {device!r} was lost (board reset?); "
+        "reset the device and run 'mpremote debug' again"
+    ) from cause
+
+
+def _stay_attached(proxy, message):
+    """Block until `proxy`'s one client session ends, reaping it on every exit path.
+
+    Shared by `--dap-log`'s own proxy and a `serial_dap` bridge - both are a
+    `dap_log.PumpingProxy` mpremote must stay alive for, since unlike the
+    plain network path nothing else keeps the client's real endpoint
+    listening once this process exits.
+    """
+    print(message, flush=True)
+
+    def cleanup():
+        try:
+            old_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
+        except ValueError:
+            old_handler = None  # not called from the main thread
+        try:
+            proxy.close()
+        finally:
+            if old_handler is not None:
+                signal.signal(signal.SIGINT, old_handler)
+
+    # Same reap-on-every-exit-path ladder as _do_debug_unix's child, applied
+    # to the proxy instead of a subprocess.
+    _reaping_signals = [signal.SIGTERM]
+    if hasattr(signal, "SIGHUP"):
+        _reaping_signals.append(signal.SIGHUP)
+    old_handlers = {}
+    for _sig in _reaping_signals:
+        try:
+            old_handlers[_sig] = signal.signal(_sig, lambda *_a: sys.exit(1))
+        except ValueError:
+            pass  # not called from the main thread
+    try:
+        try:
+            while not proxy.wait(_POLL_S):
+                pass
+        except KeyboardInterrupt:
+            cleanup()
+            sys.exit(1)
+        except BaseException:
+            cleanup()
+            raise
+        cleanup()
+    finally:
+        for _sig, _old in old_handlers.items():
+            signal.signal(_sig, _old)
+
+
 def _dap_log_ports(port, dap_log_arg):
     """Split a single `--port` between the device and the `--dap-log` proxy.
 
@@ -1036,6 +1155,20 @@ def do_debug(state, args):
 
     _check_requires(resolved, handshake["caps"])
 
+    # A dap_device target puts the whole DAP channel through mpremote (there
+    # is no device-side TCP endpoint to report at all), so this always stays
+    # attached, with or without --dap-log; the plain network path below only
+    # does that when --dap-log adds its own proxy in front of the device.
+    serial_bind_port = dap_log_bind_port if dap_log_arg else (args.port or 0)
+    serial_bridge = _maybe_start_serial_dap(resolved, handshake, dap_log_arg, serial_bind_port)
+    if serial_bridge is not None:
+        proxy, reported = serial_bridge
+        _report_debug_result(reported)
+        _stay_attached(proxy, "staying attached to run the serial DAP bridge; Ctrl-C ends it")
+        if proxy.target_error is not None:
+            _serial_dap_lost(resolved.dap_device, proxy.target_error)
+        return reported
+
     if not dap_log_arg:
         return _report_debug_result(handshake)
 
@@ -1046,45 +1179,8 @@ def do_debug(state, args):
     # or the user/environment ends it first.
     proxy, reported = _start_dap_log(dap_log_arg, handshake, dap_log_bind_port)
     _report_debug_result(reported)
-    print("staying attached to run the --dap-log proxy; Ctrl-C ends it", flush=True)
-
-    def cleanup():
-        try:
-            old_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
-        except ValueError:
-            old_handler = None  # not called from the main thread
-        try:
-            proxy.close()
-        finally:
-            if old_handler is not None:
-                signal.signal(signal.SIGINT, old_handler)
-
-    # Same reap-on-every-exit-path ladder as _do_debug_unix's child, applied
-    # to the proxy instead of a subprocess.
-    _reaping_signals = [signal.SIGTERM]
-    if hasattr(signal, "SIGHUP"):
-        _reaping_signals.append(signal.SIGHUP)
-    old_handlers = {}
-    for _sig in _reaping_signals:
-        try:
-            old_handlers[_sig] = signal.signal(_sig, lambda *_a: sys.exit(1))
-        except ValueError:
-            pass  # not called from the main thread
-    try:
-        try:
-            while not proxy.wait(_POLL_S):
-                pass
-        except KeyboardInterrupt:
-            cleanup()
-            sys.exit(1)
-        except BaseException:
-            cleanup()
-            raise
-        cleanup()
-        return reported
-    finally:
-        for _sig, _old in old_handlers.items():
-            signal.signal(_sig, _old)
+    _stay_attached(proxy, "staying attached to run the --dap-log proxy; Ctrl-C ends it")
+    return reported
 
 
 def do_mount(state, args):

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -1,6 +1,5 @@
 import binascii
 import codecs
-import collections
 import contextlib
 import errno
 import hashlib
@@ -942,14 +941,13 @@ def _pump_mount(transport, stop_event, failed_event):
     answers `\\x18`-prefixed filesystem RPC from any read of the wrapped
     serial object, but nothing else reads this particular connection once
     the boot script is running - the DAP traffic the client drives rides a
-    separate TCP endpoint. Without something to keep
-    calling read on it, an RPC request the device makes on its next
-    filesystem access would sit unanswered and the device would block on it
-    indefinitely. Ordinary console bytes collected between RPC commands are
-    discarded rather than printed, unlike `_pump_console`: this loop reads
-    the RPC framing itself, so what is left over is whatever fell between
-    two commands rather than a clean stream of the program's output. Both
-    keep the console emptied, which is what the device needs of them.
+    separate TCP endpoint. Without something to keep calling read on it, an
+    RPC request the device makes on its next filesystem access would sit
+    unanswered and the device would block on it indefinitely. Ordinary console
+    bytes collected between RPC commands are discarded rather than printed:
+    this loop reads the RPC framing itself, so what is left over is whatever
+    fell between two commands rather than a clean stream of the program's
+    output. Emptying the console is what the device needs of it either way.
 
     A read raising while `stop_event` is not set means the device stopped
     answering an RPC command mid-exchange, not that the caller asked this
@@ -1014,24 +1012,28 @@ def _pump_console(transport, stop_event):
     prints has no reason to send, and `stop_event` would not be looked at
     again until they came.
     """
-    buffered = collections.deque()
-    buffered_bytes = [0]
-    dropped = [0]
-    lock = threading.Lock()
+    buffered = bytearray()
+    dropped = 0
+    ready = threading.Condition()
+    decoder = codecs.getincrementaldecoder("utf-8")("replace")
 
     def emit():
         while True:
-            with lock:
-                chunk = buffered.popleft() if buffered else None
-                if chunk is not None:
-                    buffered_bytes[0] -= len(chunk)
-            if chunk is None:
+            with ready:
+                while not buffered and not stop_event.is_set():
+                    ready.wait(_CONSOLE_POLL_S)
+                chunk = bytes(buffered)
+                del buffered[:]
+            if not chunk:
                 if stop_event.is_set():
                     return
-                stop_event.wait(_CONSOLE_POLL_S)
                 continue
             try:
-                sys.stdout.write(chunk.decode("utf-8", "replace"))
+                # Decoded incrementally: a read ends wherever the port had
+                # bytes, so a multi-byte character routinely straddles two of
+                # them and decoding each in isolation would mint replacement
+                # characters at every boundary.
+                sys.stdout.write(decoder.decode(chunk))
                 sys.stdout.flush()
             except Exception:
                 return  # a consumer that closed the pipe, not a device problem
@@ -1048,18 +1050,21 @@ def _pump_console(transport, stop_event):
         if not data:
             stop_event.wait(_CONSOLE_POLL_S)
             continue
-        with lock:
-            buffered.append(data)
-            buffered_bytes[0] += len(data)
-            while buffered_bytes[0] > _CONSOLE_BUFFER_BYTES and len(buffered) > 1:
-                dropped[0] += len(buffered[0])
-                buffered_bytes[0] -= len(buffered.popleft())
+        with ready:
+            buffered += data
+            excess = len(buffered) - _CONSOLE_BUFFER_BYTES
+            if excess > 0:
+                del buffered[:excess]
+                dropped += excess
+            ready.notify()
 
     stop_event.set()
+    with ready:
+        ready.notify()
     writer.join(timeout=1)
-    if dropped[0]:
+    if dropped:
         print(
-            f"warning: dropped {dropped[0]} bytes of the board's console output; "
+            f"warning: dropped {dropped} bytes of the board's console output; "
             "whatever is reading this command's output did not keep up",
             file=sys.stderr,
         )
@@ -1490,16 +1495,13 @@ def do_debug(state, args):
     # --dap-repl on the command line overrides a target's configured
     # 'dap_repl'; either one asks for the DAP channel to share the stream
     # carrying the REPL, which is what a board with one UART and no network
-    # has. A target that also configures a dedicated DAP interface is
-    # rejected at config load, but the flag can reach one, so the same
-    # conflict is refused here rather than one of the two silently winning.
+    # has.
     dap_repl = args.dap_repl or (resolved.dap_repl if resolved is not None else False)
-    if dap_repl:
-        if is_unix:
-            raise CommandError(
-                "--dap-repl is not valid for a unix target: it reaches its debug "
-                "channel over the loopback interface, with no stream to share"
-            )
+    if dap_repl and is_unix:
+        raise CommandError(
+            "--dap-repl is not valid for a unix target: it reaches its debug "
+            "channel over the loopback interface, with no stream to share"
+        )
 
     if args.source is not None:
         if is_unix:
@@ -1527,8 +1529,7 @@ def do_debug(state, args):
             f"{origin} cannot be combined with --dap-repl: mounting and the "
             "REPL-stream DAP channel both frame the same stream, and running "
             "them together would desync it. Put the program on the device's "
-            "own filesystem for this session, or use a target with a network "
-            "or dedicated DAP interface"
+            "own filesystem for this session, or use a target with a network"
         )
 
     # Both checks below depend only on host state - the source root and the

--- a/tools/mpremote/mpremote/dap_log.py
+++ b/tools/mpremote/mpremote/dap_log.py
@@ -1,6 +1,6 @@
 """`--dap-log`: a localhost proxy that records DAP traffic to JSONL.
 
-Neither `debug` transport puts the byte stream through mpremote - the
+Neither TCP `debug` transport puts the byte stream through mpremote - the
 command reports an endpoint and the DAP client connects to the device
 directly. Logging therefore means interposing a proxy: bind an ephemeral
 port, accept the one client connection, connect through to the device's
@@ -8,6 +8,12 @@ real endpoint, and pump both directions while handing each complete frame
 to a `DapLogger`. The caller substitutes the proxy's host/port for the
 device's in whatever it reports, so the client attaches to the logger
 instead of bypassing it.
+
+`PumpingProxy`, the accept/pump/close machinery below `DapProxy`, is generic
+in what it forwards to (`_connect_target()`); `repl_dap.py`'s bridge is the
+other subclass, forwarding to the framed half of the REPL's own stream
+instead of a TCP endpoint - that path *does* always put the byte stream
+through mpremote, since there is no device-side TCP listener to bypass to.
 """
 
 import json
@@ -106,20 +112,38 @@ def default_log_path():
     return "mpremote-dap-{}-{}.jsonl".format(time.strftime("%Y%m%dT%H%M%S"), os.getpid())
 
 
-class DapProxy:
-    """Localhost proxy: one client, forwarded to (target_host, target_port).
+class NullLogger:
+    """A `DapLogger` that discards everything - the no-`--dap-log` case."""
+
+    def log(self, direction, frame):
+        pass
+
+    def close(self):
+        pass
+
+
+class PumpingProxy:
+    """Localhost proxy: one client, forwarded to a target `_connect_target()` opens.
 
     Binds its port immediately (`host`/`port` are set once `__init__`
     returns); the accept and both pump directions run on background threads
     started by `start()`, so construction and reporting the substituted
     endpoint never block on a client actually connecting. `bind_port`
     defaults to 0 (OS-assigned); a caller pinning the client-facing endpoint
-    (`--port` alongside `--dap-log`) passes the requested port instead.
+    passes the requested port instead.
+
+    A subclass supplies `_connect_target()`, called once a client has
+    connected, returning the object the client is bridged to - a
+    `socket.socket` (`DapProxy`, forwarding to another TCP endpoint) or
+    anything else duck-typing `recv`/`sendall`/`shutdown`/`close`
+    (`repl_dap.py`'s duplex over the REPL stream's framed half). The pump
+    code below only ever
+    calls those four methods, on either side, so it never has to know which
+    kind of target it is forwarding to.
     """
 
-    def __init__(self, target_host, target_port, logger, bind_host="127.0.0.1", bind_port=0):
+    def __init__(self, logger, bind_host="127.0.0.1", bind_port=0):
         self.host = bind_host
-        self._target = (target_host, target_port)
         self._logger = logger
         self._listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -131,6 +155,15 @@ class DapProxy:
         self._pumps = []
         self._done = threading.Event()
         self._closed = False
+        # Set when the *target* side (not the client) ends abnormally - an
+        # exception out of `_connect_target()` or out of a read on the
+        # target - as opposed to a clean EOF, which leaves this None. A
+        # caller uses this to tell "session ended" from "target connection
+        # was lost" (e.g. a board reset behind a serial bridge).
+        self.target_error = None
+
+    def _connect_target(self):
+        raise NotImplementedError
 
     def start(self):
         threading.Thread(target=self._accept, name="dap-proxy-accept", daemon=True).start()
@@ -142,8 +175,9 @@ class DapProxy:
             self._done.set()
             return
         try:
-            self._server = socket.create_connection(self._target)
-        except OSError:
+            self._server = self._connect_target()
+        except OSError as er:
+            self.target_error = er
             self._client.close()
             self._done.set()
             return
@@ -161,14 +195,29 @@ class DapProxy:
         self._done.set()
 
     def _pump(self, src, dst, direction):
-        # `direction` names where the frame came from, not where it's going.
+        # `direction` names where the frame came from, not where it's going -
+        # it has nothing to do with which endpoint is `self._server` (the
+        # target), so `target_error` is keyed on endpoint identity (`src is
+        # self._server` / `dst is self._server`), not on `direction`: each
+        # pump thread reads one endpoint and writes the other, so a failure
+        # on either side of either thread can be a target failure.
         parser = FrameParser()
         try:
             while True:
-                chunk = src.recv(4096)
+                try:
+                    chunk = src.recv(4096)
+                except OSError as er:
+                    if src is self._server:
+                        self.target_error = er
+                    break
                 if not chunk:
                     break
-                dst.sendall(chunk)
+                try:
+                    dst.sendall(chunk)
+                except OSError as er:
+                    if dst is self._server:
+                        self.target_error = er
+                    break
                 # Forwarding must survive a logging fault - non-DAP bytes on
                 # the socket (an HTTP probe, console output) or anything else
                 # that trips the parser or writer must not tear down the pump.
@@ -181,8 +230,6 @@ class DapProxy:
                         self._logger.log(direction, frame)
                     except Exception:
                         pass
-        except OSError:
-            pass
         finally:
             # Half-closing only tells the peer we are done writing; if it
             # never closes its own side, the opposite pump stays blocked in
@@ -213,3 +260,14 @@ class DapProxy:
         for t in self._pumps:
             t.join(timeout=2)
         self._logger.close()
+
+
+class DapProxy(PumpingProxy):
+    """`PumpingProxy` forwarding to (target_host, target_port) over TCP."""
+
+    def __init__(self, target_host, target_port, logger, bind_host="127.0.0.1", bind_port=0):
+        super().__init__(logger, bind_host, bind_port)
+        self._target = (target_host, target_port)
+
+    def _connect_target(self):
+        return socket.create_connection(self._target)

--- a/tools/mpremote/mpremote/dap_log.py
+++ b/tools/mpremote/mpremote/dap_log.py
@@ -1,0 +1,215 @@
+"""`--dap-log`: a localhost proxy that records DAP traffic to JSONL.
+
+Neither `debug` transport puts the byte stream through mpremote - the
+command reports an endpoint and the DAP client connects to the device
+directly. Logging therefore means interposing a proxy: bind an ephemeral
+port, accept the one client connection, connect through to the device's
+real endpoint, and pump both directions while handing each complete frame
+to a `DapLogger`. The caller substitutes the proxy's host/port for the
+device's in whatever it reports, so the client attaches to the logger
+instead of bypassing it.
+"""
+
+import json
+import os
+import queue
+import socket
+import threading
+import time
+
+_HEADER_SEP = b"\r\n\r\n"
+
+
+class FrameParser:
+    """Incremental parser for Content-Length-framed DAP messages.
+
+    `feed(chunk)` returns the list of message bodies (JSON bytes, header
+    stripped) completed by that chunk; a header or body split across
+    multiple `feed()` calls is carried in `_buf` until whole, and several
+    frames arriving in one chunk are all returned.
+    """
+
+    def __init__(self):
+        self._buf = b""
+
+    def feed(self, chunk):
+        self._buf += chunk
+        frames = []
+        while True:
+            sep = self._buf.find(_HEADER_SEP)
+            if sep == -1:
+                break
+            header = self._buf[:sep].decode("ascii", errors="replace")
+            length = None
+            for line in header.split("\r\n"):
+                name, _, value = line.partition(":")
+                if name.strip().lower() == "content-length":
+                    try:
+                        length = int(value.strip())
+                    except ValueError:
+                        length = None
+            body_start = sep + len(_HEADER_SEP)
+            if length is None:
+                # No Content-Length, or an unparsable one: drop the header
+                # and resync on the next separator rather than raising -
+                # this parser sits in the data path, not just the log.
+                self._buf = self._buf[body_start:]
+                continue
+            if len(self._buf) < body_start + length:
+                break  # body not fully arrived yet
+            frames.append(self._buf[body_start : body_start + length])
+            self._buf = self._buf[body_start + length :]
+        return frames
+
+
+class DapLogger:
+    """Appends one `{ts, dir, msg}` JSON line per frame, off the pump thread.
+
+    `log()` only ever puts onto a queue; a dedicated writer thread does the
+    file I/O, so a slow disk can't perturb the timing `--dap-log` exists to
+    observe. The file is opened here, in the caller's thread, so a bad path
+    (missing directory, permissions) raises `OSError` to the caller instead
+    of surfacing as an uncaught exception in the writer thread later.
+    """
+
+    def __init__(self, path):
+        self._file = open(path, "a", buffering=1)
+        self._q = queue.Queue()
+        self._thread = threading.Thread(target=self._run, name="dap-log-writer", daemon=True)
+        self._thread.start()
+
+    def log(self, direction, frame):
+        self._q.put((time.time(), direction, frame))
+
+    def _run(self):
+        with self._file:
+            while True:
+                item = self._q.get()
+                if item is None:
+                    break
+                ts, direction, frame = item
+                try:
+                    msg = json.loads(frame.decode("utf-8"))
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    msg = frame.decode("utf-8", errors="replace")
+                self._file.write(json.dumps({"ts": ts, "dir": direction, "msg": msg}) + "\n")
+
+    def close(self):
+        self._q.put(None)
+        self._thread.join(timeout=2)
+
+
+def default_log_path():
+    # Sortable and Windows-filename-safe (no ':'), unlike isoformat(). The
+    # pid disambiguates two sessions started in the same second in the same
+    # cwd, which would otherwise append-interleave into the same file.
+    return "mpremote-dap-{}-{}.jsonl".format(time.strftime("%Y%m%dT%H%M%S"), os.getpid())
+
+
+class DapProxy:
+    """Localhost proxy: one client, forwarded to (target_host, target_port).
+
+    Binds its port immediately (`host`/`port` are set once `__init__`
+    returns); the accept and both pump directions run on background threads
+    started by `start()`, so construction and reporting the substituted
+    endpoint never block on a client actually connecting. `bind_port`
+    defaults to 0 (OS-assigned); a caller pinning the client-facing endpoint
+    (`--port` alongside `--dap-log`) passes the requested port instead.
+    """
+
+    def __init__(self, target_host, target_port, logger, bind_host="127.0.0.1", bind_port=0):
+        self.host = bind_host
+        self._target = (target_host, target_port)
+        self._logger = logger
+        self._listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._listener.bind((bind_host, bind_port))
+        self._listener.listen(1)
+        self.port = self._listener.getsockname()[1]
+        self._client = None
+        self._server = None
+        self._pumps = []
+        self._done = threading.Event()
+        self._closed = False
+
+    def start(self):
+        threading.Thread(target=self._accept, name="dap-proxy-accept", daemon=True).start()
+
+    def _accept(self):
+        try:
+            self._client, _ = self._listener.accept()
+        except OSError:
+            self._done.set()
+            return
+        try:
+            self._server = socket.create_connection(self._target)
+        except OSError:
+            self._client.close()
+            self._done.set()
+            return
+        a = threading.Thread(
+            target=self._pump, args=(self._client, self._server, "client"), name="dap-proxy-c2s"
+        )
+        b = threading.Thread(
+            target=self._pump, args=(self._server, self._client, "device"), name="dap-proxy-s2c"
+        )
+        self._pumps = [a, b]
+        a.start()
+        b.start()
+        a.join()
+        b.join()
+        self._done.set()
+
+    def _pump(self, src, dst, direction):
+        # `direction` names where the frame came from, not where it's going.
+        parser = FrameParser()
+        try:
+            while True:
+                chunk = src.recv(4096)
+                if not chunk:
+                    break
+                dst.sendall(chunk)
+                # Forwarding must survive a logging fault - non-DAP bytes on
+                # the socket (an HTTP probe, console output) or anything else
+                # that trips the parser or writer must not tear down the pump.
+                try:
+                    frames = parser.feed(chunk)
+                except Exception:
+                    frames = []
+                for frame in frames:
+                    try:
+                        self._logger.log(direction, frame)
+                    except Exception:
+                        pass
+        except OSError:
+            pass
+        finally:
+            # Half-closing only tells the peer we are done writing; if it
+            # never closes its own side, the opposite pump stays blocked in
+            # recv() and the session never ends. Shut down BOTH directions so
+            # that pump returns and the proxy can report the session over.
+            for sock in (dst, src):
+                try:
+                    sock.shutdown(socket.SHUT_RDWR)
+                except OSError:
+                    pass
+
+    def wait(self, timeout=None):
+        """Block until the one client session this proxy serves has ended."""
+        return self._done.wait(timeout)
+
+    def close(self):
+        # Idempotent and signal-safe: called from every do_debug exit path,
+        # including a second Ctrl-C landing mid-cleanup.
+        if self._closed:
+            return
+        self._closed = True
+        for sock in (self._listener, self._client, self._server):
+            if sock is not None:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+        for t in self._pumps:
+            t.join(timeout=2)
+        self._logger.close()

--- a/tools/mpremote/mpremote/dap_log.py
+++ b/tools/mpremote/mpremote/dap_log.py
@@ -1,6 +1,6 @@
 """`--dap-log`: a localhost proxy that records DAP traffic to JSONL.
 
-Neither `debug` transport puts the byte stream through mpremote - the
+Neither TCP `debug` transport puts the byte stream through mpremote - the
 command reports an endpoint and the DAP client connects to the device
 directly. Logging therefore means interposing a proxy: bind an ephemeral
 port, accept the one client connection, connect through to the device's
@@ -8,6 +8,12 @@ real endpoint, and pump both directions while handing each complete frame
 to a `DapLogger`. The caller substitutes the proxy's host/port for the
 device's in whatever it reports, so the client attaches to the logger
 instead of bypassing it.
+
+`PumpingProxy`, the accept/pump/close machinery below `DapProxy`, is generic
+in what it forwards to (`_connect_target()`); `serial_dap.py`'s
+`SerialDapBridge` is the other subclass, forwarding to a serial device
+instead of a TCP endpoint - that path *does* always put the byte stream
+through mpremote, since there is no device-side TCP listener to bypass to.
 """
 
 import json
@@ -106,20 +112,37 @@ def default_log_path():
     return "mpremote-dap-{}-{}.jsonl".format(time.strftime("%Y%m%dT%H%M%S"), os.getpid())
 
 
-class DapProxy:
-    """Localhost proxy: one client, forwarded to (target_host, target_port).
+class NullLogger:
+    """A `DapLogger` that discards everything - the no-`--dap-log` case."""
+
+    def log(self, direction, frame):
+        pass
+
+    def close(self):
+        pass
+
+
+class PumpingProxy:
+    """Localhost proxy: one client, forwarded to a target `_connect_target()` opens.
 
     Binds its port immediately (`host`/`port` are set once `__init__`
     returns); the accept and both pump directions run on background threads
     started by `start()`, so construction and reporting the substituted
     endpoint never block on a client actually connecting. `bind_port`
     defaults to 0 (OS-assigned); a caller pinning the client-facing endpoint
-    (`--port` alongside `--dap-log`) passes the requested port instead.
+    passes the requested port instead.
+
+    A subclass supplies `_connect_target()`, called once a client has
+    connected, returning the object the client is bridged to - a
+    `socket.socket` (`DapProxy`, forwarding to another TCP endpoint) or
+    anything else duck-typing `recv`/`sendall`/`shutdown`/`close`
+    (`SerialDapBridge`'s `_SerialDuplex`). The pump code below only ever
+    calls those four methods, on either side, so it never has to know which
+    kind of target it is forwarding to.
     """
 
-    def __init__(self, target_host, target_port, logger, bind_host="127.0.0.1", bind_port=0):
+    def __init__(self, logger, bind_host="127.0.0.1", bind_port=0):
         self.host = bind_host
-        self._target = (target_host, target_port)
         self._logger = logger
         self._listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -131,6 +154,15 @@ class DapProxy:
         self._pumps = []
         self._done = threading.Event()
         self._closed = False
+        # Set when the *target* side (not the client) ends abnormally - an
+        # exception out of `_connect_target()` or out of a read on the
+        # target - as opposed to a clean EOF, which leaves this None. A
+        # caller uses this to tell "session ended" from "target connection
+        # was lost" (e.g. a board reset behind a serial bridge).
+        self.target_error = None
+
+    def _connect_target(self):
+        raise NotImplementedError
 
     def start(self):
         threading.Thread(target=self._accept, name="dap-proxy-accept", daemon=True).start()
@@ -142,8 +174,9 @@ class DapProxy:
             self._done.set()
             return
         try:
-            self._server = socket.create_connection(self._target)
-        except OSError:
+            self._server = self._connect_target()
+        except OSError as er:
+            self.target_error = er
             self._client.close()
             self._done.set()
             return
@@ -161,14 +194,29 @@ class DapProxy:
         self._done.set()
 
     def _pump(self, src, dst, direction):
-        # `direction` names where the frame came from, not where it's going.
+        # `direction` names where the frame came from, not where it's going -
+        # it has nothing to do with which endpoint is `self._server` (the
+        # target), so `target_error` is keyed on endpoint identity (`src is
+        # self._server` / `dst is self._server`), not on `direction`: each
+        # pump thread reads one endpoint and writes the other, so a failure
+        # on either side of either thread can be a target failure.
         parser = FrameParser()
         try:
             while True:
-                chunk = src.recv(4096)
+                try:
+                    chunk = src.recv(4096)
+                except OSError as er:
+                    if src is self._server:
+                        self.target_error = er
+                    break
                 if not chunk:
                     break
-                dst.sendall(chunk)
+                try:
+                    dst.sendall(chunk)
+                except OSError as er:
+                    if dst is self._server:
+                        self.target_error = er
+                    break
                 # Forwarding must survive a logging fault - non-DAP bytes on
                 # the socket (an HTTP probe, console output) or anything else
                 # that trips the parser or writer must not tear down the pump.
@@ -181,8 +229,6 @@ class DapProxy:
                         self._logger.log(direction, frame)
                     except Exception:
                         pass
-        except OSError:
-            pass
         finally:
             # Half-closing only tells the peer we are done writing; if it
             # never closes its own side, the opposite pump stays blocked in
@@ -213,3 +259,14 @@ class DapProxy:
         for t in self._pumps:
             t.join(timeout=2)
         self._logger.close()
+
+
+class DapProxy(PumpingProxy):
+    """`PumpingProxy` forwarding to (target_host, target_port) over TCP."""
+
+    def __init__(self, target_host, target_port, logger, bind_host="127.0.0.1", bind_port=0):
+        super().__init__(logger, bind_host, bind_port)
+        self._target = (target_host, target_port)
+
+    def _connect_target(self):
+        return socket.create_connection(self._target)

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -181,8 +181,8 @@ def argparse_run():
 def argparse_debug():
     cmd_parser = argparse.ArgumentParser(
         description="debug a MicroPython script with a DAP client",
-        epilog="--port/--timeout/--dap-log must come before target/program, "
-        "as with any other mpremote option",
+        epilog="--port/--timeout/--dap-log/--dap-log-file must come before "
+        "target/program, as with any other mpremote option",
     )
     cmd_parser.add_argument(
         "target",
@@ -219,7 +219,21 @@ def argparse_debug():
         help="seconds to wait for the device to bind its debug-server socket "
         "and report the endpoint (default: 60)",
     )
-    _bool_flag(cmd_parser, "dap-log", "d", False, "log DAP traffic (not yet implemented)")
+    _bool_flag(
+        cmd_parser,
+        "dap-log",
+        "d",
+        False,
+        "log DAP traffic as JSONL via a local proxy inserted between the "
+        "client and the device (default file: a timestamped file in the "
+        "current directory; name one with --dap-log-file)",
+    )
+    cmd_parser.add_argument(
+        "--dap-log-file",
+        metavar="FILE",
+        default=None,
+        help="path for --dap-log's JSONL output; requires --dap-log",
+    )
     return cmd_parser
 
 

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -186,14 +186,19 @@ def argparse_debug():
     )
     cmd_parser.add_argument(
         "target",
-        help="'unix' (not yet implemented) or a connect string as accepted by 'mpremote connect'",
+        nargs="?",
+        default=None,
+        help="name of a target in mpdebug.toml, 'unix' (not yet implemented), or a "
+        "connect string as accepted by 'mpremote connect'; omit to use the file's "
+        "sole target, or list the available names if it defines several",
     )
     cmd_parser.add_argument(
         "program",
         nargs="?",
-        default="target:main",
-        help="module[:method] to run under the debugger (default: target:main); "
-        "put '+' before a chained command so it isn't read as this argument",
+        default=None,
+        help="module[:method] to run under the debugger (default: the target's own "
+        "'program', or 'target:main'); put '+' before a chained command so it "
+        "isn't read as this argument",
     )
     # No port in this tree binds socket.getsockname(), so the device cannot
     # report a system-assigned port and listen(port=0) raises there. Leaving

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -182,7 +182,7 @@ def argparse_debug():
     cmd_parser = argparse.ArgumentParser(
         description="debug a MicroPython script with a DAP client",
         epilog="as with any other mpremote option, --port/--timeout/--dap-log/"
-        "--dap-log-file/--source must come before target/program",
+        "--dap-log-file/--source/--loop must come before target/program",
     )
     cmd_parser.add_argument(
         "target",
@@ -243,6 +243,15 @@ def argparse_debug():
         "whatever copy is already on the device; overrides the target's 'source' in "
         "mpdebug.toml; rejected for a unix target, which already runs from the host "
         "filesystem",
+    )
+    _bool_flag(
+        cmd_parser,
+        "loop",
+        "l",
+        False,
+        "keep the session alive across re-runs: the client's restart request "
+        "evicts what the program imported and imports it again, so an edit "
+        "takes effect with no upload and no reset",
     )
     return cmd_parser
 

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -182,7 +182,7 @@ def argparse_debug():
     cmd_parser = argparse.ArgumentParser(
         description="debug a MicroPython script with a DAP client",
         epilog="as with any other mpremote option, --port/--timeout/--dap-log/"
-        "--dap-log-file/--source/--loop must come before target/program",
+        "--dap-log-file/--source/--loop/--dap-repl must come before target/program",
     )
     cmd_parser.add_argument(
         "target",
@@ -252,6 +252,16 @@ def argparse_debug():
         "keep the session alive across re-runs: the client's restart request "
         "evicts what the program imported and imports it again, so an edit "
         "takes effect with no upload and no reset",
+    )
+    _bool_flag(
+        cmd_parser,
+        "dap-repl",
+        "r",
+        False,
+        "put the DAP channel on the stream already carrying the REPL, for a "
+        "board with one UART and no network; overrides the target's "
+        "'dap_repl'. The REPL is not usable for anything else while the "
+        "session runs - see docs/debugging.md",
     )
     return cmd_parser
 

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -188,9 +188,9 @@ def argparse_debug():
         "target",
         nargs="?",
         default=None,
-        help="name of a target in mpdebug.toml, 'unix' (not yet implemented), or a "
-        "connect string as accepted by 'mpremote connect'; omit to use the file's "
-        "sole target, or list the available names if it defines several",
+        help="name of a target in mpdebug.toml, 'unix' to debug a local unix-port "
+        "build, or a connect string as accepted by 'mpremote connect'; omit to use "
+        "the file's sole target, or list the available names if it defines several",
     )
     cmd_parser.add_argument(
         "program",

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -181,8 +181,8 @@ def argparse_run():
 def argparse_debug():
     cmd_parser = argparse.ArgumentParser(
         description="debug a MicroPython script with a DAP client",
-        epilog="--port/--timeout/--dap-log/--dap-log-file must come before "
-        "target/program, as with any other mpremote option",
+        epilog="as with any other mpremote option, --port/--timeout/--dap-log/"
+        "--dap-log-file/--source must come before target/program",
     )
     cmd_parser.add_argument(
         "target",
@@ -233,6 +233,16 @@ def argparse_debug():
         metavar="FILE",
         default=None,
         help="path for --dap-log's JSONL output; requires --dap-log",
+    )
+    cmd_parser.add_argument(
+        "--source",
+        metavar="PATH",
+        default=None,
+        help="host directory to mount at the device's remote-fs mount point before "
+        "running the program, so it debugs a live view of this directory instead of "
+        "whatever copy is already on the device; overrides the target's 'source' in "
+        "mpdebug.toml; rejected for a unix target, which already runs from the host "
+        "filesystem",
     )
     return cmd_parser
 

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -13,6 +13,7 @@ MicroPython device over a serial connection.  Commands supported are:
     mpremote eval <string>           -- evaluate and print the string
     mpremote exec <string>           -- execute the string
     mpremote run <script>            -- run the given local script
+    mpremote debug <target> [prog]   -- debug the given script with a DAP client
     mpremote fs <command> <args...>  -- execute filesystem commands on the device
     mpremote repl                    -- enter REPL
 """
@@ -27,6 +28,7 @@ import platformdirs
 from .commands import (
     CommandError,
     do_connect,
+    do_debug,
     do_disconnect,
     do_edit,
     do_filesystem,
@@ -173,6 +175,46 @@ def argparse_run():
         cmd_parser, "follow", "f", True, "follow output until the script completes (default)"
     )
     cmd_parser.add_argument("path", nargs=1, help="path to script to execute")
+    return cmd_parser
+
+
+def argparse_debug():
+    cmd_parser = argparse.ArgumentParser(
+        description="debug a MicroPython script with a DAP client",
+        epilog="--port/--timeout/--dap-log must come before target/program, "
+        "as with any other mpremote option",
+    )
+    cmd_parser.add_argument(
+        "target",
+        help="'unix' (not yet implemented) or a connect string as accepted by 'mpremote connect'",
+    )
+    cmd_parser.add_argument(
+        "program",
+        nargs="?",
+        default="target:main",
+        help="module[:method] to run under the debugger (default: target:main); "
+        "put '+' before a chained command so it isn't read as this argument",
+    )
+    # No port in this tree binds socket.getsockname(), so the device cannot
+    # report a system-assigned port and listen(port=0) raises there. Leaving
+    # --port unset omits it from the boot script's argv, so the device applies
+    # its own default rather than the host choosing one.
+    cmd_parser.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help="TCP port for the debug server to listen on (default: the "
+        "device's own default); 0 is rejected, since a device that cannot "
+        "report the system-assigned port has no endpoint to advertise",
+    )
+    cmd_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=60,
+        help="seconds to wait for the device to bind its debug-server socket "
+        "and report the endpoint (default: 60)",
+    )
+    _bool_flag(cmd_parser, "dap-log", "d", False, "log DAP traffic (not yet implemented)")
     return cmd_parser
 
 
@@ -330,6 +372,10 @@ _COMMANDS = {
     "run": (
         do_run,
         argparse_run,
+    ),
+    "debug": (
+        do_debug,
+        argparse_debug,
     ),
     "rtc": (
         do_rtc,

--- a/tools/mpremote/mpremote/mpdebug_config.py
+++ b/tools/mpremote/mpremote/mpdebug_config.py
@@ -1,0 +1,246 @@
+"""Project-level named debug targets (`mpdebug.toml`) for `mpremote debug`.
+
+Maps a short name to a transport kind, connect string, and firmware/program
+defaults, replacing hardcoded IPs and per-transport invocations with one file
+discovered like `.git` - nearest `mpdebug.toml` from the current directory
+upward:
+
+    [target.pico]
+    kind = "serial"
+    device = "/dev/serial/by-id/usb-MicroPython_..."
+    requires = ["settrace", "save_names"]
+
+`kind` is one of "unix", "serial", "network". `device` is a connect string as
+accepted by `mpremote connect` (required for "serial"; optional for
+"network", where it names the control-plane device used for the pre-IP
+handshake - the debug endpoint itself is never written here, the device
+reports its own). `firmware` names a firmware.toml variant id (or "system"
+for whatever binary is already on PATH/flashed); satisfying it is the
+caller's job, not this module's. `program` is a "module[:method]" default.
+`requires` lists capability names, checked here against the fixed vocabulary
+the MPDBG-READY handshake can report, so a typo is caught before any device
+is touched; matching them against what a specific device actually probes
+happens later, once `do_debug` has a handshake to check it against.
+
+Unknown keys in a target table are ignored, not rejected, so a front-end can
+store its own metadata (icons, ordering, ...) alongside these.
+
+A bare name that isn't a target in the file, but looks like a connect string
+(a path, an ``id:``/``port:`` prefix, or one of ``auto``/``list``/``unix``),
+falls back to the pre-existing literal handling instead of erroring - so a
+project with an `mpdebug.toml` doesn't break `mpremote debug /dev/ttyACM0`.
+"""
+
+import os
+import sys
+
+CONFIG_FILENAME = "mpdebug.toml"
+
+
+def _command_error(msg):
+    # Imported lazily: commands.py imports this module at load time, so a
+    # top-level "from .commands import CommandError" here would be circular.
+    from .commands import CommandError
+
+    raise CommandError(msg)
+
+
+# The caps keys the MPDBG-READY handshake reports (see debugpy's
+# probe_capabilities()); keep in step with the probe. A target's `requires`
+# is checked against this tuple.
+KNOWN_CAPABILITIES = ("settrace", "save_names", "set_local", "f_back")
+
+_KINDS = ("unix", "serial", "network")
+
+
+# Names that resolve_target falls back to literal connect-string handling
+# for, when they aren't a target name in the file: mpremote's own
+# "auto"/"list" device strings, "unix", the "a0"/"u0"/"c0"-style port
+# shorthands, and the "id:"/"port:" connect-string prefixes.
+class Target:
+    def __init__(self, name, kind, device=None, firmware=None, program=None, requires=()):
+        self.name = name
+        self.kind = kind
+        self.device = device
+        self.firmware = firmware
+        self.program = program
+        self.requires = requires
+
+
+def find_config(start_dir=None):
+    """Search start_dir (default cwd) upward for mpdebug.toml; None if absent.
+
+    Stops above the home directory, so a config outside $HOME is never
+    picked up, and at a directory holding `.git` (a project root) - as
+    either a directory or a `gitdir:` file, so worktrees and submodule
+    checkouts are recognised too.
+    """
+    d = os.path.abspath(start_dir or os.getcwd())
+    home = os.path.abspath(os.path.expanduser("~"))
+    while True:
+        candidate = os.path.join(d, CONFIG_FILENAME)
+        if os.path.isfile(candidate):
+            return candidate
+        if os.path.exists(os.path.join(d, ".git")) or d == home:
+            return None
+        parent = os.path.dirname(d)
+        if parent == d:
+            return None
+        d = parent
+
+
+def _toml_module():
+    # mpremote declares no toml dependency and a pre-3.11 floor; try the
+    # stdlib module first, fall back to the third-party backport, and only
+    # fail once neither is importable.
+    try:
+        import tomllib
+
+        return tomllib
+    except ImportError:
+        pass
+    try:
+        import tomli
+
+        return tomli
+    except ImportError:
+        _command_error(
+            f"reading {CONFIG_FILENAME} needs a TOML parser: Python >= 3.11 "
+            "(stdlib tomllib) or 'pip install tomli'"
+        )
+
+
+def _load_targets(path):
+    toml = _toml_module()
+    try:
+        with open(path, "rb") as f:
+            data = toml.load(f)
+    except OSError as er:
+        _command_error(f"{path}: {er}")
+    except Exception as er:
+        _command_error(f"{path}: invalid TOML: {er}")
+
+    raw = data.get("target", {})
+    if not isinstance(raw, dict):
+        _command_error(f"{path}: 'target' must be a table of [target.<name>] entries")
+
+    targets = {}
+    for name, spec in raw.items():
+        if not isinstance(spec, dict):
+            _command_error(f"{path}: target '{name}' must be a table")
+
+        kind = spec.get("kind")
+        if kind not in _KINDS:
+            if kind is None and any(isinstance(v, dict) for v in spec.values()):
+                _command_error(
+                    f"{path}: target '{name}' has a nested table (e.g. "
+                    f"[target.{name}.<sub>]); a target entry must be a flat table"
+                )
+            _command_error(
+                f"{path}: target '{name}' has kind {kind!r}, expected one of {', '.join(_KINDS)}"
+            )
+
+        requires = spec.get("requires", [])
+        if not isinstance(requires, list) or not all(isinstance(r, str) for r in requires):
+            _command_error(f"{path}: target '{name}' requires must be a list of capability names")
+        unknown = [r for r in requires if r not in KNOWN_CAPABILITIES]
+        if unknown:
+            _command_error(
+                f"{path}: target '{name}' requires unknown capability "
+                f"{', '.join(repr(u) for u in unknown)}; the probe only reports "
+                f"{', '.join(KNOWN_CAPABILITIES)}"
+            )
+
+        for key in ("device", "program", "firmware"):
+            value = spec.get(key)
+            if value is not None and not isinstance(value, str):
+                _command_error(f"{path}: target '{name}' {key} must be a string")
+
+        device = spec.get("device")
+        if kind == "serial" and not device:
+            _command_error(f"{path}: target '{name}' is kind 'serial' but has no 'device'")
+        if device == "":
+            # Distinct from an absent device, which means "let mpremote choose".
+            _command_error(f"{path}: target '{name}' has an empty 'device'")
+
+        targets[name] = Target(
+            name=name,
+            kind=kind,
+            device=device,
+            firmware=spec.get("firmware"),
+            program=spec.get("program"),
+            requires=requires,
+        )
+    return targets
+
+
+def warn_if_tty_device(device, label):
+    """Warn on stderr if `device` is a /dev/tty* path (renumbers on replug).
+
+    Called by `do_debug` against the connect string it actually ends up
+    using, whether that came from a resolved target or a literal argument,
+    so the warning fires the same way regardless of where the string came
+    from.
+    """
+    if isinstance(device, str) and device.startswith("/dev/tty"):
+        print(
+            f"warning: {label} uses {device!r}; /dev/tty* nodes can "
+            "renumber on replug, prefer a /dev/serial/by-id/... path",
+            file=sys.stderr,
+        )
+
+
+def resolve_target(name, start_dir=None):
+    """Resolve `name` to a Target, or None if `name` isn't one (try it as a literal).
+
+    `name=None` picks the sole target when the file defines exactly one.
+    Any `name` that is not a configured target is handled as a connect
+    string, which is what `do_connect` accepts - there is no attempt to tell
+    the two apart by shape, since a connect string can be a path, an
+    `id:`/`port:` selector, a shortcut, or a bare device name like `COM4`.
+    A typo'd target name therefore reaches the transport; `target_hint()`
+    supplies the "did you mean" text for that case.
+    """
+    path = find_config(start_dir)
+    if path is None:
+        if name is None:
+            _command_error(
+                f"no target given and no {CONFIG_FILENAME} found; pass a connect string "
+                "or add a [target.<name>] table"
+            )
+        return None
+
+    targets = _load_targets(path)
+    if not targets:
+        _command_error(f"{path} defines no [target.<name>] entries")
+
+    if name is None:
+        if len(targets) == 1:
+            return next(iter(targets.values()))
+        _command_error(
+            "no target given and {} defines several; choose one of: {}".format(
+                path, ", ".join(sorted(targets))
+            )
+        )
+
+    if name not in targets:
+        return None
+    return targets[name]
+
+
+def target_hint(name, start_dir=None):
+    """Text naming the configured targets, for when `name` failed as a device.
+
+    Empty when there is no config or `name` is one of its targets, so a
+    caller can append this to a transport error unconditionally.
+    """
+    path = find_config(start_dir)
+    if path is None:
+        return ""
+    try:
+        targets = _load_targets(path)
+    except Exception:
+        return ""
+    if not targets or name in targets:
+        return ""
+    return " ({} defines targets: {})".format(path, ", ".join(sorted(targets)))

--- a/tools/mpremote/mpremote/mpdebug_config.py
+++ b/tools/mpremote/mpremote/mpdebug_config.py
@@ -21,6 +21,11 @@ caller's job, not this module's. `program` is a "module[:method]" default.
 the MPDBG-READY handshake can report, so a typo is caught before any device
 is touched; matching them against what a specific device actually probes
 happens later, once `do_debug` has a handshake to check it against.
+`dap_repl` is the answer for a board with one UART and no network: `true`
+puts the DAP channel on the stream already carrying the REPL, framed so the
+two are told apart without inspecting content. It is meaningless on a "unix"
+target, which reaches its debug channel over the loopback interface. What it
+costs the REPL during a session is in `docs/debugging.md`.
 
 `source` names a host directory that `do_debug` mounts at the device's
 remote-fs mount point before running the debugged program, so the program
@@ -64,6 +69,15 @@ def _command_error(msg):
 # The caps keys the MPDBG-READY handshake reports (see debugpy's
 # probe_capabilities()); keep in step with the probe. A target's `requires`
 # is checked against this tuple.
+#
+# `repl_dap` is deliberately not here even though the probe reports it: it is
+# not an interpreter feature at all, it is a report of which channel the
+# session took, so it is only ever `True` on a run that already asked for that
+# channel. Putting it in `requires` would make every target that names it fail
+# before the run that could satisfy it. A `dap_repl` target checks the key
+# directly, in do_debug, against the handshake of the run it just started.
+# `caps` itself has no allowlist (mpdebug_handshake._validate only checks
+# types), so the key is read fine regardless of this tuple.
 KNOWN_CAPABILITIES = ("settrace", "save_names", "set_local", "f_back")
 
 _KINDS = ("unix", "serial", "network")
@@ -83,6 +97,7 @@ class Target:
         program=None,
         requires=(),
         source=None,
+        dap_repl=False,
     ):
         self.name = name
         self.kind = kind
@@ -90,6 +105,9 @@ class Target:
         self.firmware = firmware
         self.program = program
         self.requires = requires
+        # True when DAP shares the REPL's own stream instead of reaching the
+        # device over the network. The single-UART, no-network channel.
+        self.dap_repl = dap_repl
         # Absolute, symlink-resolved host directory `do_debug` mounts at the
         # device's remote-fs mount point before running the program. None
         # means the program's module already lives on the device's own
@@ -181,6 +199,7 @@ def _load_targets(path):
                 f"{', '.join(KNOWN_CAPABILITIES)}"
             )
 
+        for key in ("device", "program", "firmware", "source"):
             value = spec.get(key)
             if value is not None and not isinstance(value, str):
                 _command_error(f"{path}: target '{name}' {key} must be a string")
@@ -192,6 +211,14 @@ def _load_targets(path):
             # Distinct from an absent device, which means "let mpremote choose".
             _command_error(f"{path}: target '{name}' has an empty 'device'")
 
+        dap_repl = spec.get("dap_repl", False)
+        if not isinstance(dap_repl, bool):
+            _command_error(f"{path}: target '{name}' dap_repl must be true or false")
+        if dap_repl and kind == "unix":
+            _command_error(
+                f"{path}: target '{name}' is kind 'unix' and sets 'dap_repl'; a unix "
+                "target reaches its debug channel over the loopback interface"
+            )
 
         source = spec.get("source")
         if source == "":
@@ -219,6 +246,7 @@ def _load_targets(path):
             program=spec.get("program"),
             requires=requires,
             source=source,
+            dap_repl=dap_repl,
         )
     return targets
 

--- a/tools/mpremote/mpremote/mpdebug_config.py
+++ b/tools/mpremote/mpremote/mpdebug_config.py
@@ -77,7 +77,12 @@ def _command_error(msg):
 # directly, in do_debug, against the handshake of the run they just started.
 # `caps` itself has no allowlist (mpdebug_handshake._validate only checks
 # types), so this key is read fine regardless of this tuple.
-KNOWN_CAPABILITIES = ("settrace", "save_names", "set_local", "f_back")
+#
+# `second_cdc` is here despite also not being an interpreter feature, because
+# unlike `serial_dap` it describes the build rather than the run: it is True on
+# a board that has the interface whether or not this session took it, so a
+# target naming it in `requires` gets the answer it asked for on any run.
+KNOWN_CAPABILITIES = ("settrace", "save_names", "set_local", "f_back", "second_cdc")
 
 _KINDS = ("unix", "serial", "network")
 

--- a/tools/mpremote/mpremote/mpdebug_config.py
+++ b/tools/mpremote/mpremote/mpdebug_config.py
@@ -53,13 +53,14 @@ def _command_error(msg):
 # probe_capabilities()); keep in step with the probe. A target's `requires`
 # is checked against this tuple.
 #
-# `serial_dap` is deliberately not here even though the probe reports it
-# (currently always `False` - board-specific second-CDC detection isn't
-# implemented for any port yet): it names a specific `dap_device` wiring
-# rather than a general interpreter feature, so `dap_device` targets check
-# it directly, in do_debug, instead of through a target's `requires`. `caps`
-# itself has no allowlist (mpdebug_handshake._validate only checks types),
-# so this key is read fine regardless of this tuple.
+# `serial_dap` is deliberately not here even though the probe reports it: it
+# is not an interpreter feature at all but a report of which channel the
+# session took, so it is only ever `True` on a run that already asked for a
+# stream. Putting it in `requires` would make every target that names it fail
+# before the run that could satisfy it. `dap_device` targets check it
+# directly, in do_debug, against the handshake of the run they just started.
+# `caps` itself has no allowlist (mpdebug_handshake._validate only checks
+# types), so this key is read fine regardless of this tuple.
 KNOWN_CAPABILITIES = ("settrace", "save_names", "set_local", "f_back")
 
 _KINDS = ("unix", "serial", "network")

--- a/tools/mpremote/mpremote/mpdebug_config.py
+++ b/tools/mpremote/mpremote/mpdebug_config.py
@@ -21,6 +21,10 @@ caller's job, not this module's. `program` is a "module[:method]" default.
 the MPDBG-READY handshake can report, so a typo is caught before any device
 is touched; matching them against what a specific device actually probes
 happens later, once `do_debug` has a handshake to check it against.
+`dap_device` is a second by-id connect string, the board's dedicated DAP
+serial interface, used only when the handshake also reports `serial_dap:
+true`; without it `do_debug` always uses the network transport, whatever a
+device's own probe says it has.
 
 Unknown keys in a target table are ignored, not rejected, so a front-end can
 store its own metadata (icons, ordering, ...) alongside these.
@@ -48,6 +52,14 @@ def _command_error(msg):
 # The caps keys the MPDBG-READY handshake reports (see debugpy's
 # probe_capabilities()); keep in step with the probe. A target's `requires`
 # is checked against this tuple.
+#
+# `serial_dap` is deliberately not here even though the probe reports it
+# (currently always `False` - board-specific second-CDC detection isn't
+# implemented for any port yet): it names a specific `dap_device` wiring
+# rather than a general interpreter feature, so `dap_device` targets check
+# it directly, in do_debug, instead of through a target's `requires`. `caps`
+# itself has no allowlist (mpdebug_handshake._validate only checks types),
+# so this key is read fine regardless of this tuple.
 KNOWN_CAPABILITIES = ("settrace", "save_names", "set_local", "f_back")
 
 _KINDS = ("unix", "serial", "network")
@@ -58,13 +70,22 @@ _KINDS = ("unix", "serial", "network")
 # "auto"/"list" device strings, "unix", the "a0"/"u0"/"c0"-style port
 # shorthands, and the "id:"/"port:" connect-string prefixes.
 class Target:
-    def __init__(self, name, kind, device=None, firmware=None, program=None, requires=()):
+    def __init__(
+        self, name, kind, device=None, firmware=None, program=None, requires=(), dap_device=None
+    ):
         self.name = name
         self.kind = kind
         self.device = device
         self.firmware = firmware
         self.program = program
         self.requires = requires
+        # The second CDC interface's connect string, for boards where DAP
+        # rides its own serial device node instead of the network (`serial_dap`
+        # in caps) - by-id, like `device`. None means "this target has no
+        # dedicated DAP interface configured"; `do_debug` then always uses
+        # the network transport, even if the device's own probe says it has
+        # one, since there is no path to reach it without this.
+        self.dap_device = dap_device
 
 
 def find_config(start_dir=None):
@@ -151,7 +172,7 @@ def _load_targets(path):
                 f"{', '.join(KNOWN_CAPABILITIES)}"
             )
 
-        for key in ("device", "program", "firmware"):
+        for key in ("device", "program", "firmware", "dap_device"):
             value = spec.get(key)
             if value is not None and not isinstance(value, str):
                 _command_error(f"{path}: target '{name}' {key} must be a string")
@@ -163,6 +184,10 @@ def _load_targets(path):
             # Distinct from an absent device, which means "let mpremote choose".
             _command_error(f"{path}: target '{name}' has an empty 'device'")
 
+        dap_device = spec.get("dap_device")
+        if dap_device == "":
+            _command_error(f"{path}: target '{name}' has an empty 'dap_device'")
+
         targets[name] = Target(
             name=name,
             kind=kind,
@@ -170,6 +195,7 @@ def _load_targets(path):
             firmware=spec.get("firmware"),
             program=spec.get("program"),
             requires=requires,
+            dap_device=dap_device,
         )
     return targets
 

--- a/tools/mpremote/mpremote/mpdebug_config.py
+++ b/tools/mpremote/mpremote/mpdebug_config.py
@@ -22,6 +22,22 @@ the MPDBG-READY handshake can report, so a typo is caught before any device
 is touched; matching them against what a specific device actually probes
 happens later, once `do_debug` has a handshake to check it against.
 
+`source` names a host directory that `do_debug` mounts at the device's
+remote-fs mount point before running the debugged program, so the program
+executes from a live view of the host filesystem rather than whatever copy
+already sits on the device. A relative path is resolved against the
+directory holding this `mpdebug.toml`; the value stored on `Target` is
+always an absolute, symlink-resolved path, checked for existence when
+`do_debug` actually uses it rather than here, so one target's stale source
+doesn't break every other target in the file. Its absence means the module
+already lives on the device's own filesystem - the hardware-in-the-loop
+targets that run `/flash/target.py` want exactly this - so nothing is
+mounted and `do_debug` behaves as it did before this key existed. Valid only
+on a "serial" or "network" target: a "unix" target already runs the program
+straight from the host filesystem, so there is nothing to mount. A
+`--source PATH` command-line option overrides this key without needing an
+`mpdebug.toml` entry at all.
+
 Unknown keys in a target table are ignored, not rejected, so a front-end can
 store its own metadata (icons, ordering, ...) alongside these.
 
@@ -58,13 +74,27 @@ _KINDS = ("unix", "serial", "network")
 # "auto"/"list" device strings, "unix", the "a0"/"u0"/"c0"-style port
 # shorthands, and the "id:"/"port:" connect-string prefixes.
 class Target:
-    def __init__(self, name, kind, device=None, firmware=None, program=None, requires=()):
+    def __init__(
+        self,
+        name,
+        kind,
+        device=None,
+        firmware=None,
+        program=None,
+        requires=(),
+        source=None,
+    ):
         self.name = name
         self.kind = kind
         self.device = device
         self.firmware = firmware
         self.program = program
         self.requires = requires
+        # Absolute, symlink-resolved host directory `do_debug` mounts at the
+        # device's remote-fs mount point before running the program. None
+        # means the program's module already lives on the device's own
+        # filesystem, so `do_debug` mounts nothing.
+        self.source = source
 
 
 def find_config(start_dir=None):
@@ -151,7 +181,6 @@ def _load_targets(path):
                 f"{', '.join(KNOWN_CAPABILITIES)}"
             )
 
-        for key in ("device", "program", "firmware"):
             value = spec.get(key)
             if value is not None and not isinstance(value, str):
                 _command_error(f"{path}: target '{name}' {key} must be a string")
@@ -163,6 +192,25 @@ def _load_targets(path):
             # Distinct from an absent device, which means "let mpremote choose".
             _command_error(f"{path}: target '{name}' has an empty 'device'")
 
+
+        source = spec.get("source")
+        if source == "":
+            _command_error(f"{path}: target '{name}' has an empty 'source'")
+        if source is not None:
+            if kind == "unix":
+                _command_error(
+                    f"{path}: target '{name}' is kind 'unix' and has a 'source'; a "
+                    "unix target already runs the program straight from the host "
+                    "filesystem, there is nothing to mount"
+                )
+            if not os.path.isabs(source):
+                source = os.path.join(os.path.dirname(path), source)
+            source = os.path.realpath(source)
+            # Existence is checked at the point of use (do_debug), not here:
+            # an isdir check at load time would fail every target in the
+            # file the moment any one of them names a source root that
+            # doesn't (yet) exist, not just the one actually being run.
+
         targets[name] = Target(
             name=name,
             kind=kind,
@@ -170,6 +218,7 @@ def _load_targets(path):
             firmware=spec.get("firmware"),
             program=spec.get("program"),
             requires=requires,
+            source=source,
         )
     return targets
 

--- a/tools/mpremote/mpremote/mpdebug_config.py
+++ b/tools/mpremote/mpremote/mpdebug_config.py
@@ -26,6 +26,22 @@ serial interface, used only when the handshake also reports `serial_dap:
 true`; without it `do_debug` always uses the network transport, whatever a
 device's own probe says it has.
 
+`source` names a host directory that `do_debug` mounts at the device's
+remote-fs mount point before running the debugged program, so the program
+executes from a live view of the host filesystem rather than whatever copy
+already sits on the device. A relative path is resolved against the
+directory holding this `mpdebug.toml`; the value stored on `Target` is
+always an absolute, symlink-resolved path, checked for existence when
+`do_debug` actually uses it rather than here, so one target's stale source
+doesn't break every other target in the file. Its absence means the module
+already lives on the device's own filesystem - the hardware-in-the-loop
+targets that run `/flash/target.py` want exactly this - so nothing is
+mounted and `do_debug` behaves as it did before this key existed. Valid only
+on a "serial" or "network" target: a "unix" target already runs the program
+straight from the host filesystem, so there is nothing to mount. A
+`--source PATH` command-line option overrides this key without needing an
+`mpdebug.toml` entry at all.
+
 Unknown keys in a target table are ignored, not rejected, so a front-end can
 store its own metadata (icons, ordering, ...) alongside these.
 
@@ -72,7 +88,15 @@ _KINDS = ("unix", "serial", "network")
 # shorthands, and the "id:"/"port:" connect-string prefixes.
 class Target:
     def __init__(
-        self, name, kind, device=None, firmware=None, program=None, requires=(), dap_device=None
+        self,
+        name,
+        kind,
+        device=None,
+        firmware=None,
+        program=None,
+        requires=(),
+        dap_device=None,
+        source=None,
     ):
         self.name = name
         self.kind = kind
@@ -87,6 +111,11 @@ class Target:
         # the network transport, even if the device's own probe says it has
         # one, since there is no path to reach it without this.
         self.dap_device = dap_device
+        # Absolute, symlink-resolved host directory `do_debug` mounts at the
+        # device's remote-fs mount point before running the program. None
+        # means the program's module already lives on the device's own
+        # filesystem, so `do_debug` mounts nothing.
+        self.source = source
 
 
 def find_config(start_dir=None):
@@ -173,7 +202,7 @@ def _load_targets(path):
                 f"{', '.join(KNOWN_CAPABILITIES)}"
             )
 
-        for key in ("device", "program", "firmware", "dap_device"):
+        for key in ("device", "program", "firmware", "dap_device", "source"):
             value = spec.get(key)
             if value is not None and not isinstance(value, str):
                 _command_error(f"{path}: target '{name}' {key} must be a string")
@@ -189,6 +218,24 @@ def _load_targets(path):
         if dap_device == "":
             _command_error(f"{path}: target '{name}' has an empty 'dap_device'")
 
+        source = spec.get("source")
+        if source == "":
+            _command_error(f"{path}: target '{name}' has an empty 'source'")
+        if source is not None:
+            if kind == "unix":
+                _command_error(
+                    f"{path}: target '{name}' is kind 'unix' and has a 'source'; a "
+                    "unix target already runs the program straight from the host "
+                    "filesystem, there is nothing to mount"
+                )
+            if not os.path.isabs(source):
+                source = os.path.join(os.path.dirname(path), source)
+            source = os.path.realpath(source)
+            # Existence is checked at the point of use (do_debug), not here:
+            # an isdir check at load time would fail every target in the
+            # file the moment any one of them names a source root that
+            # doesn't (yet) exist, not just the one actually being run.
+
         targets[name] = Target(
             name=name,
             kind=kind,
@@ -197,6 +244,7 @@ def _load_targets(path):
             program=spec.get("program"),
             requires=requires,
             dap_device=dap_device,
+            source=source,
         )
     return targets
 

--- a/tools/mpremote/mpremote/mpdebug_handshake.py
+++ b/tools/mpremote/mpremote/mpdebug_handshake.py
@@ -1,0 +1,180 @@
+"""Shared parsing of the `MPDBG-READY {json}` handshake line.
+
+Every control plane that launches a debug session (unix subprocess stdout,
+raw-REPL exec output over serial) gets the same one-line handshake back over
+a different byte stream. `read_handshake()` scans whatever `read_chunk()`
+supplies for that line, validates its payload, and resolves the endpoint it
+reports against caller-supplied context - so no caller ever hands a bare
+`0.0.0.0` bind address to a DAP client.
+"""
+
+import json
+import time
+
+PREFIX = "MPDBG-READY "
+
+CONTROL_KIND_UNIX = "unix"
+CONTROL_KIND_SERIAL = "serial"
+_CONTROL_KINDS = (CONTROL_KIND_UNIX, CONTROL_KIND_SERIAL)
+
+# Bind addresses meaning "no address of my own to report" (see
+# mpy_launch_debugpy.py's _detect_host, which reports "0.0.0.0"). Never a
+# connectable endpoint, so never returned by _resolve_host.
+# Spellings of "bound to every interface". Normalised before comparison, so
+# "::0", "[::]" and stray whitespace are recognised too - a wildcard that slips
+# through would be handed to a client as an address to connect to.
+_WILDCARD_HOSTS = ("0.0.0.0", "0:0:0:0:0:0:0:0", "::", "::0", "")
+
+
+def _is_wildcard(host):
+    return host.strip().strip("[]").lower() in _WILDCARD_HOSTS
+
+
+class HandshakeError(Exception):
+    """A missing/duplicate/malformed handshake line, or an unresolvable endpoint."""
+
+
+def _tail(text):
+    text = text.strip()
+    return f"; last output: {text!r}" if text else ""
+
+
+def _validate(payload):
+    if not isinstance(payload, dict):
+        raise HandshakeError(
+            f"malformed handshake payload from the device, expected a JSON object: {payload!r}"
+        )
+    try:
+        host, port, caps = payload["host"], payload["port"], payload["caps"]
+    except KeyError as er:
+        raise HandshakeError(f"malformed handshake payload from the device, missing key {er}")
+    if not isinstance(host, str):
+        raise HandshakeError(
+            f"malformed handshake payload from the device, 'host' is not a string: {host!r}"
+        )
+    if not isinstance(port, int) or isinstance(port, bool):
+        raise HandshakeError(
+            f"malformed handshake payload from the device, 'port' is not an int: {port!r}"
+        )
+    if not isinstance(caps, dict) or any(not isinstance(v, bool) for v in caps.values()):
+        raise HandshakeError(
+            f"malformed handshake payload from the device, 'caps' is not a table of booleans: {caps!r}"
+        )
+    return host, port, caps
+
+
+def _resolve_host(host, port, control_kind, known_host):
+    if control_kind not in _CONTROL_KINDS:
+        raise HandshakeError(
+            f"unknown control_kind {control_kind!r}, expected one of {_CONTROL_KINDS!r}"
+        )
+    # host is a bind address ("what I listened on"), not necessarily a
+    # connectable one - see _WILDCARD_HOSTS.
+    if not _is_wildcard(host):
+        return host
+    if control_kind == CONTROL_KIND_UNIX:
+        return "127.0.0.1"
+    # known_host is equally unusable if it's itself a wildcard - a caller
+    # that only knows "device is listening on all interfaces" knows nothing.
+    if known_host and known_host not in _WILDCARD_HOSTS:
+        return known_host
+    raise HandshakeError(
+        "the device reported no network address (bound all interfaces on port "
+        f"{port}); connect it to a network, or debug it over a control plane "
+        "that knows its address - refusing to guess"
+    )
+
+
+def read_handshake(
+    read_chunk,
+    timeout,
+    control_kind,
+    known_host=None,
+    initial="",
+    on_line=None,
+    eof=None,
+    on_eof=None,
+):
+    """Scan `read_chunk()` for one `MPDBG-READY {json}` line and resolve it.
+
+    `read_chunk()` returns available text each poll, `''` when none yet; it
+    owns its own pacing (a real blocking read with a short timeout, or a
+    non-blocking read plus a short sleep) - this loop just calls it
+    repeatedly until a line is found or `timeout` elapses. `initial` seeds
+    the buffer with text a caller already drained before this was called.
+
+    Matches `PREFIX` at line start only - never as a substring - and
+    tolerates the line splitting across `read_chunk()` calls. The JSON is
+    parsed with `raw_decode`, so trailing bytes after the closing brace but
+    before the newline (a stray `\\r`, echoed prompt/control bytes) don't
+    break it. Two `MPDBG-READY` lines arriving in the same buffered batch is
+    a duplicate error, matching the emit side's one-line guarantee; a
+    duplicate arriving only after this has already returned is not
+    detected. A line-at-a-time `read_chunk` (serial: one `read_until(...,
+    b"\\n")` per poll) can only ever buffer one line at a time, so it can
+    detect a duplicate only if the caller seeds both lines via `initial`.
+
+    `on_line`, given a complete non-handshake line (trailing newline
+    included), lets a caller pass banner text straight through.
+
+    `eof`, if given, is a marker string that never appears in ordinary
+    output; seeing it before any handshake line ends the wait immediately
+    instead of stalling for the full timeout (a device that crashes on
+    import prints no `MPDBG-READY` line, ever). `on_eof(rest)`, given
+    whatever trailed the marker so far, may do further caller-side reads to
+    build a diagnostic suffix appended to the resulting error.
+
+    Returns `{"kind": "tcp", "host", "port", "caps", "raw_host"}`. `host` is
+    resolved (never `"0.0.0.0"`); `raw_host` keeps what the device actually
+    reported, for diagnostics.
+    """
+    deadline = time.monotonic() + timeout
+    buf = initial
+    last_line = ""
+    matches = []
+    while True:
+        # Cut the eof marker out first: on serial, read_chunk returns
+        # everything through the next newline, so `\x04Traceback ...\r\n`
+        # arrives as one chunk with the marker glued to the line after it.
+        # Splitting on "\n" before checking for eof would swallow the
+        # marker into that line and hide it from the check below.
+        if eof is not None and eof in buf:
+            head, _, rest = buf.partition(eof)
+        else:
+            head, rest = buf, None
+        while "\n" in head:
+            line, head = head.split("\n", 1)
+            if line.startswith(PREFIX):
+                matches.append(line[len(PREFIX) :])
+            else:
+                if on_line:
+                    on_line(line + "\n")
+                last_line = line
+        if matches:
+            break
+        if rest is not None:
+            extra = on_eof(rest) if on_eof else ""
+            raise HandshakeError(
+                f"device exited before printing a {PREFIX!r} line{_tail(last_line + head)}{extra}"
+            )
+        buf = head
+        if time.monotonic() >= deadline:
+            raise HandshakeError(
+                f"timed out waiting for a {PREFIX!r} line{_tail(last_line + buf)}"
+            )
+        buf += read_chunk()
+
+    if len(matches) > 1:
+        raise HandshakeError(
+            f"expected exactly one {PREFIX!r} line, got {len(matches)}{_tail(last_line + head)}"
+        )
+
+    payload_text = matches[0]
+    try:
+        payload, _ = json.JSONDecoder().raw_decode(payload_text)
+    except json.JSONDecodeError as er:
+        raise HandshakeError(f"malformed {PREFIX!r} line from the device: {payload_text!r} ({er})")
+
+    host, port, caps = _validate(payload)
+    resolved_host = _resolve_host(host, port, control_kind, known_host)
+    return {"kind": "tcp", "host": resolved_host, "port": port, "caps": caps, "raw_host": host}

--- a/tools/mpremote/mpremote/mpy_launch_debugpy.py
+++ b/tools/mpremote/mpremote/mpy_launch_debugpy.py
@@ -4,7 +4,7 @@
 # routine reformat in either repo can't silently break the copies apart.
 """Single parameterised boot script for MicroPython debugpy sessions.
 
-Usage: mpy_launch_debugpy.py [target_module] [target_method] [port] [dap_device]
+Usage: mpy_launch_debugpy.py [target_module] [target_method] [port] [dap_stream]
 
 The bind address is probed at runtime rather than passed in: boards with a
 `network` module report their own address, everything else binds all
@@ -22,11 +22,14 @@ text around it. `wait_for_client()` (not a fixed sleep) blocks until the DAP
 client has finished configuring breakpoints, so breakpoints set before then
 are already applied by the time the target starts running.
 
-On a board `_detect_dap_stream()` finds a dedicated DAP CDC interface on, or
-when `dap_device` names a path this runtime can open directly, the session
-runs over that stream instead of TCP (`host`/`port` in the handshake become
-`"serial"`/`0`, and the `port` argument is unused). `caps["serial_dap"]`
-reports which of the two actually happened, not a board guess.
+`dap_stream`, when given, moves the DAP channel off TCP and onto a byte
+stream: `"board"` selects the board's own dedicated DAP interface, anything
+else is a path this runtime can open. Either way `host`/`port` in the
+handshake become `"serial"`/`0` and the `port` argument goes unused.
+`caps["serial_dap"]` reports which channel was actually taken, not a board
+guess. A caller that asks for a stream and does not get one is told so: this
+never falls back to TCP behind the caller's back, because the caller has a
+bridge waiting on the stream and nothing listening on a port.
 """
 
 import json
@@ -63,25 +66,62 @@ def _detect_host():
     return addr
 
 
-def _detect_dap_stream(device=None):
-    """Return an open reader/writer stream for a dedicated DAP CDC interface, if any.
+def _board_dap_stream():
+    """Return this board's dedicated DAP interface, or None if it has none.
 
-    `device`, when given, is a device path this runtime can open directly.
-    Only the unix port has one to give: a real board's DAP interface is a
-    runtime object (e.g. rp2's second `machine.USBDevice` CDC), not a path
-    the host can name, so board-specific second-CDC detection still has no
-    implementation here and `device` stays unused there. With no `device`,
-    this always returns `None` and `_run()` falls back to
-    `debugpy.listen()` over TCP. `caps["serial_dap"]` is derived from which
-    channel `_run()` actually picked (see `debugpy.get_capabilities()`),
-    never guessed here, so the two can't disagree.
+    stm32 is the only port with an implementation: `pyb.USB_VCP(1)` is the
+    second CDC interface, and `pyb.USB_VCP(0)` is the one carrying the REPL
+    this script was launched over. The constructor is not the test for
+    whether that interface exists - it answers from
+    `MICROPY_HW_USB_CDC_NUM`, which is a build-time maximum. Which
+    interfaces are really enumerated is decided at boot by `usb_mode`, whose
+    name carries the count (`VCP+MSC` for one, `2xVCP+MSC` for two), so that
+    is what this reads.
+
+    `isconnected()` is deliberately not the test either: the host opens the
+    interface only after reading the handshake that this feeds, so it is
+    False here on every run that goes on to succeed.
     """
-    if device is not None:
-        try:
-            return open(device, "r+b")
-        except OSError as er:
-            raise OSError(f"dap_device {device!r} could not be opened: {er}")
-    return None
+    try:
+        import pyb
+    except ImportError:
+        return None  # no other port implements a dedicated DAP interface yet
+    try:
+        mode = pyb.usb_mode()
+    except AttributeError:
+        return None  # a pyb without USB at all
+    if not mode or "xVCP" not in mode:
+        return None  # at most one CDC interface, and the REPL is on it
+    try:
+        return pyb.USB_VCP(1)
+    except ValueError:
+        return None  # firmware built with a single CDC; usb_mode lied
+
+
+def _detect_dap_stream(spec=None):
+    """Return an open reader/writer stream for the DAP channel, or None for TCP.
+
+    `spec` is the caller's choice of channel: `None` for TCP, `"board"` for
+    the board's dedicated DAP interface, or a path this runtime can open
+    directly (what the unix port has instead of a USB interface). Failing to
+    produce the requested stream raises rather than returning None, so the
+    caller never gets a TCP endpoint it has no client for.
+
+    `caps["serial_dap"]` is derived from which channel `_run()` actually
+    picked (see `debugpy.get_capabilities()`), never guessed here, so the two
+    cannot disagree.
+    """
+    if spec is None:
+        return None
+    if spec == "board":
+        stream = _board_dap_stream()
+        if stream is None:
+            raise OSError("no dedicated DAP interface on this board")
+        return stream
+    try:
+        return open(spec, "r+b")
+    except OSError as er:
+        raise OSError(f"dap_stream {spec!r} could not be opened: {er}")
 
 
 def _parse_args():
@@ -91,25 +131,24 @@ def _parse_args():
     target_module = args[0] if len(args) > 0 else "target"
     target_method = args[1] if len(args) > 1 else "main"
     port = int(args[2]) if len(args) > 2 else debugpy.DEFAULT_PORT
-    dap_device = args[3] if len(args) > 3 else None
+    dap_stream = args[3] if len(args) > 3 else None
     if len(args) > 4:
         raise ValueError(
             "Too many arguments. Usage: mpy_launch_debugpy.py "
-            "[target_module] [target_method] [port] [dap_device]"
+            "[target_module] [target_method] [port] [dap_stream]"
         )
-    return target_module, target_method, port, dap_device
+    return target_module, target_method, port, dap_stream
 
 
 def _run():
     import debugpy
 
-
     print(_banner)
     print("MicroPython VS Code Debugging")
-    print("Usage: mpy_launch_debugpy.py [target_module] [target_method] [port] [dap_device]")
+    print("Usage: mpy_launch_debugpy.py [target_module] [target_method] [port] [dap_stream]")
     print("==================================")
 
-    target_module, target_method, port, dap_device = _parse_args()
+    target_module, target_method, port, dap_stream = _parse_args()
     print(f"Target module: {target_module}")
     print(f"Target method: {target_method}")
     print("==================================")
@@ -120,7 +159,7 @@ def _run():
         )
         return
 
-    stream = _detect_dap_stream(dap_device)
+    stream = _detect_dap_stream(dap_stream)
     if stream is not None:
         debugpy.listen_stream(stream)
         actual_host, actual_port = "serial", 0

--- a/tools/mpremote/mpremote/mpy_launch_debugpy.py
+++ b/tools/mpremote/mpremote/mpy_launch_debugpy.py
@@ -21,6 +21,10 @@ Tooling parses that one line rather than any of the human-readable banner
 text around it. `wait_for_client()` (not a fixed sleep) blocks until the DAP
 client has finished configuring breakpoints, so breakpoints set before then
 are already applied by the time the target starts running.
+
+On a board `_detect_dap_stream()` finds a dedicated DAP CDC interface on,
+the session runs over that stream instead of TCP (`host`/`port` in the
+handshake become `"serial"`/`0`, and the `port` argument is unused).
 """
 
 import json
@@ -55,6 +59,20 @@ def _detect_host():
     if not addr or addr == "0.0.0.0":
         return "0.0.0.0"
     return addr
+
+
+def _detect_dap_stream():
+    """Return an open reader/writer stream for a dedicated DAP CDC interface, if any.
+
+    No port implements the board-specific second-CDC detection this needs
+    yet (matching `DebugSession._probe_serial_dap()`, which is why `caps`
+    always reports `serial_dap: false` today), so this always returns
+    `None` and `_run()` falls back to `debugpy.listen()` over TCP. Once a
+    board-specific check lands here, returning a stream is what switches
+    that board to `listen_stream()` instead - `caps` and this function
+    report the same thing so they can never disagree.
+    """
+    return None
 
 
 def _parse_args():
@@ -92,8 +110,13 @@ def _run():
         )
         return
 
-    host = _detect_host()
-    actual_host, actual_port = debugpy.listen(host=host, port=port)
+    stream = _detect_dap_stream()
+    if stream is not None:
+        debugpy.listen_stream(stream)
+        actual_host, actual_port = "serial", 0
+    else:
+        host = _detect_host()
+        actual_host, actual_port = debugpy.listen(host=host, port=port)
     print(f"Debug server listening on {actual_host}:{actual_port}")
 
     caps = debugpy.get_capabilities()

--- a/tools/mpremote/mpremote/mpy_launch_debugpy.py
+++ b/tools/mpremote/mpremote/mpy_launch_debugpy.py
@@ -4,7 +4,11 @@
 # routine reformat in either repo can't silently break the copies apart.
 """Single parameterised boot script for MicroPython debugpy sessions.
 
-Usage: mpy_launch_debugpy.py [target_module] [target_method] [port] [dap_stream]
+Usage: mpy_launch_debugpy.py [target_module] [target_method] [port] [dap_stream] [loop]
+
+Every argument is positional, so one that is not given but is followed by one
+that is has to be passed as the empty string; an empty `port` or `dap_stream`
+reads the same as leaving it off the end.
 
 The bind address is probed at runtime rather than passed in: boards with a
 `network` module report their own address, everything else binds all
@@ -30,6 +34,18 @@ handshake become `"serial"`/`0` and the `port` argument goes unused.
 guess. A caller that asks for a stream and does not get one is told so: this
 never falls back to TCP behind the caller's back, because the caller has a
 bridge waiting on the stream and nothing listening on a port.
+
+`loop`, when the literal `"loop"`, keeps the process and the DAP session alive
+across re-runs of the target: the DAP `restart` request is advertised and
+honoured, and each restart evicts whatever the target imported from
+`sys.modules` and imports it again, so a source edit takes effect with no
+upload and no reset. Each re-run announces itself with
+
+    MPDBG-RESTART {"iteration": N, "evicted": [...]}
+
+which is deliberately not another MPDBG-READY: the endpoint has not changed.
+That line goes to the client's debug console as well as to stdout, because a
+mounted serial session's host never sees anything the device prints.
 """
 
 import json
@@ -130,14 +146,82 @@ def _parse_args():
     args = sys.argv[1:]
     target_module = args[0] if len(args) > 0 else "target"
     target_method = args[1] if len(args) > 1 else "main"
-    port = int(args[2]) if len(args) > 2 else debugpy.DEFAULT_PORT
+    # Empty reads as "not given" for both of these, which is how a caller
+    # passes over one of them to reach a later positional argument.
+    port = int(args[2]) if len(args) > 2 and args[2] else debugpy.DEFAULT_PORT
     dap_stream = args[3] if len(args) > 3 else None
-    if len(args) > 4:
+    # Anything other than the literal "loop" is refused rather than quietly
+    # read as false.
+    loop = args[4] if len(args) > 4 else ""
+    if loop not in ("", "loop"):
+        raise ValueError(f"loop argument must be 'loop' or empty, not {loop!r}")
+    if len(args) > 5:
         raise ValueError(
             "Too many arguments. Usage: mpy_launch_debugpy.py "
-            "[target_module] [target_method] [port] [dap_stream]"
+            "[target_module] [target_method] [port] [dap_stream] [loop]"
         )
-    return target_module, target_method, port, dap_stream
+    return target_module, target_method, port, dap_stream or None, loop == "loop"
+
+
+def _evict_target_modules(baseline):
+    """Drop from sys.modules everything the target's imports added.
+
+    The eviction set is defined by what the target pulled in, not by a list of
+    names to spare, so the debugger cannot be evicted out from under itself:
+    every module debugpy needs was imported before `baseline` was taken. It also
+    means a submodule of the target that changed is re-read along with it, which
+    a target-module-only eviction would miss.
+
+    Returns the evicted names, sorted, for the restart marker.
+    """
+    evicted = []
+    for name in list(sys.modules):
+        if name not in baseline:
+            del sys.modules[name]
+            evicted.append(name)
+    evicted.sort()
+    return evicted
+
+
+def _report(line, debugpy):
+    """Print a marker line to stdout and show it in the client's debug console.
+
+    Both, because neither reaches everyone on its own: a mounted serial session
+    discards everything the device prints, and a caller reading stdout may have
+    no DAP client of its own. The text is identical on both channels, so there
+    is one format to parse rather than two.
+    """
+    print(line)
+    debugpy.console(line + "\n")
+
+
+def _tracing_survived_unwind():
+    """True if sys.settrace still calls back after the unwind that just ran.
+
+    A firmware whose profiling hook leaves its recursion guard set when a trace
+    callback raises never invokes another callback, while sys.settrace() and
+    sys.gettrace() go on reporting success - so installing one and watching is
+    the only way to tell. Silence about that would mean every run after the
+    first restart binds no breakpoints at all, with nothing to see.
+
+    Only safe to call after an unwind: on an affected firmware tracing is
+    already gone by then, and on a sound one this leaves nothing behind.
+    """
+    calls = []
+
+    def _count(frame, event, arg):
+        calls.append(event)
+        return _count
+
+    def _probe():
+        return 1
+
+    sys.settrace(_count)
+    try:
+        _probe()
+    finally:
+        sys.settrace(None)
+    return bool(calls)
 
 
 def _run():
@@ -145,10 +229,12 @@ def _run():
 
     print(_banner)
     print("MicroPython VS Code Debugging")
-    print("Usage: mpy_launch_debugpy.py [target_module] [target_method] [port] [dap_stream]")
+    print(
+        "Usage: mpy_launch_debugpy.py [target_module] [target_method] [port] [dap_stream] [loop]"
+    )
     print("==================================")
 
-    target_module, target_method, port, dap_stream = _parse_args()
+    target_module, target_method, port, dap_stream, loop = _parse_args()
     print(f"Target module: {target_module}")
     print(f"Target method: {target_method}")
     print("==================================")
@@ -158,6 +244,10 @@ def _run():
             "sys.settrace is not available. You need a firmware compiled with debugging features."
         )
         return
+
+    if loop:
+        # Before wait_for_client(), which is where `initialize` is answered.
+        debugpy.enable_restart()
 
     stream = _detect_dap_stream(dap_stream)
     if stream is not None:
@@ -181,30 +271,77 @@ def _run():
         debugpy.disconnect()
         return
 
-    debugpy.debug_this_thread()
+    # Everything the debugger needs is imported by now, so nothing captured here
+    # is ever a candidate for eviction on a restart.
+    baseline_modules = set(sys.modules)
 
-    # Imported only once a client is configured: the module's top-level code
-    # runs on import, and it should run under the debugger with the client's
-    # breakpoints already in place, not before the session exists.
-    try:
-        target = __import__(target_module, None, None, ("*",))
-    except ImportError as e:
-        print(f"Error importing target module '{target_module}': {e}")
-        return
+    iteration = 0
+    while True:
+        iteration += 1
+        if iteration > 1:
+            evicted = _evict_target_modules(baseline_modules)
+            # A restart is NOT another MPDBG-READY: the endpoint has not
+            # changed and a caller that re-parsed one would think a second
+            # session had started.
+            _report(
+                "MPDBG-RESTART " + json.dumps({"iteration": iteration, "evicted": evicted}),
+                debugpy,
+            )
+            if not _tracing_survived_unwind():
+                _report(
+                    "MPDBG-DEGRADED sys.settrace stopped calling back after the unwind; "
+                    "this run has no breakpoints. The firmware needs the fix that clears "
+                    "the profiling recursion guard when a trace callback raises.",
+                    debugpy,
+                )
 
-    method = getattr(target, target_method, None)
-    if method is None:
-        print(f"Method '{target_method}' not found in module '{target_module}'")
-        return
+        # Traced from here to the end of the run and no further: the loop's own
+        # code must not be traced, or a restart handled while it waits below
+        # would unwind the loop itself. The unwind also drops the trace
+        # function (sys.settrace semantics), so this re-arms it each iteration.
+        debugpy.debug_this_thread()
+        restarting = False
+        try:
+            # Imported only once a client is configured: the module's top-level
+            # code runs on import, and it should run under the debugger with the
+            # client's breakpoints already in place, not before the session
+            # exists. On a later iteration the eviction above is what makes this
+            # re-read the file rather than hand back the cached module.
+            try:
+                target = __import__(target_module, None, None, ("*",))
+            except ImportError as e:
+                print(f"Error importing target module '{target_module}': {e}")
+                return
 
-    result = method()
+            method = getattr(target, target_method, None)
+            if method is None:
+                print(f"Method '{target_method}' not found in module '{target_module}'")
+                return
 
-    print("Target completed successfully!")
-    if result is None:
-        print("No result returned from target method")
-    else:
-        print("Result type:", type(result))
-        print("Result:", result)
+            result = method()
+        except debugpy.RestartRequest:
+            # The target was unwound part-way through on purpose; it has no
+            # result, and the next iteration is already asked for.
+            print("Target restarting")
+            restarting = True
+        finally:
+            sys.settrace(None)
+
+        if not restarting:
+            print("Target completed successfully!")
+            if result is None:
+                print("No result returned from target method")
+            else:
+                print("Result type:", type(result))
+                print("Result:", result)
+
+        if not loop:
+            return
+        if not restarting and not debugpy.wait_for_restart():
+            # No client left to restart for. Ending here rather than looping
+            # keeps a session whose client went away from spinning forever.
+            print("Debug client gone; not waiting for another restart")
+            return
 
 
 # Guarded so importing this module does not run device boot code: it ships as

--- a/tools/mpremote/mpremote/mpy_launch_debugpy.py
+++ b/tools/mpremote/mpremote/mpy_launch_debugpy.py
@@ -34,6 +34,9 @@ handshake become `"serial"`/`0` and the `port` argument goes unused.
 guess. A caller that asks for a stream and does not get one is told so: this
 never falls back to TCP behind the caller's back, because the caller has a
 bridge waiting on the stream and nothing listening on a port.
+`caps["second_cdc"]` is the other half of that answer and is a build
+property rather than a session one: whether this firmware has a second CDC
+interface for `"board"` to select at all.
 
 `loop`, when the literal `"loop"`, keeps the process and the DAP session alive
 across re-runs of the target: the DAP `restart` request is advertised and
@@ -113,6 +116,40 @@ def _board_dap_stream():
         return pyb.USB_VCP(1)
     except ValueError:
         return None  # firmware built with a single CDC; usb_mode lied
+
+
+def _probe_second_cdc():
+    """True when this build has a second CDC interface DAP could run over.
+
+    The build's maximum, which is a different question from either of the
+    two next to it and can answer differently on the same run:
+    `pyb.USB_VCP(id)` constructs for every `id` below
+    `MICROPY_HW_USB_CDC_NUM`, a compile-time constant, so this stays True on
+    a board booted `VCP+MSC` with a single interface enumerated, and it is
+    True before any host has opened the interface. `_board_dap_stream()`
+    asks the narrower question - is there an interface here on this boot -
+    and reads `usb_mode` for it; `isconnected()` asks the narrowest, whether
+    a host is holding it. The three are meant to be able to disagree.
+
+    Only stm32 defines the flag, so every other port reports False. That is
+    the right answer for the current firmware variants - rp2 and esp32 build
+    TinyUSB with `CFG_TUD_CDC (1)`, and the unix port has no USB device
+    peripheral - but it is False by ignorance rather than by measurement, so
+    a port that gains a second CDC has to be taught to this probe before a
+    manifest may claim it.
+
+    The expected failures are `ImportError` (no `pyb`), `AttributeError` (a
+    `pyb` with no USB) and `ValueError` (a single-CDC build), but anything at
+    all reads as False, for the same reason `_detect_host()` swallows its own
+    probe: a capability report is not worth aborting a launch over.
+    """
+    try:
+        import pyb
+
+        pyb.USB_VCP(1)
+    except Exception:
+        return False
+    return True
 
 
 def _detect_dap_stream(spec=None):
@@ -274,7 +311,11 @@ def _run():
         actual_host, actual_port = debugpy.listen(host=host, port=port)
     print(f"Debug server listening on {actual_host}:{actual_port}")
 
-    caps = debugpy.get_capabilities()
+    # `.copy()` first: with a session live `get_capabilities()` hands back the
+    # session's own dict, and the second CDC is not the debug server's to
+    # report - it is USB topology, which only the boot script can see.
+    caps = debugpy.get_capabilities().copy()
+    caps["second_cdc"] = _probe_second_cdc()
     # Exactly one MPDBG-READY line, valid JSON, nothing else on this line.
     print("MPDBG-READY " + json.dumps({"host": actual_host, "port": actual_port, "caps": caps}))
 

--- a/tools/mpremote/mpremote/mpy_launch_debugpy.py
+++ b/tools/mpremote/mpremote/mpy_launch_debugpy.py
@@ -320,8 +320,8 @@ def _run():
     print(f"Debug server listening on {actual_host}:{actual_port}")
 
     # `.copy()` first: with a session live `get_capabilities()` hands back the
-    # session's own dict, and the second CDC is not the debug server's to
-    # report - it is USB topology, which only the boot script can see.
+    # session's own dict, and which channel this run took is not the debug
+    # server's to report - only the boot script knows it split the REPL.
     caps = debugpy.get_capabilities().copy()
     caps["repl_dap"] = bool(_repl_mux)
     # Exactly one MPDBG-READY line, valid JSON, nothing else on this line.

--- a/tools/mpremote/mpremote/mpy_launch_debugpy.py
+++ b/tools/mpremote/mpremote/mpy_launch_debugpy.py
@@ -4,7 +4,7 @@
 # routine reformat in either repo can't silently break the copies apart.
 """Single parameterised boot script for MicroPython debugpy sessions.
 
-Usage: mpy_launch_debugpy.py [target_module] [target_method] [port]
+Usage: mpy_launch_debugpy.py [target_module] [target_method] [port] [dap_device]
 
 The bind address is probed at runtime rather than passed in: boards with a
 `network` module report their own address, everything else binds all
@@ -22,9 +22,11 @@ text around it. `wait_for_client()` (not a fixed sleep) blocks until the DAP
 client has finished configuring breakpoints, so breakpoints set before then
 are already applied by the time the target starts running.
 
-On a board `_detect_dap_stream()` finds a dedicated DAP CDC interface on,
-the session runs over that stream instead of TCP (`host`/`port` in the
-handshake become `"serial"`/`0`, and the `port` argument is unused).
+On a board `_detect_dap_stream()` finds a dedicated DAP CDC interface on, or
+when `dap_device` names a path this runtime can open directly, the session
+runs over that stream instead of TCP (`host`/`port` in the handshake become
+`"serial"`/`0`, and the `port` argument is unused). `caps["serial_dap"]`
+reports which of the two actually happened, not a board guess.
 """
 
 import json
@@ -61,17 +63,24 @@ def _detect_host():
     return addr
 
 
-def _detect_dap_stream():
+def _detect_dap_stream(device=None):
     """Return an open reader/writer stream for a dedicated DAP CDC interface, if any.
 
-    No port implements the board-specific second-CDC detection this needs
-    yet (matching `DebugSession._probe_serial_dap()`, which is why `caps`
-    always reports `serial_dap: false` today), so this always returns
-    `None` and `_run()` falls back to `debugpy.listen()` over TCP. Once a
-    board-specific check lands here, returning a stream is what switches
-    that board to `listen_stream()` instead - `caps` and this function
-    report the same thing so they can never disagree.
+    `device`, when given, is a device path this runtime can open directly.
+    Only the unix port has one to give: a real board's DAP interface is a
+    runtime object (e.g. rp2's second `machine.USBDevice` CDC), not a path
+    the host can name, so board-specific second-CDC detection still has no
+    implementation here and `device` stays unused there. With no `device`,
+    this always returns `None` and `_run()` falls back to
+    `debugpy.listen()` over TCP. `caps["serial_dap"]` is derived from which
+    channel `_run()` actually picked (see `debugpy.get_capabilities()`),
+    never guessed here, so the two can't disagree.
     """
+    if device is not None:
+        try:
+            return open(device, "r+b")
+        except OSError as er:
+            raise OSError(f"dap_device {device!r} could not be opened: {er}")
     return None
 
 
@@ -82,12 +91,13 @@ def _parse_args():
     target_module = args[0] if len(args) > 0 else "target"
     target_method = args[1] if len(args) > 1 else "main"
     port = int(args[2]) if len(args) > 2 else debugpy.DEFAULT_PORT
-    if len(args) > 3:
+    dap_device = args[3] if len(args) > 3 else None
+    if len(args) > 4:
         raise ValueError(
             "Too many arguments. Usage: mpy_launch_debugpy.py "
-            "[target_module] [target_method] [port]"
+            "[target_module] [target_method] [port] [dap_device]"
         )
-    return target_module, target_method, port
+    return target_module, target_method, port, dap_device
 
 
 def _run():
@@ -96,10 +106,10 @@ def _run():
 
     print(_banner)
     print("MicroPython VS Code Debugging")
-    print("Usage: mpy_launch_debugpy.py [target_module] [target_method] [port]")
+    print("Usage: mpy_launch_debugpy.py [target_module] [target_method] [port] [dap_device]")
     print("==================================")
 
-    target_module, target_method, port = _parse_args()
+    target_module, target_method, port, dap_device = _parse_args()
     print(f"Target module: {target_module}")
     print(f"Target method: {target_method}")
     print("==================================")
@@ -110,7 +120,7 @@ def _run():
         )
         return
 
-    stream = _detect_dap_stream()
+    stream = _detect_dap_stream(dap_device)
     if stream is not None:
         debugpy.listen_stream(stream)
         actual_host, actual_port = "serial", 0

--- a/tools/mpremote/mpremote/mpy_launch_debugpy.py
+++ b/tools/mpremote/mpremote/mpy_launch_debugpy.py
@@ -96,7 +96,8 @@ def _board_dap_stream():
 
     `isconnected()` is deliberately not the test either: the host opens the
     interface only after reading the handshake that this feeds, so it is
-    False here on every run that goes on to succeed.
+    False here on every run that goes on to succeed. It is what
+    `_dap_stream_liveness` reads later, once there is a session to lose.
     """
     try:
         import pyb
@@ -138,6 +139,21 @@ def _detect_dap_stream(spec=None):
         return open(spec, "r+b")
     except OSError as er:
         raise OSError(f"dap_stream {spec!r} could not be opened: {er}")
+
+
+def _dap_stream_liveness(stream):
+    """How `stream` reports that the host has gone, or None if it cannot.
+
+    A USB CDC interface has no EOF: an idle one and one nobody is holding
+    both read as no bytes, so a session whose host disappears - the editor
+    killed, the terminal closed - would leave the target stopped at its
+    breakpoint until the board is power-cycled. `isconnected()` is that
+    interface's DTR line, which the host raises when it opens the port and
+    the kernel drops when the last opener goes away, so it is the signal a
+    CDC stream has instead of EOF. A stream that does reach EOF - the file
+    the unix port opens - has no `isconnected` and needs none.
+    """
+    return getattr(stream, "isconnected", None)
 
 
 def _parse_args():
@@ -251,7 +267,7 @@ def _run():
 
     stream = _detect_dap_stream(dap_stream)
     if stream is not None:
-        debugpy.listen_stream(stream)
+        debugpy.listen_stream(stream, is_connected=_dap_stream_liveness(stream))
         actual_host, actual_port = "serial", 0
     else:
         host = _detect_host()

--- a/tools/mpremote/mpremote/mpy_launch_debugpy.py
+++ b/tools/mpremote/mpremote/mpy_launch_debugpy.py
@@ -97,6 +97,21 @@ def _detect_dap_stream(spec=None):
         raise OSError(f"dap_stream {spec!r} could not be opened: {er}")
 
 
+def _dap_stream_liveness(stream):
+    """How `stream` reports that the host has gone, or None if it cannot.
+
+    A USB CDC interface has no EOF: an idle one and one nobody is holding
+    both read as no bytes, so a session whose host disappears - the editor
+    killed, the terminal closed - would leave the target stopped at its
+    breakpoint until the board is power-cycled. `isconnected()` is that
+    interface's DTR line, which the host raises when it opens the port and
+    the kernel drops when the last opener goes away, so it is the signal a
+    CDC stream has instead of EOF. A stream that does reach EOF - the file
+    the unix port opens - has no `isconnected` and needs none.
+    """
+    return getattr(stream, "isconnected", None)
+
+
 def _parse_args():
     import debugpy
 
@@ -208,7 +223,7 @@ def _run():
 
     stream = _detect_dap_stream(dap_stream)
     if stream is not None:
-        debugpy.listen_stream(stream)
+        debugpy.listen_stream(stream, is_connected=_dap_stream_liveness(stream))
         actual_host, actual_port = "serial", 0
     else:
         host = _detect_host()

--- a/tools/mpremote/mpremote/mpy_launch_debugpy.py
+++ b/tools/mpremote/mpremote/mpy_launch_debugpy.py
@@ -113,6 +113,12 @@ def _repl_dap_stream():
     (`usb_vcp_attach_to_repl(vcp, false)`), which stops the interrupt
     character being scanned, so Ctrl-C reaches the target as data instead of
     raising `KeyboardInterrupt`. `docs/debugging.md` states that trade-off.
+
+    Which is why the stream must be able to say when the host has let go. On
+    every other channel a session that waits forever costs nothing the user
+    cannot walk away from; on this one it holds the console the board is
+    reached by, and Ctrl-C cannot end it. A stream with no `isconnected` is
+    refused here rather than taken and never given back.
     """
     import os
 
@@ -128,6 +134,9 @@ def _repl_dap_stream():
         # diverted nothing; put it back the way it was found.
         os.dupterm(None, _REPL_DUPTERM_SLOT)
         raise OSError(f"no REPL stream in dupterm slot {_REPL_DUPTERM_SLOT} to share")
+    if getattr(previous, "isconnected", None) is None:
+        os.dupterm(previous, _REPL_DUPTERM_SLOT)
+        raise OSError("the REPL stream cannot report the host letting go of it")
     mux.attach(previous)
     _repl_mux.append(mux)
     return mux.dap

--- a/tools/mpremote/mpremote/mpy_launch_debugpy.py
+++ b/tools/mpremote/mpremote/mpy_launch_debugpy.py
@@ -4,7 +4,11 @@
 # routine reformat in either repo can't silently break the copies apart.
 """Single parameterised boot script for MicroPython debugpy sessions.
 
-Usage: mpy_launch_debugpy.py [target_module] [target_method] [port] [dap_device]
+Usage: mpy_launch_debugpy.py [target_module] [target_method] [port] [dap_stream] [loop]
+
+Every argument is positional, so one that is not given but is followed by one
+that is has to be passed as the empty string; an empty `port` or `dap_stream`
+reads the same as leaving it off the end.
 
 The bind address is probed at runtime rather than passed in: boards with a
 `network` module report their own address, everything else binds all
@@ -22,11 +26,24 @@ text around it. `wait_for_client()` (not a fixed sleep) blocks until the DAP
 client has finished configuring breakpoints, so breakpoints set before then
 are already applied by the time the target starts running.
 
-When `dap_stream` names a path this runtime can open, the session runs over
-that stream instead of TCP (`host`/`port` in the handshake become
-`"serial"`/`0`, and the `port` argument is unused). A caller that asks for a
-stream and does not get one is told so rather than quietly given a TCP
-endpoint it has no client for.
+`dap_stream`, when given, moves the DAP channel off TCP and onto a byte
+stream: a path this runtime can open. `host`/`port` in the handshake then
+become `"serial"`/`0` and the `port` argument goes unused. A caller that asks
+for a stream and does not get one is told so: this never falls back to TCP
+behind the caller's back, because the caller has a bridge waiting on the
+stream and nothing listening on a port.
+
+`loop`, when the literal `"loop"`, keeps the process and the DAP session alive
+across re-runs of the target: the DAP `restart` request is advertised and
+honoured, and each restart evicts whatever the target imported from
+`sys.modules` and imports it again, so a source edit takes effect with no
+upload and no reset. Each re-run announces itself with
+
+    MPDBG-RESTART {"iteration": N, "evicted": [...]}
+
+which is deliberately not another MPDBG-READY: the endpoint has not changed.
+That line goes to the client's debug console as well as to stdout, because a
+mounted serial session's host never sees anything the device prints.
 """
 
 import json
@@ -66,11 +83,11 @@ def _detect_host():
 def _detect_dap_stream(spec=None):
     """Return an open reader/writer stream for the DAP channel, or None for TCP.
 
-    `spec`, when given, is a path this runtime can open directly - what the
-    unix port has instead of a USB interface. With no `spec` this returns
-    `None` and `_run()` falls back to `debugpy.listen()` over TCP. Failing to
-    produce a stream that was asked for raises rather than returning None, so
-    the caller never gets a TCP endpoint it has no client for.
+    `spec` is the caller's choice of channel: `None` for TCP, or a path this
+    runtime can open directly (what the unix port has instead of a USB
+    interface). Failing to produce the requested stream raises rather than
+    returning None, so the caller never gets a TCP endpoint it has no client
+    for.
     """
     if spec is None:
         return None
@@ -86,26 +103,95 @@ def _parse_args():
     args = sys.argv[1:]
     target_module = args[0] if len(args) > 0 else "target"
     target_method = args[1] if len(args) > 1 else "main"
-    port = int(args[2]) if len(args) > 2 else debugpy.DEFAULT_PORT
-    dap_device = args[3] if len(args) > 3 else None
-    if len(args) > 4:
+    # Empty reads as "not given" for both of these, which is how a caller
+    # passes over one of them to reach a later positional argument.
+    port = int(args[2]) if len(args) > 2 and args[2] else debugpy.DEFAULT_PORT
+    dap_stream = args[3] if len(args) > 3 else None
+    # Anything other than the literal "loop" is refused rather than quietly
+    # read as false.
+    loop = args[4] if len(args) > 4 else ""
+    if loop not in ("", "loop"):
+        raise ValueError(f"loop argument must be 'loop' or empty, not {loop!r}")
+    if len(args) > 5:
         raise ValueError(
             "Too many arguments. Usage: mpy_launch_debugpy.py "
-            "[target_module] [target_method] [port] [dap_device]"
+            "[target_module] [target_method] [port] [dap_stream] [loop]"
         )
-    return target_module, target_method, port, dap_device
+    return target_module, target_method, port, dap_stream or None, loop == "loop"
+
+
+def _evict_target_modules(baseline):
+    """Drop from sys.modules everything the target's imports added.
+
+    The eviction set is defined by what the target pulled in, not by a list of
+    names to spare, so the debugger cannot be evicted out from under itself:
+    every module debugpy needs was imported before `baseline` was taken. It also
+    means a submodule of the target that changed is re-read along with it, which
+    a target-module-only eviction would miss.
+
+    Returns the evicted names, sorted, for the restart marker.
+    """
+    evicted = []
+    for name in list(sys.modules):
+        if name not in baseline:
+            del sys.modules[name]
+            evicted.append(name)
+    evicted.sort()
+    return evicted
+
+
+def _report(line, debugpy):
+    """Print a marker line to stdout and show it in the client's debug console.
+
+    Both, because neither reaches everyone on its own: a mounted serial session
+    discards everything the device prints, and a caller reading stdout may have
+    no DAP client of its own. The text is identical on both channels, so there
+    is one format to parse rather than two.
+    """
+    print(line)
+    debugpy.console(line + "\n")
+
+
+def _tracing_survived_unwind():
+    """True if sys.settrace still calls back after the unwind that just ran.
+
+    A firmware whose profiling hook leaves its recursion guard set when a trace
+    callback raises never invokes another callback, while sys.settrace() and
+    sys.gettrace() go on reporting success - so installing one and watching is
+    the only way to tell. Silence about that would mean every run after the
+    first restart binds no breakpoints at all, with nothing to see.
+
+    Only safe to call after an unwind: on an affected firmware tracing is
+    already gone by then, and on a sound one this leaves nothing behind.
+    """
+    calls = []
+
+    def _count(frame, event, arg):
+        calls.append(event)
+        return _count
+
+    def _probe():
+        return 1
+
+    sys.settrace(_count)
+    try:
+        _probe()
+    finally:
+        sys.settrace(None)
+    return bool(calls)
 
 
 def _run():
     import debugpy
 
-
     print(_banner)
     print("MicroPython VS Code Debugging")
-    print("Usage: mpy_launch_debugpy.py [target_module] [target_method] [port] [dap_device]")
+    print(
+        "Usage: mpy_launch_debugpy.py [target_module] [target_method] [port] [dap_stream] [loop]"
+    )
     print("==================================")
 
-    target_module, target_method, port, dap_device = _parse_args()
+    target_module, target_method, port, dap_stream, loop = _parse_args()
     print(f"Target module: {target_module}")
     print(f"Target method: {target_method}")
     print("==================================")
@@ -116,7 +202,11 @@ def _run():
         )
         return
 
-    stream = _detect_dap_stream(dap_device)
+    if loop:
+        # Before wait_for_client(), which is where `initialize` is answered.
+        debugpy.enable_restart()
+
+    stream = _detect_dap_stream(dap_stream)
     if stream is not None:
         debugpy.listen_stream(stream)
         actual_host, actual_port = "serial", 0
@@ -138,30 +228,77 @@ def _run():
         debugpy.disconnect()
         return
 
-    debugpy.debug_this_thread()
+    # Everything the debugger needs is imported by now, so nothing captured here
+    # is ever a candidate for eviction on a restart.
+    baseline_modules = set(sys.modules)
 
-    # Imported only once a client is configured: the module's top-level code
-    # runs on import, and it should run under the debugger with the client's
-    # breakpoints already in place, not before the session exists.
-    try:
-        target = __import__(target_module, None, None, ("*",))
-    except ImportError as e:
-        print(f"Error importing target module '{target_module}': {e}")
-        return
+    iteration = 0
+    while True:
+        iteration += 1
+        if iteration > 1:
+            evicted = _evict_target_modules(baseline_modules)
+            # A restart is NOT another MPDBG-READY: the endpoint has not
+            # changed and a caller that re-parsed one would think a second
+            # session had started.
+            _report(
+                "MPDBG-RESTART " + json.dumps({"iteration": iteration, "evicted": evicted}),
+                debugpy,
+            )
+            if not _tracing_survived_unwind():
+                _report(
+                    "MPDBG-DEGRADED sys.settrace stopped calling back after the unwind; "
+                    "this run has no breakpoints. The firmware needs the fix that clears "
+                    "the profiling recursion guard when a trace callback raises.",
+                    debugpy,
+                )
 
-    method = getattr(target, target_method, None)
-    if method is None:
-        print(f"Method '{target_method}' not found in module '{target_module}'")
-        return
+        # Traced from here to the end of the run and no further: the loop's own
+        # code must not be traced, or a restart handled while it waits below
+        # would unwind the loop itself. The unwind also drops the trace
+        # function (sys.settrace semantics), so this re-arms it each iteration.
+        debugpy.debug_this_thread()
+        restarting = False
+        try:
+            # Imported only once a client is configured: the module's top-level
+            # code runs on import, and it should run under the debugger with the
+            # client's breakpoints already in place, not before the session
+            # exists. On a later iteration the eviction above is what makes this
+            # re-read the file rather than hand back the cached module.
+            try:
+                target = __import__(target_module, None, None, ("*",))
+            except ImportError as e:
+                print(f"Error importing target module '{target_module}': {e}")
+                return
 
-    result = method()
+            method = getattr(target, target_method, None)
+            if method is None:
+                print(f"Method '{target_method}' not found in module '{target_module}'")
+                return
 
-    print("Target completed successfully!")
-    if result is None:
-        print("No result returned from target method")
-    else:
-        print("Result type:", type(result))
-        print("Result:", result)
+            result = method()
+        except debugpy.RestartRequest:
+            # The target was unwound part-way through on purpose; it has no
+            # result, and the next iteration is already asked for.
+            print("Target restarting")
+            restarting = True
+        finally:
+            sys.settrace(None)
+
+        if not restarting:
+            print("Target completed successfully!")
+            if result is None:
+                print("No result returned from target method")
+            else:
+                print("Result type:", type(result))
+                print("Result:", result)
+
+        if not loop:
+            return
+        if not restarting and not debugpy.wait_for_restart():
+            # No client left to restart for. Ending here rather than looping
+            # keeps a session whose client went away from spinning forever.
+            print("Debug client gone; not waiting for another restart")
+            return
 
 
 # Guarded so importing this module does not run device boot code: it ships as

--- a/tools/mpremote/mpremote/mpy_launch_debugpy.py
+++ b/tools/mpremote/mpremote/mpy_launch_debugpy.py
@@ -33,8 +33,10 @@ the handshake become `"serial"`/`0` and the `port` argument goes unused. A
 caller that asks for a stream and does not get one is told so: this never
 falls back to TCP behind the caller's back, because the caller has a bridge
 waiting on the stream and nothing listening on a port. `caps["repl_dap"]`
-reports whether this run split the REPL stream, which is the channel a board
-with one UART and no network has (see `docs/debugging.md`).
+reports whether this run split the REPL stream - a property of the session
+rather than of the build, and the channel a board with one UART and no
+network has. It is the only one that changes what the REPL itself can do
+while a session is live (see `docs/debugging.md`).
 
 `loop`, when the literal `"loop"`, keeps the process and the DAP session alive
 across re-runs of the target: the DAP `restart` request is advertised and

--- a/tools/mpremote/mpremote/mpy_launch_debugpy.py
+++ b/tools/mpremote/mpremote/mpy_launch_debugpy.py
@@ -27,11 +27,14 @@ client has finished configuring breakpoints, so breakpoints set before then
 are already applied by the time the target starts running.
 
 `dap_stream`, when given, moves the DAP channel off TCP and onto a byte
-stream: a path this runtime can open. `host`/`port` in the handshake then
-become `"serial"`/`0` and the `port` argument goes unused. A caller that asks
-for a stream and does not get one is told so: this never falls back to TCP
-behind the caller's back, because the caller has a bridge waiting on the
-stream and nothing listening on a port.
+stream: `"repl"` shares the stream this script was launched over, and
+anything else is a path this runtime can open. Either way `host`/`port` in
+the handshake become `"serial"`/`0` and the `port` argument goes unused. A
+caller that asks for a stream and does not get one is told so: this never
+falls back to TCP behind the caller's back, because the caller has a bridge
+waiting on the stream and nothing listening on a port. `caps["repl_dap"]`
+reports whether this run split the REPL stream, which is the channel a board
+with one UART and no network has (see `docs/debugging.md`).
 
 `loop`, when the literal `"loop"`, keeps the process and the DAP session alive
 across re-runs of the target: the DAP `restart` request is advertised and
@@ -80,17 +83,92 @@ def _detect_host():
     return addr
 
 
+# The dupterm slot the REPL occupies on the ports that put it in one. stm32
+# fixes it at 1 (`pyb_usb_vcp_init0`), and no other port currently has enough
+# slots for it to be anything else; a port that arrives with a different
+# arrangement has to be taught this rather than discovering it, since reading
+# every slot to find the busy one would displace whichever came first.
+_REPL_DUPTERM_SLOT = 1
+
+# Holds the one `ReplMux` for the length of a run that split the REPL stream,
+# empty otherwise. Two things read it: the handshake, for `caps["repl_dap"]`,
+# and the release at exit, which has to put the REPL back.
+_repl_mux = []
+
+
+def _repl_dap_stream():
+    """Split the REPL's own stream and return the DAP half.
+
+    The channel a board with one UART and no network has. What makes it
+    possible is that on some ports the runtime's console is a Python object in
+    a `dupterm` slot, so replacing it with a framing wrapper puts DAP on the
+    same wire and leaves program output on it too, marked apart. Where the
+    slot is empty the runtime writes to its console directly and no Python
+    object can intercept it, so this refuses rather than handing back a stream
+    that would carry nothing: rp2 and esp32 build one slot and the REPL is not
+    in it, and the unix port has no `dupterm` at all.
+
+    The REPL is displaced for the length of the session. On stm32, installing
+    anything in the slot detaches the interface from the REPL
+    (`usb_vcp_attach_to_repl(vcp, false)`), which stops the interrupt
+    character being scanned, so Ctrl-C reaches the target as data instead of
+    raising `KeyboardInterrupt`. `docs/debugging.md` states that trade-off.
+    """
+    import os
+
+    from debugpy.common import repl_mux
+
+    mux = repl_mux.ReplMux()
+    try:
+        previous = os.dupterm(mux.console, _REPL_DUPTERM_SLOT)
+    except (AttributeError, ValueError, OSError) as er:
+        raise OSError(f"this runtime cannot share the REPL stream: {er}")
+    if previous is None:
+        # An empty slot is not the REPL, and installing into it would have
+        # diverted nothing; put it back the way it was found.
+        os.dupterm(None, _REPL_DUPTERM_SLOT)
+        raise OSError(f"no REPL stream in dupterm slot {_REPL_DUPTERM_SLOT} to share")
+    mux.attach(previous)
+    _repl_mux.append(mux)
+    return mux.dap
+
+
+def _release_repl_stream():
+    """Put the REPL back, if this run took it. Safe to call when it did not.
+
+    Runs on every exit path, including a failed one: a board left with the
+    framing wrapper in the slot answers a plain REPL with escaped bytes, and
+    nothing short of a reset would clear it.
+    """
+    import os
+
+    while _repl_mux:
+        mux = _repl_mux.pop()
+        try:
+            port = mux.detach()
+            os.dupterm(port, _REPL_DUPTERM_SLOT)
+        except Exception:
+            pass
+
+
 def _detect_dap_stream(spec=None):
     """Return an open reader/writer stream for the DAP channel, or None for TCP.
 
-    `spec` is the caller's choice of channel: `None` for TCP, or a path this
+    `spec` is the caller's choice of channel: `None` for TCP, `"repl"` for
+    a share of the stream this script was launched over, or a path this
     runtime can open directly (what the unix port has instead of a USB
     interface). Failing to produce the requested stream raises rather than
     returning None, so the caller never gets a TCP endpoint it has no client
     for.
+
+    `caps["repl_dap"]` is derived from which channel `_run()` actually picked
+    (see `debugpy.get_capabilities()`), never guessed here, so the two cannot
+    disagree.
     """
     if spec is None:
         return None
+    if spec == "repl":
+        return _repl_dap_stream()
     try:
         return open(spec, "r+b")
     except OSError as er:
@@ -230,7 +308,11 @@ def _run():
         actual_host, actual_port = debugpy.listen(host=host, port=port)
     print(f"Debug server listening on {actual_host}:{actual_port}")
 
-    caps = debugpy.get_capabilities()
+    # `.copy()` first: with a session live `get_capabilities()` hands back the
+    # session's own dict, and the second CDC is not the debug server's to
+    # report - it is USB topology, which only the boot script can see.
+    caps = debugpy.get_capabilities().copy()
+    caps["repl_dap"] = bool(_repl_mux)
     # Exactly one MPDBG-READY line, valid JSON, nothing else on this line.
     print("MPDBG-READY " + json.dumps({"host": actual_host, "port": actual_port, "caps": caps}))
 
@@ -328,4 +410,8 @@ if __name__ == "__main__":
         print("\nTest interrupted by user")
     except Exception as e:
         print(f"Error: {e}")
+    finally:
+        # Last, and after the prints above, so anything they said still goes
+        # out through the framing the host is still reading.
+        _release_repl_stream()
 # fmt: on

--- a/tools/mpremote/mpremote/mpy_launch_debugpy.py
+++ b/tools/mpremote/mpremote/mpy_launch_debugpy.py
@@ -4,7 +4,7 @@
 # routine reformat in either repo can't silently break the copies apart.
 """Single parameterised boot script for MicroPython debugpy sessions.
 
-Usage: mpy_launch_debugpy.py [target_module] [target_method] [port]
+Usage: mpy_launch_debugpy.py [target_module] [target_method] [port] [dap_device]
 
 The bind address is probed at runtime rather than passed in: boards with a
 `network` module report their own address, everything else binds all
@@ -21,6 +21,12 @@ Tooling parses that one line rather than any of the human-readable banner
 text around it. `wait_for_client()` (not a fixed sleep) blocks until the DAP
 client has finished configuring breakpoints, so breakpoints set before then
 are already applied by the time the target starts running.
+
+When `dap_stream` names a path this runtime can open, the session runs over
+that stream instead of TCP (`host`/`port` in the handshake become
+`"serial"`/`0`, and the `port` argument is unused). A caller that asks for a
+stream and does not get one is told so rather than quietly given a TCP
+endpoint it has no client for.
 """
 
 import json
@@ -57,6 +63,23 @@ def _detect_host():
     return addr
 
 
+def _detect_dap_stream(spec=None):
+    """Return an open reader/writer stream for the DAP channel, or None for TCP.
+
+    `spec`, when given, is a path this runtime can open directly - what the
+    unix port has instead of a USB interface. With no `spec` this returns
+    `None` and `_run()` falls back to `debugpy.listen()` over TCP. Failing to
+    produce a stream that was asked for raises rather than returning None, so
+    the caller never gets a TCP endpoint it has no client for.
+    """
+    if spec is None:
+        return None
+    try:
+        return open(spec, "r+b")
+    except OSError as er:
+        raise OSError(f"dap_stream {spec!r} could not be opened: {er}")
+
+
 def _parse_args():
     import debugpy
 
@@ -64,12 +87,13 @@ def _parse_args():
     target_module = args[0] if len(args) > 0 else "target"
     target_method = args[1] if len(args) > 1 else "main"
     port = int(args[2]) if len(args) > 2 else debugpy.DEFAULT_PORT
-    if len(args) > 3:
+    dap_device = args[3] if len(args) > 3 else None
+    if len(args) > 4:
         raise ValueError(
             "Too many arguments. Usage: mpy_launch_debugpy.py "
-            "[target_module] [target_method] [port]"
+            "[target_module] [target_method] [port] [dap_device]"
         )
-    return target_module, target_method, port
+    return target_module, target_method, port, dap_device
 
 
 def _run():
@@ -78,10 +102,10 @@ def _run():
 
     print(_banner)
     print("MicroPython VS Code Debugging")
-    print("Usage: mpy_launch_debugpy.py [target_module] [target_method] [port]")
+    print("Usage: mpy_launch_debugpy.py [target_module] [target_method] [port] [dap_device]")
     print("==================================")
 
-    target_module, target_method, port = _parse_args()
+    target_module, target_method, port, dap_device = _parse_args()
     print(f"Target module: {target_module}")
     print(f"Target method: {target_method}")
     print("==================================")
@@ -92,8 +116,13 @@ def _run():
         )
         return
 
-    host = _detect_host()
-    actual_host, actual_port = debugpy.listen(host=host, port=port)
+    stream = _detect_dap_stream(dap_device)
+    if stream is not None:
+        debugpy.listen_stream(stream)
+        actual_host, actual_port = "serial", 0
+    else:
+        host = _detect_host()
+        actual_host, actual_port = debugpy.listen(host=host, port=port)
     print(f"Debug server listening on {actual_host}:{actual_port}")
 
     caps = debugpy.get_capabilities()

--- a/tools/mpremote/mpremote/mpy_launch_debugpy.py
+++ b/tools/mpremote/mpremote/mpy_launch_debugpy.py
@@ -1,0 +1,150 @@
+# fmt: off
+# This file is vendored byte-for-byte between repos with different ruff
+# line-length settings; `ruff format` must leave it alone everywhere so a
+# routine reformat in either repo can't silently break the copies apart.
+"""Single parameterised boot script for MicroPython debugpy sessions.
+
+Usage: mpy_launch_debugpy.py [target_module] [target_method] [port]
+
+The bind address is probed at runtime rather than passed in: boards with a
+`network` module report their own address, everything else binds all
+interfaces. No device IP is hardcoded by the caller; the port, if given, is
+supplied by the caller (0 is rejected by `debugpy.listen()` on every current
+MicroPython port, since none implements `socket.getsockname()`). The actual
+bound endpoint plus the probed firmware capabilities are reported in a
+single machine-readable handshake line on stdout, printed as soon as the
+socket is bound and before any client has attached:
+
+    MPDBG-READY {"host": "...", "port": ..., "caps": {...}}
+
+Tooling parses that one line rather than any of the human-readable banner
+text around it. `wait_for_client()` (not a fixed sleep) blocks until the DAP
+client has finished configuring breakpoints, so breakpoints set before then
+are already applied by the time the target starts running.
+"""
+
+import json
+import sys
+
+_banner = r"""
+ _____  _______ ______ _______ _______ ______ ___ ___
+|     \|    ___|   __ \   |   |     __|   __ \   |   |
+|  --  |    ___|   __ <   |   |    |  |    __/\     /
+|_____/|_______|______/_______|_______|___|    |___|
+"""
+
+
+def _detect_host():
+    """Return the address debugpy should bind to on this runtime.
+
+    Boards with a `network` module report their own DHCP/WiFi address so
+    tooling never has to guess or hardcode a device IP. The unix port has no
+    `network` module, and a board with `network` but no configured/connected
+    interface has no address to report either - both cases, and any error
+    while probing, fall back to binding all interfaces so a network probe
+    failure never aborts the launch.
+    """
+    try:
+        import network
+
+        wlan = network.WLAN(network.STA_IF)
+        addr = wlan.ipconfig("addr4")[0]
+    except Exception:
+        return "0.0.0.0"
+
+    if not addr or addr == "0.0.0.0":
+        return "0.0.0.0"
+    return addr
+
+
+def _parse_args():
+    import debugpy
+
+    args = sys.argv[1:]
+    target_module = args[0] if len(args) > 0 else "target"
+    target_method = args[1] if len(args) > 1 else "main"
+    port = int(args[2]) if len(args) > 2 else debugpy.DEFAULT_PORT
+    if len(args) > 3:
+        raise ValueError(
+            "Too many arguments. Usage: mpy_launch_debugpy.py "
+            "[target_module] [target_method] [port]"
+        )
+    return target_module, target_method, port
+
+
+def _run():
+    import debugpy
+
+
+    print(_banner)
+    print("MicroPython VS Code Debugging")
+    print("Usage: mpy_launch_debugpy.py [target_module] [target_method] [port]")
+    print("==================================")
+
+    target_module, target_method, port = _parse_args()
+    print(f"Target module: {target_module}")
+    print(f"Target method: {target_method}")
+    print("==================================")
+
+    if not hasattr(sys, "settrace"):
+        print(
+            "sys.settrace is not available. You need a firmware compiled with debugging features."
+        )
+        return
+
+    host = _detect_host()
+    actual_host, actual_port = debugpy.listen(host=host, port=port)
+    print(f"Debug server listening on {actual_host}:{actual_port}")
+
+    caps = debugpy.get_capabilities()
+    # Exactly one MPDBG-READY line, valid JSON, nothing else on this line.
+    print("MPDBG-READY " + json.dumps({"host": actual_host, "port": actual_port, "caps": caps}))
+
+    print("Waiting for the client to finish configuring (configurationDone)...")
+    if not debugpy.wait_for_client():
+        print(
+            "[DAP] No client finished configuring (timed out or disconnected) - "
+            "not running the target under a dead debug session."
+        )
+        debugpy.disconnect()
+        return
+
+    debugpy.debug_this_thread()
+
+    # Imported only once a client is configured: the module's top-level code
+    # runs on import, and it should run under the debugger with the client's
+    # breakpoints already in place, not before the session exists.
+    try:
+        target = __import__(target_module, None, None, ("*",))
+    except ImportError as e:
+        print(f"Error importing target module '{target_module}': {e}")
+        return
+
+    method = getattr(target, target_method, None)
+    if method is None:
+        print(f"Method '{target_method}' not found in module '{target_module}'")
+        return
+
+    result = method()
+
+    print("Target completed successfully!")
+    if result is None:
+        print("No result returned from target method")
+    else:
+        print("Result type:", type(result))
+        print("Result:", result)
+
+
+# Guarded so importing this module does not run device boot code: it ships as
+# a resource inside the mpremote package, where a package walk or autodoc pass
+# would otherwise execute it on the host. Both real invocations - `micropython
+# mpy_launch_debugpy.py ...` and the raw-REPL exec mpremote performs - run it
+# as __main__.
+if __name__ == "__main__":
+    try:
+        _run()
+    except KeyboardInterrupt:
+        print("\nTest interrupted by user")
+    except Exception as e:
+        print(f"Error: {e}")
+# fmt: on

--- a/tools/mpremote/mpremote/repl_dap.py
+++ b/tools/mpremote/mpremote/repl_dap.py
@@ -1,0 +1,342 @@
+"""Host end of the DAP channel that shares the REPL's own serial stream.
+
+For a board with one UART and no network there is nothing else to put the
+debug channel on, so it rides the stream that already carries the REPL,
+marked with `0x18` the way `mpremote mount` marks its filesystem RPC. The
+wire is described once, in the device's `debugpy/common/repl_mux.py`; this is
+the same protocol read and written from the host, and the constants below are
+that module's constants. They are duplicated rather than imported because
+`mpremote` cannot depend on a `micropython-lib` package being present on the
+machine it runs on; a test in the integration repo feeds identical byte
+streams to both implementations, so the two cannot drift silently.
+
+The port is read by one thread from the moment the channel opens, not from
+the moment a DAP client connects: the program's output belongs on the
+terminal whether or not anything is attached, and it is also how a traceback
+from the debug server itself is seen at all.
+"""
+
+import errno
+import sys
+import threading
+
+from .dap_log import PumpingProxy
+
+MARKER = 0x18
+_MARKER_B = bytes((MARKER,))
+
+# `fs_hook_cmds` in transport_serial.py owns 1..13.
+CMD_DAP = 14
+CMD_DAP_ACK = 15
+# The device saying the DAP channel is over. A serial port has no EOF of its
+# own, so without this a finished session reads exactly like an idle one.
+CMD_DAP_EOF = 16
+
+RX_CREDIT = 192
+MAX_PAYLOAD = 128  # capped so one frame always fits inside the credit window
+ACK_THRESHOLD = 64
+
+
+def frame(code, payload):
+    """One framed message: marker, code, two-byte length, payload."""
+    n = len(payload)
+    return bytes((MARKER, code, n & 0xFF, (n >> 8) & 0xFF)) + bytes(payload)
+
+
+def _consume(buf, n):
+    """Drop the first `n` bytes of `buf`, in place.
+
+    Spelled the way the device's copy has to spell it: `del buf[:n]` works
+    here and raises on a MicroPython bytearray, which implements slice
+    assignment but not slice deletion, and the two readers are kept
+    line-for-line comparable.
+    """
+    if n >= len(buf):
+        buf[:] = b""
+    else:
+        buf[:] = buf[n:]
+
+
+def escape(data):
+    """Plain bytes with the marker doubled, so a reader never mistakes one."""
+    data = bytes(data)
+    if data.find(_MARKER_B) < 0:
+        return data
+    return data.replace(_MARKER_B, bytes((MARKER, MARKER)))
+
+
+class Demux:
+    """Reads the marker-framed wire into plain bytes and framed payload.
+
+    Incremental: a marker, a length or a payload split across two reads
+    resumes where it left off, which is the normal case on a serial port that
+    delivers whatever a USB packet happened to contain. `unknown_code` records
+    the first code with no handler, which means the two ends disagree about
+    the protocol and every later byte is suspect.
+    """
+
+    _PLAIN, _CODE, _LEN0, _LEN1, _BODY = 0, 1, 2, 3, 4
+
+    def __init__(self):
+        self.plain = bytearray()
+        self.dap = bytearray()
+        self.credited = 0
+        self.eof = False
+        self.unknown_code = None
+        self._state = self._PLAIN
+        self._code = 0
+        self._need = 0
+        self._body = bytearray()
+
+    def feed(self, data):
+        data = bytes(data)
+        i = 0
+        end = len(data)
+        while i < end:
+            if self._state == self._PLAIN:
+                j = data.find(_MARKER_B, i)
+                if j < 0:
+                    self.plain += data[i:]
+                    return
+                self.plain += data[i:j]
+                i = j + 1
+                self._state = self._CODE
+                continue
+
+            c = data[i]
+            i += 1
+            if self._state == self._CODE:
+                if c == MARKER:
+                    self.plain.append(MARKER)  # escaped literal
+                    self._state = self._PLAIN
+                else:
+                    self._code = c
+                    self._state = self._LEN0
+            elif self._state == self._LEN0:
+                self._need = c
+                self._state = self._LEN1
+            elif self._state == self._LEN1:
+                self._need |= c << 8
+                self._body = bytearray()
+                self._state = self._BODY if self._need else self._PLAIN
+                if not self._need:
+                    self._deliver()
+            else:  # _BODY
+                self._body.append(c)
+                if len(self._body) == self._need:
+                    self._deliver()
+                    self._state = self._PLAIN
+
+    def _deliver(self):
+        if self._code == CMD_DAP:
+            self.dap += self._body
+        elif self._code == CMD_DAP_ACK:
+            if len(self._body) >= 2:
+                self.credited += self._body[0] | (self._body[1] << 8)
+        elif self._code == CMD_DAP_EOF:
+            self.eof = True
+        elif self.unknown_code is None:
+            self.unknown_code = self._code
+
+    def take_plain(self, n):
+        out = bytes(self.plain[:n])
+        _consume(self.plain, len(out))
+        return out
+
+    def take_dap(self, n):
+        out = bytes(self.dap[:n])
+        _consume(self.dap, len(out))
+        return out
+
+
+class ReplDapChannel:
+    """Owns the shared serial port for the length of a debug session.
+
+    One reader thread demultiplexes the port: plain bytes go to `console`
+    (mpremote's stdout, so a program's `print()` lands where it would without
+    a debugger), framed bytes queue for whoever is bridging DAP. Writes are
+    credit-limited, because the device's receive ring discards the tail of a
+    packet when it overflows rather than exerting back-pressure, and a target
+    inside `time.sleep()` is not draining it.
+
+    Nothing else may read the port while this is open. That holds for the
+    `repl` channel by construction - a mount is refused on it, and the
+    handshake has already been read by the time the channel opens.
+    """
+
+    _POLL_TIMEOUT = 0.2  # seconds; caps how long close() takes to be noticed
+
+    def __init__(self, serial, console=None):
+        self._serial = serial
+        self._console = console
+        self._demux = Demux()
+        self._lock = threading.Lock()
+        self._arrived = threading.Condition(self._lock)
+        self._sent = 0  # wire bytes written
+        self._closed = False
+        self.error = None  # the exception that ended the reader, if one did
+        self._serial.timeout = self._POLL_TIMEOUT
+        self._thread = threading.Thread(
+            target=self._read_loop, name="repl-dap-reader", daemon=True
+        )
+
+    def start(self):
+        self._thread.start()
+
+    def close(self):
+        with self._lock:
+            self._closed = True
+            self._arrived.notify_all()
+        if self._thread.is_alive():
+            self._thread.join(timeout=self._POLL_TIMEOUT * 5)
+
+    # -- reader -----------------------------------------------------------
+
+    def _write_console(self, data):
+        if not data:
+            return
+        if self._console is not None:
+            self._console(data)
+        else:
+            sys.stdout.buffer.write(data)
+            sys.stdout.buffer.flush()
+
+    def _read_loop(self):
+        while not self._closed:
+            try:
+                # Wait for one byte with the port's timeout, then take
+                # whatever else is already buffered without waiting for more:
+                # asking for a fixed count up front would pay the whole
+                # timeout on every read, since a frame is essentially never
+                # exactly that many bytes. `_SerialDuplex.recv` reads the same
+                # way and for the same reason.
+                chunk = self._serial.read(1)
+                if chunk:
+                    chunk += self._serial.read(self._serial.in_waiting)
+            except Exception as er:  # pyserial raises several shapes on a lost port
+                if not self._closed:
+                    self.error = er
+                with self._arrived:
+                    self._arrived.notify_all()
+                return
+            if not chunk:
+                continue
+            with self._lock:
+                self._demux.feed(chunk)
+                plain = self._demux.take_plain(len(self._demux.plain))
+                self._arrived.notify_all()
+            # Outside the lock: a slow terminal must not hold up the reader,
+            # and nothing in here touches the demux.
+            self._write_console(plain)
+
+    # -- DAP side ---------------------------------------------------------
+
+    def read_dap(self, n):
+        """Up to `n` bytes of DAP payload, or `b""` once the channel is over.
+
+        Over means one of three things: this end closed it, the port stopped
+        being readable, or the device sent `CMD_DAP_EOF`. The queued payload
+        is drained before any of them is reported, so an end-of-session frame
+        can never discard a response that arrived in the same read.
+        """
+        with self._arrived:
+            while True:
+                if self._demux.dap:
+                    return self._demux.take_dap(n)
+                if self._closed or self.error is not None or self._demux.eof:
+                    return b""
+                self._arrived.wait(self._POLL_TIMEOUT)
+
+    def write_dap(self, data):
+        """Frame `data` onto the port, waiting for credit rather than overrunning.
+
+        The only thing this end writes to the port, which is what makes
+        `_sent` comparable with the byte count the device credits back: the
+        device counts everything it reads, so anything written around this
+        method would be credited without ever having been charged.
+        """
+        data = bytes(data)
+        for i in range(0, len(data), MAX_PAYLOAD):
+            chunk = frame(CMD_DAP, data[i : i + MAX_PAYLOAD])
+            self._await_credit(len(chunk))
+            if self._closed or self._demux.eof:
+                raise OSError(errno.EPIPE, "repl DAP channel closed")
+            if self.error is not None:
+                raise OSError(errno.EIO, f"repl DAP channel is not readable: {self.error}")
+            self._serial.write(chunk)
+            with self._lock:
+                self._sent += len(chunk)
+
+    def _await_credit(self, n):
+        """Wait until `n` more wire bytes fit inside the outstanding-byte window.
+
+        `MAX_PAYLOAD` is capped so that one frame always fits an empty window;
+        without that a large enough frame would wait for credit only its own
+        unsent bytes could ever earn.
+        """
+        with self._arrived:
+            while not self._closed and self.error is None and not self._demux.eof:
+                if self._sent - self._demux.credited + n <= RX_CREDIT:
+                    return
+                self._arrived.wait(self._POLL_TIMEOUT)
+
+    @property
+    def unknown_code(self):
+        return self._demux.unknown_code
+
+    @property
+    def finished(self):
+        """True once the device's end is over, however it ended.
+
+        Read by the caller's wait loop, which otherwise only learns a session
+        has ended through the client that attached to it - and a device can
+        finish before one ever does.
+        """
+        return self._demux.eof or self.error is not None
+
+
+class _ChannelDuplex:
+    """Presents `ReplDapChannel` as the connected target `PumpingProxy` expects.
+
+    The four methods the pump code uses - `recv`/`sendall`/`shutdown`/`close` -
+    over a channel that outlives any one client, so `close()` here ends the
+    client's view of the session without tearing down the port the console is
+    still being read from.
+    """
+
+    def __init__(self, channel):
+        self._channel = channel
+        self._shut = False
+
+    def recv(self, n):
+        if self._shut:
+            return b""
+        return self._channel.read_dap(n)
+
+    def sendall(self, data):
+        self._channel.write_dap(data)
+
+    def shutdown(self, how=None):
+        self._shut = True
+
+    def close(self):
+        self._shut = True
+
+
+class ReplDapBridge(PumpingProxy):
+    """Bridges a localhost DAP client onto the REPL stream's framed channel.
+
+    A client attaches over plain TCP and never
+    learns that the other side is a serial port. The difference is that the
+    port is not a second device node but the one `mpremote` is already holding,
+    so the channel is opened by the caller and outlives this bridge.
+    """
+
+    def __init__(self, channel, logger, bind_host="127.0.0.1", bind_port=0):
+        super().__init__(logger, bind_host=bind_host, bind_port=bind_port)
+        self._channel = channel
+
+    def _connect_target(self):
+        if self._channel.error is not None:
+            raise OSError(errno.EIO, f"repl DAP channel is not readable: {self._channel.error}")
+        return _ChannelDuplex(self._channel)

--- a/tools/mpremote/mpremote/repl_dap.py
+++ b/tools/mpremote/mpremote/repl_dap.py
@@ -208,8 +208,7 @@ class ReplDapChannel:
                 # whatever else is already buffered without waiting for more:
                 # asking for a fixed count up front would pay the whole
                 # timeout on every read, since a frame is essentially never
-                # exactly that many bytes. `_SerialDuplex.recv` reads the same
-                # way and for the same reason.
+                # exactly that many bytes.
                 chunk = self._serial.read(1)
                 if chunk:
                     chunk += self._serial.read(self._serial.in_waiting)

--- a/tools/mpremote/mpremote/serial_dap.py
+++ b/tools/mpremote/mpremote/serial_dap.py
@@ -1,0 +1,119 @@
+"""Localhost<->serial bridge for `mpremote debug` on multi-CDC boards.
+
+On a board with a dedicated second USB CDC interface for DAP (`serial_dap`
+in the MPDBG-READY `caps`), the device's debug channel is never a TCP
+socket - it's a second serial device node, opened directly instead of
+connected to over the network. `SerialDapBridge` is a `dap_log.PumpingProxy`
+whose target is that node rather than (host, port): a DAP client still
+attaches over plain localhost TCP, unaware the other side of the bridge is
+serial.
+"""
+
+import errno
+
+import serial
+
+from .dap_log import PumpingProxy
+
+# Native-USB CDC ACM interfaces don't have a meaningful line speed - the
+# firmware doesn't gate on it - but pyserial requires some value be set.
+DEFAULT_BAUDRATE = 115200
+
+
+def check_device(device, baudrate=DEFAULT_BAUDRATE):
+    """Open and immediately close `device`, raising `OSError` if it can't be opened.
+
+    `SerialDapBridge` itself only opens the device lazily on first client
+    connect, so a bad `dap_device` (typo, unplugged board) would otherwise
+    surface as a session-in-progress failure reported as a lost connection
+    ("board reset?") rather than the config error it actually is. Call this
+    before reporting the bridge's endpoint to a caller.
+    """
+    serial.serial_for_url(device, baudrate=baudrate).close()
+
+
+class _SerialDuplex:
+    """Wraps a pyserial connection so it duck-types a connected socket.
+
+    `PumpingProxy`'s pump threads only ever call `recv`/`sendall`/`shutdown`/
+    `close` on the target - matching those four methods is what lets a
+    serial connection stand in for `socket.create_connection`'s result
+    without the pump code caring which one it has.
+
+    A serial port has no independent-direction close the way a TCP socket's
+    `shutdown(SHUT_RDWR)` does, and pyserial's blocking `read()` isn't
+    reliably interrupted by another thread closing the port under it. So the
+    port is opened with a short read timeout and `recv()` loops on it,
+    rechecking `_closed` each time instead of blocking indefinitely -
+    `shutdown()` just sets that flag, and the read in flight (bounded by
+    `_POLL_TIMEOUT`) returns empty and lets the loop notice within one poll.
+
+    `close()` running concurrently with a `read()`/`write()` already past
+    that check is still possible within one poll window: pyserial's `close()`
+    sets its internal fd to `None` rather than making the next syscall raise,
+    so a read/write already inside pyserial can hit `os.read(None, ...)` and
+    raise `TypeError`, not `OSError` - `_reraise_as_oserror` gives that the
+    same shape every other "the port is gone" case already has, which is
+    what `PumpingProxy._pump`'s `except OSError` is written against.
+    """
+
+    _POLL_TIMEOUT = 0.2  # seconds; caps how long shutdown()/close() take to be noticed
+
+    def __init__(self, device, baudrate):
+        self._serial = serial.serial_for_url(device, baudrate=baudrate, timeout=self._POLL_TIMEOUT)
+        self._closed = False
+
+    @staticmethod
+    def _reraise_as_oserror(er):
+        raise OSError(errno.EBADF, "serial port closed during I/O") from er
+
+    def recv(self, n):
+        # pyserial's read(size) blocks for the full port timeout unless
+        # `size` bytes arrive - a DAP frame is essentially never exactly
+        # `n` (4096) bytes, so requesting `n` up front would pay the whole
+        # `_POLL_TIMEOUT` on every call. Wait for one byte with the port's
+        # timeout, then take whatever else is already buffered
+        # (non-blocking) instead of waiting for more.
+        while not self._closed:
+            try:
+                chunk = self._serial.read(1)
+                if chunk:
+                    chunk += self._serial.read(self._serial.in_waiting)
+            except TypeError as er:
+                self._reraise_as_oserror(er)
+            if chunk:
+                return chunk
+        return b""
+
+    def sendall(self, data):
+        try:
+            self._serial.write(data)
+        except TypeError as er:
+            self._reraise_as_oserror(er)
+
+    def shutdown(self, how=None):
+        self._closed = True
+
+    def close(self):
+        self._closed = True
+        self._serial.close()
+
+
+class SerialDapBridge(PumpingProxy):
+    """`PumpingProxy` forwarding to a serial device instead of a TCP endpoint.
+
+    `device` is opened lazily, once a client has connected (`_connect_target`,
+    called from the accept thread) - not in `__init__` - matching `DapProxy`,
+    which doesn't dial its TCP target until then either, and keeping the
+    device node untouched if no client ever attaches.
+    """
+
+    def __init__(
+        self, device, logger, baudrate=DEFAULT_BAUDRATE, bind_host="127.0.0.1", bind_port=0
+    ):
+        super().__init__(logger, bind_host, bind_port)
+        self._device = device
+        self._baudrate = baudrate
+
+    def _connect_target(self):
+        return _SerialDuplex(self._device, self._baudrate)

--- a/tools/mpremote/mpremote/transport_serial.py
+++ b/tools/mpremote/mpremote/transport_serial.py
@@ -133,13 +133,29 @@ class SerialTransport(Transport):
         self.serial.close()
 
     def read_until(
-        self, min_num_bytes, ending, timeout=10, data_consumer=None, timeout_overall=None
+        self,
+        min_num_bytes,
+        ending,
+        timeout=10,
+        data_consumer=None,
+        timeout_overall=None,
+        timeout_overall_strict=False,
     ):
         """
         min_num_bytes: Obsolete.
         ending: Return if 'ending' matches.
         timeout [s]: Return if timeout between characters. None: Infinite timeout.
         timeout_overall [s]: Return not later than timeout_overall. None: Infinite timeout.
+        timeout_overall_strict: When False (the default, and every pre-existing
+            caller's behaviour), timeout_overall is only consulted once the peer
+            goes quiet - a peer that keeps producing bytes right up to the
+            deadline and past it is not cut off, which is what a verbose
+            board's boot-time printing relies on. When True, timeout_overall
+            is consulted every iteration regardless of how much data is still
+            arriving, so a caller that genuinely needs a hard wall-clock bound
+            (a mounted transport's filesystem RPC pump, the debug handshake
+            scan - both read from a peer that may stream continuously for the
+            whole session) gets one.
         data_consumer: Use callback for incoming characters.
             If data_consumer is used then data is not accumulated and the ending must be 1 byte long
 
@@ -163,6 +179,12 @@ class SerialTransport(Transport):
             while True:
                 if data.endswith(ending):
                     break
+                if (
+                    timeout_overall_strict
+                    and timeout_overall is not None
+                    and time.monotonic() >= begin_overall_s + timeout_overall
+                ):
+                    break
                 new_data = None
                 if self.is_pty or self.serial.inWaiting() > 0:
                     new_data = self.serial.read(1)
@@ -176,18 +198,13 @@ class SerialTransport(Transport):
                 else:
                     if timeout is not None and time.monotonic() >= begin_char_s + timeout:
                         break
-                    if (
-                        timeout_overall is not None
-                        and time.monotonic() >= begin_overall_s + timeout_overall
-                    ):
-                        break
                     time.sleep(0.01)
             return data
         finally:
             if self.is_pty:
                 self.serial.timeout = saved_timeout
 
-    def enter_raw_repl(self, soft_reset=True, timeout_overall=10):
+    def enter_raw_repl(self, soft_reset=True, timeout_overall=10, timeout_overall_strict=False):
         self.serial.write(b"\r\x03")  # ctrl-C: interrupt any running program
 
         # flush input (without relying on serial.flushInput())
@@ -200,7 +217,10 @@ class SerialTransport(Transport):
 
         if soft_reset:
             data = self.read_until(
-                1, b"raw REPL; CTRL-B to exit\r\n>", timeout_overall=timeout_overall
+                1,
+                b"raw REPL; CTRL-B to exit\r\n>",
+                timeout_overall=timeout_overall,
+                timeout_overall_strict=timeout_overall_strict,
             )
             if not data.endswith(b"raw REPL; CTRL-B to exit\r\n>"):
                 print(data)
@@ -211,12 +231,22 @@ class SerialTransport(Transport):
             # Waiting for "soft reboot" independently to "raw REPL" (done below)
             # allows boot.py to print, which will show up after "soft reboot"
             # and before "raw REPL".
-            data = self.read_until(1, b"soft reboot\r\n", timeout_overall=timeout_overall)
+            data = self.read_until(
+                1,
+                b"soft reboot\r\n",
+                timeout_overall=timeout_overall,
+                timeout_overall_strict=timeout_overall_strict,
+            )
             if not data.endswith(b"soft reboot\r\n"):
                 print(data)
                 raise TransportError("could not enter raw repl")
 
-        data = self.read_until(1, b"raw REPL; CTRL-B to exit\r\n", timeout_overall=timeout_overall)
+        data = self.read_until(
+            1,
+            b"raw REPL; CTRL-B to exit\r\n",
+            timeout_overall=timeout_overall,
+            timeout_overall_strict=timeout_overall_strict,
+        )
         if not data.endswith(b"raw REPL; CTRL-B to exit\r\n"):
             print(data)
             raise TransportError("could not enter raw repl")
@@ -227,15 +257,30 @@ class SerialTransport(Transport):
         self.serial.write(b"\r\x02")  # ctrl-B: enter friendly REPL
         self.in_raw_repl = False
 
-    def follow(self, timeout, data_consumer=None):
+    def follow(
+        self, timeout, data_consumer=None, timeout_overall=None, timeout_overall_strict=False
+    ):
         # wait for normal output
-        data = self.read_until(1, b"\x04", timeout=timeout, data_consumer=data_consumer)
+        data = self.read_until(
+            1,
+            b"\x04",
+            timeout=timeout,
+            data_consumer=data_consumer,
+            timeout_overall=timeout_overall,
+            timeout_overall_strict=timeout_overall_strict,
+        )
         if not data.endswith(b"\x04"):
             raise TransportError("timeout waiting for first EOF reception")
         data = data[:-1]
 
         # wait for error output
-        data_err = self.read_until(1, b"\x04", timeout=timeout)
+        data_err = self.read_until(
+            1,
+            b"\x04",
+            timeout=timeout,
+            timeout_overall=timeout_overall,
+            timeout_overall_strict=timeout_overall_strict,
+        )
         if not data_err.endswith(b"\x04"):
             raise TransportError("timeout waiting for second EOF reception")
         data_err = data_err[:-1]
@@ -278,14 +323,16 @@ class SerialTransport(Transport):
         if not data.endswith(b"\x04"):
             raise TransportError("could not complete raw paste: {}".format(data))
 
-    def exec_raw_no_follow(self, command):
+    def exec_raw_no_follow(self, command, timeout_overall=None, timeout_overall_strict=False):
         if isinstance(command, bytes):
             command_bytes = command
         else:
             command_bytes = bytes(command, encoding="utf8")
 
         # check we have a prompt
-        data = self.read_until(1, b">")
+        data = self.read_until(
+            1, b">", timeout_overall=timeout_overall, timeout_overall_strict=timeout_overall_strict
+        )
         if not data.endswith(b">"):
             raise TransportError("could not enter raw repl")
 
@@ -301,7 +348,12 @@ class SerialTransport(Transport):
                 return self.raw_paste_write(command_bytes)
             else:
                 # Device doesn't support raw-paste, fall back to normal raw REPL.
-                data = self.read_until(1, b"w REPL; CTRL-B to exit\r\n>")
+                data = self.read_until(
+                    1,
+                    b"w REPL; CTRL-B to exit\r\n>",
+                    timeout_overall=timeout_overall,
+                    timeout_overall_strict=timeout_overall_strict,
+                )
                 if not data.endswith(b"w REPL; CTRL-B to exit\r\n>"):
                     print(data)
                     raise TransportError("could not enter raw repl")
@@ -319,9 +371,23 @@ class SerialTransport(Transport):
         if data != b"OK":
             raise TransportError("could not exec command (response: %r)" % data)
 
-    def exec_raw(self, command, timeout=10, data_consumer=None):
-        self.exec_raw_no_follow(command)
-        return self.follow(timeout, data_consumer)
+    def exec_raw(
+        self,
+        command,
+        timeout=10,
+        data_consumer=None,
+        timeout_overall=None,
+        timeout_overall_strict=False,
+    ):
+        self.exec_raw_no_follow(
+            command, timeout_overall=timeout_overall, timeout_overall_strict=timeout_overall_strict
+        )
+        return self.follow(
+            timeout,
+            data_consumer,
+            timeout_overall=timeout_overall,
+            timeout_overall_strict=timeout_overall_strict,
+        )
 
     def eval(self, expression, parse=True):
         if parse:
@@ -333,8 +399,15 @@ class SerialTransport(Transport):
             ret = ret.strip()
             return ret
 
-    def exec(self, command, data_consumer=None):
-        ret, ret_err = self.exec_raw(command, data_consumer=data_consumer)
+    def exec(
+        self, command, data_consumer=None, timeout_overall=None, timeout_overall_strict=False
+    ):
+        ret, ret_err = self.exec_raw(
+            command,
+            data_consumer=data_consumer,
+            timeout_overall=timeout_overall,
+            timeout_overall_strict=timeout_overall_strict,
+        )
         if ret_err:
             raise TransportExecError(ret, ret_err.decode())
         return ret
@@ -442,11 +515,20 @@ class SerialTransport(Transport):
         out_callback(prompt)
         self.serial = SerialIntercept(self.serial, self.cmd)
 
-    def umount_local(self):
+    def umount_local(self, timeout_overall=None, timeout_overall_strict=False):
         if self.mounted:
-            self.exec(f'os.umount("{self.fs_hook_mount}")')
+            self.exec(
+                f'os.umount("{self.fs_hook_mount}")',
+                timeout_overall=timeout_overall,
+                timeout_overall_strict=timeout_overall_strict,
+            )
             self.mounted = False
-            self.serial = self.serial.orig_serial
+            # getattr, not a plain attribute access: `mounted` is set True
+            # before `self.serial` is swapped for a `SerialIntercept` (see
+            # mount_local), so an interruption landing in that narrow window
+            # leaves `self.serial` as the plain wrapped port, with no
+            # `orig_serial` of its own to unwrap.
+            self.serial = getattr(self.serial, "orig_serial", self.serial)
 
 
 fs_hook_cmds = {
@@ -831,22 +913,43 @@ class PyboardCommand:
         self.data_files = []
         self.unsafe_links = unsafe_links
 
+    def _rd_exact(self, n):
+        """Read exactly n bytes from the device side of the RPC channel.
+
+        `self.fin.read(n)` is a plain pyserial read: it can return fewer
+        than `n` bytes once the port's timeout elapses, which happens for
+        an ordinary slow trickle of bytes as well as for a device that has
+        stopped responding mid-command. Looping here treats the former
+        correctly instead of handing a short buffer to `struct.unpack` and
+        raising a `struct.error` that names no cause; the latter still ends
+        the loop, via `TransportError`, since a `read()` call returning
+        nothing at all means the port's own timeout was reached waiting for
+        the very first byte of what should still be coming.
+        """
+        buf = bytearray()
+        while len(buf) < n:
+            chunk = self.fin.read(n - len(buf))
+            if not chunk:
+                raise TransportError("mount filesystem RPC: device stopped responding mid-command")
+            buf += chunk
+        return bytes(buf)
+
     def rd_s8(self):
-        return struct.unpack("<b", self.fin.read(1))[0]
+        return struct.unpack("<b", self._rd_exact(1))[0]
 
     def rd_s32(self):
-        return struct.unpack("<i", self.fin.read(4))[0]
+        return struct.unpack("<i", self._rd_exact(4))[0]
 
     def rd_bytes(self):
         n = self.rd_s32()
-        return self.fin.read(n)
+        return self._rd_exact(n)
 
     def rd_str(self):
         n = self.rd_s32()
         if n == 0:
             return ""
         else:
-            return str(self.fin.read(n), "utf8", errors="backslashreplace")
+            return str(self._rd_exact(n), "utf8", errors="backslashreplace")
 
     def wr_s8(self, i):
         self.fout.write(struct.pack("<b", i))
@@ -1052,22 +1155,38 @@ class SerialIntercept:
         self.orig_serial.timeout = 5.0
 
     def _check_input(self, blocking):
-        if blocking or self.orig_serial.inWaiting() > 0:
-            c = self.orig_serial.read(1)
-            if c == b"\x18":
-                # a special command
-                c = self.orig_serial.read(1)[0]
-                self.orig_serial.write(b"\x18")  # Acknowledge command
-                PyboardCommand.cmd_table[c](self.cmd)
-            elif not VT_ENABLED and c == b"\x1b":
-                # ESC code, ignore these on windows
-                esctype = self.orig_serial.read(1)
-                if esctype == b"[":  # CSI
-                    while not (0x40 < self.orig_serial.read(1)[0] < 0x7E):
-                        # Looking for "final byte" of escape sequence
-                        pass
-            else:
-                self.buf += c
+        """Service one byte of the wrapped serial connection.
+
+        Returns True if a byte was consumed - buffered as console output, or
+        handled as filesystem RPC or an escape sequence - False if a blocking
+        read reached the wrapped port's own timeout with nothing to show for
+        it, and None if `blocking` is False and there was nothing waiting to
+        check at all. `read` below relies on False meaning "the peer has been
+        quiet for a whole timeout period" to return a short read instead of
+        looping forever; `orig_serial.read(1)` already honours the wrapped
+        port's `timeout` and returns `b""` on expiry, same as any ordinary
+        pyserial read.
+        """
+        if not (blocking or self.orig_serial.inWaiting() > 0):
+            return None
+        c = self.orig_serial.read(1)
+        if c == b"":
+            return False
+        if c == b"\x18":
+            # a special command
+            c = self.orig_serial.read(1)[0]
+            self.orig_serial.write(b"\x18")  # Acknowledge command
+            PyboardCommand.cmd_table[c](self.cmd)
+        elif not VT_ENABLED and c == b"\x1b":
+            # ESC code, ignore these on windows
+            esctype = self.orig_serial.read(1)
+            if esctype == b"[":  # CSI
+                while not (0x40 < self.orig_serial.read(1)[0] < 0x7E):
+                    # Looking for "final byte" of escape sequence
+                    pass
+        else:
+            self.buf += c
+        return True
 
     @property
     def fd(self):
@@ -1093,7 +1212,8 @@ class SerialIntercept:
 
     def read(self, n):
         while len(self.buf) < n:
-            self._check_input(True)
+            if self._check_input(True) is False:
+                break  # the wrapped port timed out with nothing new: return short, like pyserial
         out = self.buf[:n]
         self.buf = self.buf[n:]
         return out

--- a/tools/mpremote/mpremote/transport_serial.py
+++ b/tools/mpremote/mpremote/transport_serial.py
@@ -149,31 +149,43 @@ class SerialTransport(Transport):
         assert isinstance(timeout, (type(None), int, float))
         assert isinstance(timeout_overall, (type(None), int, float))
 
-        data = b""
-        begin_overall_s = begin_char_s = time.monotonic()
-        while True:
-            if data.endswith(ending):
-                break
-            new_data = None
-            if self.is_pty or self.serial.inWaiting() > 0:
-                new_data = self.serial.read(1)
-            if new_data:
-                if data_consumer:
-                    data_consumer(new_data)
-                    data = new_data
+        # A pty (e.g. QEMU) has no inWaiting() to poll, so read(1) below is
+        # called unconditionally; the port is opened with timeout=None, so
+        # that read blocks forever once the peer stops producing bytes
+        # unless bounded here, and the timeout/timeout_overall checks below
+        # would never get a chance to run.
+        saved_timeout = self.serial.timeout
+        if self.is_pty:
+            self.serial.timeout = 0.1
+        try:
+            data = b""
+            begin_overall_s = begin_char_s = time.monotonic()
+            while True:
+                if data.endswith(ending):
+                    break
+                new_data = None
+                if self.is_pty or self.serial.inWaiting() > 0:
+                    new_data = self.serial.read(1)
+                if new_data:
+                    if data_consumer:
+                        data_consumer(new_data)
+                        data = new_data
+                    else:
+                        data = data + new_data
+                    begin_char_s = time.monotonic()
                 else:
-                    data = data + new_data
-                begin_char_s = time.monotonic()
-            else:
-                if timeout is not None and time.monotonic() >= begin_char_s + timeout:
-                    break
-                if (
-                    timeout_overall is not None
-                    and time.monotonic() >= begin_overall_s + timeout_overall
-                ):
-                    break
-                time.sleep(0.01)
-        return data
+                    if timeout is not None and time.monotonic() >= begin_char_s + timeout:
+                        break
+                    if (
+                        timeout_overall is not None
+                        and time.monotonic() >= begin_overall_s + timeout_overall
+                    ):
+                        break
+                    time.sleep(0.01)
+            return data
+        finally:
+            if self.is_pty:
+                self.serial.timeout = saved_timeout
 
     def enter_raw_repl(self, soft_reset=True, timeout_overall=10):
         self.serial.write(b"\r\x03")  # ctrl-C: interrupt any running program

--- a/tools/mpremote/mpremote/transport_serial.py
+++ b/tools/mpremote/mpremote/transport_serial.py
@@ -1073,6 +1073,17 @@ class SerialIntercept:
     def fd(self):
         return self.orig_serial.fd
 
+    # Stands in for the serial object everywhere the transport reads or
+    # writes, so `read_until`'s save/restore of the read timeout has to reach
+    # the real port through it.
+    @property
+    def timeout(self):
+        return self.orig_serial.timeout
+
+    @timeout.setter
+    def timeout(self, value):
+        self.orig_serial.timeout = value
+
     def close(self):
         self.orig_serial.close()
 


### PR DESCRIPTION
### Summary

Adds `mpremote debug <target> [module[:method]]`, which starts a program on a target under the debugpy DAP server and prints the endpoint a DAP client can attach to. It is the host-side half of the MicroPython debugging work; the device-side server is micropython-lib PR #1022.

The command covers three transports. For a unix build it runs the binary as a subprocess and supervises it. For a serial device it enters raw REPL and execs a small boot script. For a board that routes DAP to a dedicated USB CDC interface it binds a localhost port and bridges to that interface, so a client that only speaks TCP still works. In all three cases the device prints one `MPDBG-READY {json}` handshake line carrying the endpoint and a capability probe, parsed by a single shared parser rather than one per flow.

Named targets come from an `mpdebug.toml` found by searching upward from the working directory, so `mpremote debug pybd` can carry the connect string, the firmware to use, the default program and the capabilities the target must report. `--dap-log` interposes a logging proxy and writes each DAP frame as a JSONL record, which is what you want when a client and a device disagree about the protocol.

Two flags make edit-run-debug practical on a device. `--source` mounts a host directory over the device filesystem for the session, so the code being debugged is the file on the host rather than a copy uploaded earlier, and the handshake reports absolute `pathMappings` so the client has no root to guess. `--loop` keeps one process and one DAP session across many runs: a DAP restart unwinds the program, evicts what its imports added to `sys.modules`, and imports it again, so breakpoints set before a restart still bind after it.

Two fixes to existing behaviour came out of this and stand on their own. `read_until` never bounded its inner read on a pty, so anything reading from one waited forever once the peer went quiet, including `enter_raw_repl`'s timeout. And `SerialIntercept`, which `mount_local` substitutes for the serial object, carried no `timeout` attribute, so every read after a mount raised `AttributeError` on real ports and ptys alike.

### Testing

Host-side suite of 307 tests covering all three flows, run against a unix build with `sys.settrace` enabled: the unix subprocess flow, the serial flow over a pty, the CDC bridge over a pty pair, `--dap-log` framing, `mpdebug.toml` resolution, the mount and its teardown, and `--loop`'s eviction and rebinding.

Hardware: PYBD-SF6W. The network flow was driven end to end over WiFi by a fake DAP client for 11 scenarios - breakpoints, stepping, locals in nested frames, a loop breakpoint, a 60 s pause at a breakpoint, and two back-to-back sessions. The serial DAP path was driven over the board's second CDC interface at a measured 81.7 kB/s for a 16 KB response.

Not tested: a board with only one serial interface, where the bridge has nothing to bind to and the flow should refuse rather than fall back. rp2 and esp32 have not been exercised at all - their USB stacks differ from stm32's and the CDC bridge is the part most likely to behave differently.

### Trade-offs and Alternatives

`--dap-log`'s frame parser and JSONL writer are a fresh implementation rather than an import of micropython-lib's `dap_monitor.py`, because that module is host-side CPython in a repo mpremote should not depend on. It is a small duplication and the alternative was a dependency in the wrong direction.

`--source` makes the command stay attached and pump for the session, where it otherwise reports the endpoint and returns. A mounted transport answers filesystem RPC from any read, so there is no way to mount and leave. Teardown has to umount on every exit path, since an abandoned mount leaves the device blocked in an RPC that Ctrl-C cannot interrupt.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.
