### PR TITLE
extmod/modselect: Wake a blocked poll() from a driver signal rather than a descriptor

### DIFF
--- a/docs/library/asyncio.rst
+++ b/docs/library/asyncio.rst
@@ -161,6 +161,10 @@ class ThreadSafeFlag
     Clear the flag. This may be used to ensure that a possibly previously-set
     flag is clear before waiting for it.
 
+.. method:: ThreadSafeFlag.is_set()
+
+    Returns ``True`` if the flag is set, ``False`` otherwise.
+
 .. method:: ThreadSafeFlag.wait()
 
     Wait for the flag to be set.  If the flag is already set then it returns

--- a/extmod/asyncio/event.py
+++ b/extmod/asyncio/event.py
@@ -40,27 +40,47 @@ class Event:
 # that asyncio will poll until a flag is set.
 # Note: Unlike Event, this is self-clearing after a wait().
 try:
-    import io
+    # _ThreadSafeFlag (extmod/modasyncio.c) declares its wake source to the "select"
+    # module, so a set() from another thread or an IRQ ends a blocked poll() directly.
+    # wait() is the only thing this subclass contributes: a generator cannot be
+    # constructed from C. It reaches the flag through methods only, never through an
+    # attribute store, which on a Python subclass of a native base would write the
+    # instance's own members dict and permanently shadow the native state instead of
+    # setting it.
+    from _asyncio import _ThreadSafeFlag
 
-    class ThreadSafeFlag(io.IOBase):
-        def __init__(self):
-            self.state = 0
-
-        def ioctl(self, req, flags):
-            if req == 3:  # MP_STREAM_POLL
-                return self.state * flags
-            return -1  # Other requests are unsupported
-
-        def set(self):
-            self.state = 1
-
-        def clear(self):
-            self.state = 0
-
+    class ThreadSafeFlag(_ThreadSafeFlag):
         async def wait(self):
-            if not self.state:
+            if not self.is_set():
                 yield core._io_queue.queue_read(self)
-            self.state = 0
+            self.clear()
 
 except ImportError:
-    pass
+    try:
+        import io
+
+        class ThreadSafeFlag(io.IOBase):
+            def __init__(self):
+                self.state = 0
+
+            def ioctl(self, req, flags):
+                if req == 3:  # MP_STREAM_POLL
+                    return self.state * flags
+                return -1  # Other requests are unsupported
+
+            def is_set(self):
+                return bool(self.state)
+
+            def set(self):
+                self.state = 1
+
+            def clear(self):
+                self.state = 0
+
+            async def wait(self):
+                if not self.state:
+                    yield core._io_queue.queue_read(self)
+                self.state = 0
+
+    except ImportError:
+        pass

--- a/extmod/modasyncio.c
+++ b/extmod/modasyncio.c
@@ -28,6 +28,7 @@
 #include "py/smallint.h"
 #include "py/pairheap.h"
 #include "py/mphal.h"
+#include "py/stream.h"
 
 #if MICROPY_PY_ASYNCIO
 
@@ -317,12 +318,142 @@ static MP_DEFINE_CONST_OBJ_TYPE(
     );
 
 /******************************************************************************/
+// ThreadSafeFlag class
+
+#if MICROPY_PY_ASYNCIO_THREADSAFEFLAG
+
+// A single-bit flag settable from any thread, ISR, or the scheduler, and awaited from the
+// asyncio loop. Declares SOURCE_SIGNAL to the "select" module (py/stream.h) so a set()
+// call ends a blocked poll() directly, rather than the loop discovering the flag only on
+// its next period-capped sweep; a flag that is never polled costs nothing beyond the plain
+// flag write, since cb stays NULL until something registers it.
+//
+// Arming is sticky: cb/ctx are installed on the first Register and never cleared on
+// Unregister, matching the recommended contract in py/stream.h. A select.poll() object has
+// no finaliser, so a caller that drops one without unregistering leaves this flag armed
+// for the rest of its life; that is harmless; it just means every future set() also pokes
+// mp_event_signal() once, which a stream with nothing registered anywhere would not do.
+//
+// wait() lives in the Python subclass (extmod/asyncio/event.py), since a generator cannot
+// be constructed from C; it reaches this object only through is_set()/clear(), never by
+// storing an attribute. This type defines no custom attr handler, so a Python subclass
+// that wrote to an attribute would land in the subclass instance's own members dict
+// without touching this struct at all, silently shadowing the flag rather than setting
+// it: set()/clear()/is_set() are the only supported way to reach the state.
+typedef struct _mp_obj_threadsafeflag_t {
+    mp_obj_base_t base;
+    volatile uint8_t state; // 0=unset, 1=set
+    void (*cb)(void *ctx);
+    void *ctx;
+} mp_obj_threadsafeflag_t;
+
+static const mp_obj_type_t mp_type_threadsafeflag;
+
+static mp_obj_t threadsafeflag_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 0, 0, false);
+    mp_obj_threadsafeflag_t *self = mp_obj_malloc(mp_obj_threadsafeflag_t, type);
+    self->state = 0;
+    self->cb = NULL;
+    self->ctx = NULL;
+    return MP_OBJ_FROM_PTR(self);
+}
+
+static mp_obj_t threadsafeflag_set(mp_obj_t self_in) {
+    mp_obj_threadsafeflag_t *self = MP_OBJ_TO_PTR(self_in);
+    self->state = 1;
+    if (self->cb != NULL) {
+        self->cb(self->ctx);
+    }
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(threadsafeflag_set_obj, threadsafeflag_set);
+
+static mp_obj_t threadsafeflag_clear(mp_obj_t self_in) {
+    mp_obj_threadsafeflag_t *self = MP_OBJ_TO_PTR(self_in);
+    self->state = 0;
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(threadsafeflag_clear_obj, threadsafeflag_clear);
+
+static mp_obj_t threadsafeflag_is_set(mp_obj_t self_in) {
+    mp_obj_threadsafeflag_t *self = MP_OBJ_TO_PTR(self_in);
+    return mp_obj_new_bool(self->state != 0);
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(threadsafeflag_is_set_obj, threadsafeflag_is_set);
+
+static mp_uint_t threadsafeflag_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode) {
+    // select.poll() and the "select" module's own MP_STREAM_SET_EVENT_SOURCE probe reach
+    // this ioctl through the stream protocol slot (py/stream.h's mp_get_stream()), which
+    // is resolved from self_in's type and calls straight through with whatever self_in the
+    // caller supplied. Unlike a locals_dict method call, that path never substitutes
+    // subobj[0] for self_in: for a Python subclass instance (extmod/asyncio/event.py's
+    // ThreadSafeFlag), self_in here is the wrapping mp_obj_instance_t, not this struct, and
+    // casting it directly would read and write past the wrapper's own members map. Cast
+    // back to the native object this ioctl actually belongs to before touching it; a
+    // direct instance of _ThreadSafeFlag itself is returned unchanged.
+    self_in = mp_obj_cast_to_native_base(self_in, MP_OBJ_FROM_PTR(&mp_type_threadsafeflag));
+    assert(self_in != MP_OBJ_NULL);
+    mp_obj_threadsafeflag_t *self = MP_OBJ_TO_PTR(self_in);
+    switch (request) {
+        case MP_STREAM_POLL:
+            return self->state ? (arg & MP_STREAM_POLL_RD) : 0;
+
+        case MP_STREAM_SET_EVENT_SOURCE: {
+            mp_stream_event_source_t *source = (mp_stream_event_source_t *)arg;
+            if (source->op == MP_STREAM_EVENT_OP_REGISTER) {
+                // Idempotent: every caller supplies the identical (poll_signal_cb, NULL)
+                // pair (extmod/modselect.c's poll_set_add_obj), so overwriting on a second
+                // Register changes nothing.
+                self->cb = source->cb;
+                self->ctx = source->ctx;
+                source->fd = -1;
+                source->fd_events = 0;
+                source->flags = MP_STREAM_EVENT_SOURCE_SIGNAL;
+            }
+            // Refresh and Unregister are both no-ops: this flag declares no fd to
+            // re-query, and staying armed for the rest of its life is the correct answer
+            // to Unregister (see this type's doc comment).
+            return 0;
+        }
+
+        default:
+            *errcode = MP_EINVAL;
+            return MP_STREAM_ERROR;
+    }
+}
+
+static const mp_stream_p_t threadsafeflag_stream_p = {
+    .ioctl = threadsafeflag_ioctl,
+};
+
+static const mp_rom_map_elem_t threadsafeflag_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_set), MP_ROM_PTR(&threadsafeflag_set_obj) },
+    { MP_ROM_QSTR(MP_QSTR_clear), MP_ROM_PTR(&threadsafeflag_clear_obj) },
+    { MP_ROM_QSTR(MP_QSTR_is_set), MP_ROM_PTR(&threadsafeflag_is_set_obj) },
+};
+static MP_DEFINE_CONST_DICT(threadsafeflag_locals_dict, threadsafeflag_locals_dict_table);
+
+static MP_DEFINE_CONST_OBJ_TYPE(
+    mp_type_threadsafeflag,
+    MP_QSTR__ThreadSafeFlag,
+    MP_TYPE_FLAG_NONE,
+    make_new, threadsafeflag_make_new,
+    protocol, &threadsafeflag_stream_p,
+    locals_dict, &threadsafeflag_locals_dict
+    );
+
+#endif // MICROPY_PY_ASYNCIO_THREADSAFEFLAG
+
+/******************************************************************************/
 // C-level asyncio module
 
 static const mp_rom_map_elem_t mp_module_asyncio_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR__asyncio) },
     { MP_ROM_QSTR(MP_QSTR_TaskQueue), MP_ROM_PTR(&task_queue_type) },
     { MP_ROM_QSTR(MP_QSTR_Task), MP_ROM_PTR(&task_type) },
+    #if MICROPY_PY_ASYNCIO_THREADSAFEFLAG
+    { MP_ROM_QSTR(MP_QSTR__ThreadSafeFlag), MP_ROM_PTR(&mp_type_threadsafeflag) },
+    #endif
 };
 static MP_DEFINE_CONST_DICT(mp_module_asyncio_globals, mp_module_asyncio_globals_table);
 

--- a/extmod/modselect.c
+++ b/extmod/modselect.c
@@ -435,8 +435,13 @@ static struct pollfd *poll_set_add_fd(poll_set_t *poll_set, int fd) {
 static bool poll_set_signal_wake_is_reliable(void) {
     #if MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
     return true;
-    #else
+    #elif MICROPY_HAL_WAKE_EVENT_HAS_POSIX_FD
     return mp_sched_thread_can_run_callbacks() && mp_hal_wake_event_fd() >= 0;
+    #else
+    // Neither a per-thread object nor a shared descriptor to put in the set, so nothing
+    // here can end a deadline block early and the period-capped sweep is the only correct
+    // cadence for a signal source.
+    return false;
     #endif
 }
 #endif
@@ -906,13 +911,17 @@ static mp_uint_t poll_set_poll_until_ready_or_timeout(poll_set_t *poll_set, size
         // way, as neither relies on this reserved slot for its own readiness.
         #if MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
         poll_set->pollfds[0].fd = mp_hal_wake_obj_posix_fd(wake_obj);
-        #else
+        #elif MICROPY_HAL_WAKE_EVENT_HAS_POSIX_FD
         // No per-thread wake object on this port or build: the shared wake event is the
         // only mechanism left, safe to inject for the same entitlement
         // poll_set_signal_wake_is_reliable() checks above (at most one thread ever holds
         // it), and -1 for every other thread so its poll() always falls back to the
         // periodic sweep below.
         poll_set->pollfds[0].fd = mp_sched_thread_can_run_callbacks() ? mp_hal_wake_event_fd() : -1;
+        #else
+        // No wake primitive this poll set can be given, so the slot stays empty and every
+        // signal source falls back to the periodic sweep below.
+        poll_set->pollfds[0].fd = -1;
         #endif
         poll_set->pollfds[0].events = POLLIN;
         poll_set->pollfds[0].revents = 0;
@@ -995,7 +1004,7 @@ static mp_uint_t poll_set_poll_until_ready_or_timeout(poll_set_t *poll_set, size
         if (poll_set->pollfds[0].revents != 0) {
             #if MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
             mp_hal_wake_obj_drain(wake_obj);
-            #else
+            #elif MICROPY_HAL_WAKE_EVENT_HAS_POSIX_FD
             mp_hal_wake_event_drain();
             #endif
         }

--- a/extmod/modselect.c
+++ b/extmod/modselect.c
@@ -410,24 +410,29 @@ static struct pollfd *poll_set_add_fd(poll_set_t *poll_set, int fd) {
 // nothing left to notice, unlike a period-capped sweep, which just polls again on the next
 // tick regardless.
 //
-// With a per-thread wake object (MICROPY_HAL_HAS_WAKE_OBJ and its POSIX descriptor), every
-// thread that reaches here has its own token: mp_hal_wake_obj_signal_all() raises every
-// claimed object independently, so no other thread's wait can consume this one's. That
-// holds under a GIL build exactly as it does without one, since it depends only on the
-// object being this thread's own, never on which thread is entitled to run scheduled
-// callbacks. Reliable unless the pool has no slot left to give this thread, or the HAL has
-// not handed out a descriptor for it yet.
+// mp_sched_thread_can_run_callbacks() is not a thread test, it asks whether this thread is
+// entitled to act on whatever a broadcast raise carries: on a non-GIL build that is the
+// main thread alone, since scheduled callbacks and pending exceptions must not run on more
+// than one thread at once. A thread with no such entitlement still has a stake in this
+// wake source when the poll set it is calling from holds SOURCE_SIGNAL entries of its own
+// (poll_set->n_signal > 0): nothing else is entitled to the raise those entries are
+// waiting for either, and this thread's own wake object (see the reserved-slot injection
+// below) is the only place that raise can land for it. Reliable when either holds; every
+// claimed wake object receives every raise independently (mp_hal_wake_obj_signal_all()),
+// so this holds identically on GIL and non-GIL builds.
 //
-// Without a wake object, the fallback is the single shared wake event, reliable only for
-// the one thread entitled to drain it: mp_sched_thread_can_run_callbacks() is false for
-// every thread but the main one on a non-GIL build, and true for every thread on a GIL
-// build, where any of them draining it first defeats every other's block. This is the same
-// entitlement mp_hal_wake_event_wait_tv() uses to decide who may wait on it.
-static bool poll_set_signal_wake_is_reliable(void) {
+// Without a per-thread wake object at all (MICROPY_HAL_HAS_WAKE_OBJ off, or its POSIX
+// descriptor unavailable), the reserved slot instead carries the shared wake event (see
+// its injection below), and this thread's stake in it is the same entitlement
+// mp_hal_wake_event_wait_tv() uses to decide who may wait on it: a build with no
+// per-thread objects has exactly one thread able to hold that entitlement
+// (MICROPY_HAL_HAS_WAKE_OBJ tracks MICROPY_PY_THREAD on unix), so no other thread's wait
+// can ever consume this one's token first.
+static bool poll_set_signal_wake_is_reliable(poll_set_t *poll_set) {
     #if MICROPY_HAL_HAS_WAKE_OBJ && MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
-    mp_hal_wake_obj_t *wake_obj = mp_hal_wake_obj_this_thread();
-    return wake_obj != NULL && mp_hal_wake_obj_posix_fd(wake_obj) >= 0;
+    return mp_sched_thread_can_run_callbacks() || poll_set->n_signal > 0;
     #else
+    (void)poll_set;
     return mp_sched_thread_can_run_callbacks() && mp_hal_wake_event_fd() >= 0;
     #endif
 }
@@ -473,7 +478,7 @@ static bool poll_set_all_have_wake_sources(poll_set_t *poll_set) {
     if (poll_set->map.used != (mp_uint_t)(poll_set->used - 1) + poll_set->n_signal_nofd) {
         return false;
     }
-    return poll_set->n_signal == 0 || poll_set_signal_wake_is_reliable();
+    return poll_set->n_signal == 0 || poll_set_signal_wake_is_reliable(poll_set);
     #else
     return poll_set->map.used == poll_set->used;
     #endif

--- a/extmod/modselect.c
+++ b/extmod/modselect.c
@@ -428,11 +428,14 @@ static struct pollfd *poll_set_add_fd(poll_set_t *poll_set, int fd) {
 // per-thread objects has exactly one thread able to hold that entitlement
 // (MICROPY_HAL_HAS_WAKE_OBJ tracks MICROPY_PY_THREAD on unix), so no other thread's wait
 // can ever consume this one's token first.
-static bool poll_set_signal_wake_is_reliable(poll_set_t *poll_set) {
-    #if MICROPY_HAL_HAS_WAKE_OBJ && MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
-    return mp_sched_thread_can_run_callbacks() || poll_set->n_signal > 0;
+// Only ever consulted for a set that holds SOURCE_SIGNAL entries, so with per-thread wake
+// objects the answer is unconditionally yes: this thread's stake in the raise is exactly
+// those entries, and its own object is where the raise lands. Callback entitlement does not
+// enter into it, which is the whole point of the object being per-thread.
+static bool poll_set_signal_wake_is_reliable(void) {
+    #if MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
+    return true;
     #else
-    (void)poll_set;
     return mp_sched_thread_can_run_callbacks() && mp_hal_wake_event_fd() >= 0;
     #endif
 }
@@ -478,7 +481,7 @@ static bool poll_set_all_have_wake_sources(poll_set_t *poll_set) {
     if (poll_set->map.used != (mp_uint_t)(poll_set->used - 1) + poll_set->n_signal_nofd) {
         return false;
     }
-    return poll_set->n_signal == 0 || poll_set_signal_wake_is_reliable(poll_set);
+    return poll_set->n_signal == 0 || poll_set_signal_wake_is_reliable();
     #else
     return poll_set->map.used == poll_set->used;
     #endif
@@ -860,6 +863,14 @@ static mp_uint_t poll_set_poll_until_ready_or_timeout(poll_set_t *poll_set, size
     bool first_pass = true;
     #endif
 
+    #if MICROPY_PY_SELECT_EVENT_SOURCE && MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
+    // Claimed once for the whole call rather than per pass. A thread holds the same object
+    // for its lifetime, so re-asking each pass answers the same thing; it matters because a
+    // claim the port could not service is deliberately not cached, and re-asking would
+    // repeat its failed allocation on every pass of the sweep.
+    mp_hal_wake_obj_t *wake_obj = mp_hal_wake_obj_this_thread();
+    #endif
+
     for (;;) {
         #if MICROPY_PY_SELECT_EVENT_SOURCE
         poll_set_refresh_fd_events(poll_set);
@@ -872,16 +883,19 @@ static mp_uint_t poll_set_poll_until_ready_or_timeout(poll_set_t *poll_set, size
         // here and forced into the timeout below instead, so poll() still runs, non-blocking,
         // and poll_set_resolve_readiness() after it resolves every entry in one place.
         bool pre_block_ready = false;
-        bool signalled = poll_set_take_signal(poll_set);
+        // mp_event_signal() is process-wide, so the count moves for raises aimed at other
+        // poll sets too. A set holding no SOURCE_SIGNAL entry has nothing that could have
+        // been readied by one, so it skips the snapshot entirely rather than resolving every
+        // entry again on each unrelated raise. Leaving its snapshot stale is safe: a later
+        // registration just sees movement it cannot attribute and does one extra ask.
+        bool signalled = poll_set->n_signal > 0 && poll_set_take_signal(poll_set);
         if (first_pass || signalled) {
             if (first_pass) {
                 poll_set_reset_revents(poll_set);
             }
             pre_block_ready = poll_set_resolve_pre_block(poll_set, first_pass, signalled) > 0;
         }
-        #endif
 
-        #if MICROPY_PY_SELECT_EVENT_SOURCE
         // Refresh the reserved slot immediately before poll() blocks on it, with this
         // thread's own wake object where the port has one: it belongs to no other thread,
         // so a raise reaching it is never stolen by another thread's wait the way a single
@@ -890,8 +904,7 @@ static mp_uint_t poll_set_poll_until_ready_or_timeout(poll_set_t *poll_set, size
         // and otherwise falls back to the period-capped sweep below regardless of what
         // this slot is wired to. A purely fd-backed or composed entry is unaffected either
         // way, as neither relies on this reserved slot for its own readiness.
-        #if MICROPY_HAL_HAS_WAKE_OBJ && MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
-        mp_hal_wake_obj_t *wake_obj = mp_hal_wake_obj_this_thread();
+        #if MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
         poll_set->pollfds[0].fd = mp_hal_wake_obj_posix_fd(wake_obj);
         #else
         // No per-thread wake object on this port or build: the shared wake event is the
@@ -903,8 +916,14 @@ static mp_uint_t poll_set_poll_until_ready_or_timeout(poll_set_t *poll_set, size
         #endif
         poll_set->pollfds[0].events = POLLIN;
         poll_set->pollfds[0].revents = 0;
+        #endif
 
-        #if MICROPY_HAL_HAS_WAKE_OBJ && MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
+        // Whether this pass may block to the caller's deadline rather than falling back to
+        // the period-capped sweep below. Answered once: the unwakeable-wait check and the
+        // timeout computation both need it, and nothing between them can change it.
+        bool can_block_to_deadline = poll_set_all_have_wake_sources(poll_set);
+
+        #if MICROPY_PY_SELECT_EVENT_SOURCE && MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
         // A wake object the port could not back has no descriptor to inject, so nothing in
         // the set below can be woken by a raise. Every way of reaching poll() from here
         // absorbs that except one: a zero timeout returns immediately, a finite one is
@@ -923,11 +942,9 @@ static mp_uint_t poll_set_poll_until_ready_or_timeout(poll_set_t *poll_set, size
         // Checked with the GIL still held, since it raises, and before the timeout is
         // computed below, where all four of its inputs are already settled.
         if (poll_set->pollfds[0].fd < 0 && poll_set->n_signal > 0
-            && timeout == (mp_uint_t)-1 && !pre_block_ready
-            && poll_set_all_have_wake_sources(poll_set)) {
+            && timeout == (mp_uint_t)-1 && !pre_block_ready && can_block_to_deadline) {
             mp_raise_OSError(MP_EMFILE);
         }
-        #endif
         #endif
 
         MP_THREAD_GIL_EXIT();
@@ -942,9 +959,9 @@ static mp_uint_t poll_set_poll_until_ready_or_timeout(poll_set_t *poll_set, size
             t = 0;
         } else
         #endif
-        if (poll_set_all_have_wake_sources(poll_set)) {
-            // All our pollables are file descriptors, so we can use a blocking
-            // poll and let it (the underlying system) handle the timeout.
+        if (can_block_to_deadline) {
+            // Every entry has a wake source, so use a blocking poll and let it (the
+            // underlying system) handle the timeout.
             if (timeout == (mp_uint_t)-1) {
                 t = -1;
             } else {
@@ -975,15 +992,13 @@ static mp_uint_t poll_set_poll_until_ready_or_timeout(poll_set_t *poll_set, size
         // Drain only after polling readable, never before: the reserved slot's fd is
         // level-triggered and counting, so draining ahead of the wait it was meant to end
         // discards the raise and leaves that wait with nothing to wake it.
-        #if MICROPY_HAL_HAS_WAKE_OBJ && MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
         if (poll_set->pollfds[0].revents != 0) {
+            #if MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
             mp_hal_wake_obj_drain(wake_obj);
-        }
-        #else
-        if (poll_set->pollfds[0].revents != 0) {
+            #else
             mp_hal_wake_event_drain();
+            #endif
         }
-        #endif
         #endif
 
         // Resolve readiness for every entry now that poll() has produced fresh state. On the

--- a/extmod/modselect.c
+++ b/extmod/modselect.c
@@ -882,25 +882,23 @@ static mp_uint_t poll_set_poll_until_ready_or_timeout(poll_set_t *poll_set, size
         #endif
 
         #if MICROPY_PY_SELECT_EVENT_SOURCE
-        // Refresh the reserved slot immediately before poll() blocks on it. -1 when this
-        // thread may not act on the fd it would otherwise use, whether that is its own
-        // wake object (pool exhausted, or none handed out yet) or the shared wake event
-        // (mp_sched_thread_can_run_callbacks(), see the caveat at its definition):
-        // registering the real fd here on a thread that will never drain it would be a
-        // lost wakeup for whichever thread actually needed it, so this thread's poll()
-        // falls back to the periodic sweep below instead.
-        //
-        // A per-thread wake object (see poll_set_signal_wake_is_reliable()) belongs to no
-        // other thread, so injecting it here carries none of the shared wake event's
-        // cross-thread drain race; a SOURCE_SIGNAL entry only ever depends on this slot to
-        // end a deadline block when poll_set_signal_wake_is_reliable() is true for it, and
-        // otherwise falls back to the period-capped sweep below regardless of what this
-        // slot is wired to. A purely fd-backed or composed entry is unaffected either way,
-        // as neither relies on this reserved slot for its own readiness.
+        // Refresh the reserved slot immediately before poll() blocks on it, with this
+        // thread's own wake object where the port has one: it belongs to no other thread,
+        // so a raise reaching it is never stolen by another thread's wait the way a single
+        // shared descriptor could be. A SOURCE_SIGNAL entry only ever depends on this slot
+        // to end a deadline block when poll_set_signal_wake_is_reliable() is true for it,
+        // and otherwise falls back to the period-capped sweep below regardless of what
+        // this slot is wired to. A purely fd-backed or composed entry is unaffected either
+        // way, as neither relies on this reserved slot for its own readiness.
         #if MICROPY_HAL_HAS_WAKE_OBJ && MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
         mp_hal_wake_obj_t *wake_obj = mp_hal_wake_obj_this_thread();
-        poll_set->pollfds[0].fd = wake_obj != NULL ? mp_hal_wake_obj_posix_fd(wake_obj) : -1;
+        poll_set->pollfds[0].fd = mp_hal_wake_obj_posix_fd(wake_obj);
         #else
+        // No per-thread wake object on this port or build: the shared wake event is the
+        // only mechanism left, safe to inject for the same entitlement
+        // poll_set_signal_wake_is_reliable() checks above (at most one thread ever holds
+        // it), and -1 for every other thread so its poll() always falls back to the
+        // periodic sweep below.
         poll_set->pollfds[0].fd = mp_sched_thread_can_run_callbacks() ? mp_hal_wake_event_fd() : -1;
         #endif
         poll_set->pollfds[0].events = POLLIN;
@@ -952,15 +950,15 @@ static mp_uint_t poll_set_poll_until_ready_or_timeout(poll_set_t *poll_set, size
         // Drain only after polling readable, never before: the reserved slot's fd is
         // level-triggered and counting, so draining ahead of the wait it was meant to end
         // discards the raise and leaves that wait with nothing to wake it.
+        #if MICROPY_HAL_HAS_WAKE_OBJ && MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
         if (poll_set->pollfds[0].revents != 0) {
-            #if MICROPY_HAL_HAS_WAKE_OBJ && MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
-            if (wake_obj != NULL) {
-                mp_hal_wake_obj_drain(wake_obj);
-            }
-            #else
-            mp_hal_wake_event_drain();
-            #endif
+            mp_hal_wake_obj_drain(wake_obj);
         }
+        #else
+        if (poll_set->pollfds[0].revents != 0) {
+            mp_hal_wake_event_drain();
+        }
+        #endif
         #endif
 
         // Resolve readiness for every entry now that poll() has produced fresh state. On the

--- a/extmod/modselect.c
+++ b/extmod/modselect.c
@@ -252,11 +252,23 @@ static bool poll_obj_should_be_asked(poll_obj_t *poll_obj, bool signalled) {
 
 #if MICROPY_PY_SELECT_EVENT_SOURCE
 // Whether any SOURCE_SIGNAL entry's readiness may have changed since this poll set last
+// took a snapshot, without refreshing that snapshot. Used where an observation cannot act
+// on a raise it sees (poll_set_resolve_readiness() runs after poll() has already been
+// asked for this pass), so a raise noticed only here must still be re-asked on this set's
+// next pre-block ask rather than being discharged by an observation that could not use it.
+static bool poll_set_peek_signal(poll_set_t *poll_set) {
+    return MICROPY_EVENT_SIGNAL_COUNT_GET() != poll_set->signal_seen;
+}
+
+// Whether any SOURCE_SIGNAL entry's readiness may have changed since this poll set last
 // asked. Reads mp_event_signal_count once and refreshes this set's own snapshot, so the
 // answer reflects every raise since this set's own last check, not since any other poll
 // set's; two sets calling this concurrently each get a true answer, never only one of them.
+// Call only where the result actually drives the pre-block ask that can act on it
+// (poll_set_poll_until_ready_or_timeout()'s loop head): refreshing anywhere else discharges
+// the movement without anything having asked on its behalf.
 static bool poll_set_take_signal(poll_set_t *poll_set) {
-    uint32_t seen = mp_event_signal_count;
+    uint32_t seen = MICROPY_EVENT_SIGNAL_COUNT_GET();
     bool moved = seen != poll_set->signal_seen;
     poll_set->signal_seen = seen;
     return moved;
@@ -728,7 +740,12 @@ static mp_uint_t poll_set_resolve_pre_block(poll_set_t *poll_set, bool first_pas
 static mp_uint_t poll_set_resolve_readiness(poll_set_t *poll_set) {
     mp_uint_t n_ready = 0;
     #if MICROPY_PY_SELECT_EVENT_SOURCE
-    bool signalled = poll_set_take_signal(poll_set);
+    // Peek, not take: this call runs after poll() for the current pass, so a raise it
+    // learns of here has already missed this pass's own pre-block ask and must wait for
+    // the next one, which reads the same movement again via poll_set_take_signal() at the
+    // top of the loop. Refreshing the snapshot here as well would discharge that movement
+    // on an observation that never asked anything on its behalf.
+    bool signalled = poll_set_peek_signal(poll_set);
     #else
     bool signalled = false;
     #endif

--- a/extmod/modselect.c
+++ b/extmod/modselect.c
@@ -91,14 +91,14 @@ typedef struct _poll_obj_t {
     #if MICROPY_PY_SELECT_EVENT_SOURCE
     // Wake-source properties declared via MP_STREAM_SET_EVENT_SOURCE, probed once at
     // registration alongside the MP_STREAM_GET_FILENO probe (the Register cadence; see
-    // py/stream.h). All zero/NULL if the object does not implement the ioctl, which is the
+    // py/stream.h). All zero if the object does not implement the ioctl, which is the
     // compatibility path: such an object is handled exactly as it would be without this
     // config, keyed only off GET_FILENO. event_flags is read by poll_obj_fd_is_readiness()
-    // and poll_set_all_are_fds(); event_fd_events by poll_set_refresh_fd_events(). cb/ctx
-    // are not yet consulted anywhere: they serve a callback-based wake source, which is
-    // outside this increment's scope.
-    void (*event_cb)(void *ctx);
-    void *event_ctx;
+    // and poll_set_all_are_fds(); event_fd_events by poll_set_refresh_fd_events().
+    // The cb/ctx passed to the stream at Register are not stored here: every SOURCE_SIGNAL
+    // entry is armed with the same (poll_signal_cb, NULL) pair (see poll_set_add_obj), so
+    // there is no per-entry value to remember, and the stream itself is what holds onto
+    // them for the life of the registration.
     uint16_t event_fd_events;
     uint8_t event_flags;
     #endif
@@ -116,6 +116,14 @@ typedef struct _poll_set_t {
     unsigned short max_used; // maximum number of used entries in pollfds
     unsigned short used; // actual number of used entries in pollfds
     struct pollfd *pollfds;
+
+    #if MICROPY_PY_SELECT_EVENT_SOURCE
+    // This set's own snapshot of mp_event_signal_count, compared and refreshed by
+    // poll_set_take_signal(). Per-set rather than a single shared snapshot, so every
+    // poll set sees every raise since its own last check regardless of what any other
+    // poll set has already consumed.
+    uint32_t signal_seen;
+    #endif
     #endif
 } poll_set_t;
 
@@ -134,6 +142,9 @@ static void poll_set_init(poll_set_t *poll_set, size_t n) {
     poll_set->pollfds[0].fd = -1;
     poll_set->pollfds[0].events = POLLIN;
     poll_set->pollfds[0].revents = 0;
+    // Snapshot rather than 0, so a raise that happened before this set existed is not
+    // mistaken for one that happened after.
+    poll_set->signal_seen = mp_event_signal_count;
     #else
     poll_set->alloc = 0;
     poll_set->max_used = 0;
@@ -186,17 +197,52 @@ static bool poll_obj_fd_is_readiness(poll_obj_t *poll_obj) {
 // Whether poll_set_resolve_readiness() must invoke this entry's MP_STREAM_POLL ioctl on
 // the current pass, for an entry that is not fd-authoritative (poll_obj_fd_is_readiness()
 // false). An entry with a wake-source-only fd (SOURCE_FD without FD_IS_READINESS, e.g.
-// SSL) is asked only when its own fd just fired, since nothing else observable to the
-// loop indicates its readiness may have changed. An entry with no fd at all -- the
-// compatibility path for a stream that does not implement MP_STREAM_SET_EVENT_SOURCE and
-// has no file descriptor either -- has no such signal to filter on and must be asked
-// every pass, matching poll_set_poll_once()'s unconditional sweep on the non-POSIX path.
-static bool poll_obj_should_be_asked(poll_obj_t *poll_obj) {
+// SSL) is asked when its own fd just fired, since that is the only other-than-signal
+// event observable to the loop that its readiness may have changed; a SOURCE_SIGNAL
+// entry (with or without a pollfd) is additionally asked whenever `signalled` is true,
+// since its readiness can change from an ISR or another thread with no fd activity at
+// all. An entry with no fd at all, the compatibility path for a stream that does not
+// implement MP_STREAM_SET_EVENT_SOURCE and has no file descriptor either, has no such
+// signal to filter on and must be asked every pass, matching poll_set_poll_once()'s
+// unconditional sweep on the non-POSIX path.
+static bool poll_obj_should_be_asked(poll_obj_t *poll_obj, bool signalled) {
     if (poll_obj->pollfd == NULL) {
         return true;
     }
-    return poll_obj->pollfd->revents != 0;
+    if (poll_obj->pollfd->revents != 0) {
+        return true;
+    }
+    #if MICROPY_PY_SELECT_EVENT_SOURCE
+    if (signalled && (poll_obj->event_flags & MP_STREAM_EVENT_SOURCE_SIGNAL) != 0) {
+        return true;
+    }
+    #else
+    (void)signalled;
+    #endif
+    return false;
 }
+
+#if MICROPY_PY_SELECT_EVENT_SOURCE
+// Whether any SOURCE_SIGNAL entry's readiness may have changed since this poll set last
+// asked. Reads mp_event_signal_count once and refreshes this set's own snapshot, so the
+// answer reflects every raise since this set's own last check, not since any other poll
+// set's; two sets calling this concurrently each get a true answer, never only one of them.
+static bool poll_set_take_signal(poll_set_t *poll_set) {
+    uint32_t seen = mp_event_signal_count;
+    bool moved = seen != poll_set->signal_seen;
+    poll_set->signal_seen = seen;
+    return moved;
+}
+
+// Installed as every SOURCE_SIGNAL entry's cb at Register (see poll_set_add_obj). ctx is
+// always NULL: the callback carries no per-poll-set identity, so mp_event_signal() wakes
+// and is checked by every poll set that has a SOURCE_SIGNAL entry registered, not only the
+// one the raise was meant for.
+static void poll_signal_cb(void *ctx) {
+    (void)ctx;
+    mp_event_signal();
+}
+#endif
 
 static mp_uint_t poll_obj_get_revents(poll_obj_t *poll_obj) {
     if (poll_obj_fd_is_readiness(poll_obj)) {
@@ -354,8 +400,6 @@ static void poll_set_add_obj(poll_set_t *poll_set, const mp_obj_t *obj, mp_uint_
             #if MICROPY_PY_SELECT_POSIX_OPTIMISATIONS
             int fd = -1;
             #if MICROPY_PY_SELECT_EVENT_SOURCE
-            poll_obj->event_cb = NULL;
-            poll_obj->event_ctx = NULL;
             poll_obj->event_fd_events = 0;
             poll_obj->event_flags = 0;
             #endif
@@ -383,19 +427,28 @@ static void poll_set_add_obj(poll_set_t *poll_set, const mp_obj_t *obj, mp_uint_
                 // A Python-level ioctl() (the IOBase trampoline in py/modio.c) can raise
                 // instead of returning MP_STREAM_ERROR for a request it does not
                 // recognise; caught here for the same reason, so an unadapted stream
-                // never crashes registration.
+                // never crashes registration. cb/ctx are stored by the stream only if it
+                // declares SOURCE_SIGNAL; poll_signal_cb carries no per-poll-set identity
+                // (see its definition), so ctx is NULL.
                 mp_stream_event_source_t source = {
-                    .cb = NULL, .ctx = NULL, .events = events, .op = MP_STREAM_EVENT_OP_REGISTER,
+                    .cb = poll_signal_cb, .ctx = NULL, .events = events, .op = MP_STREAM_EVENT_OP_REGISTER,
                     .fd = -1, .fd_events = 0, .flags = 0,
                 };
                 nlr_buf_t nlr;
                 if (nlr_push(&nlr) == 0) {
                     mp_uint_t source_res = stream_p->ioctl(obj[i], MP_STREAM_SET_EVENT_SOURCE, (uintptr_t)&source, &err);
                     if (source_res != MP_STREAM_ERROR) {
-                        poll_obj->event_cb = source.cb;
-                        poll_obj->event_ctx = source.ctx;
                         poll_obj->event_fd_events = source.fd_events;
                         poll_obj->event_flags = source.flags;
+                        if ((source.flags & MP_STREAM_EVENT_SOURCE_FD) != 0 && source.fd >= 0) {
+                            // The Register cadence's own answer for which fd is a wake
+                            // source is authoritative over the plain GET_FILENO probe
+                            // above: a driver may answer GET_FILENO with a fd that is not
+                            // the one its wake events arrive on (e.g. a control fd
+                            // distinct from a data fd), and only this ioctl knows which
+                            // one to give poll() a stake in.
+                            fd = source.fd;
+                        }
                     }
                     nlr_pop();
                 }
@@ -508,40 +561,16 @@ static void poll_set_refresh_fd_events(poll_set_t *poll_set) {
 #endif
 
 #if MICROPY_PY_SELECT_EVENT_SOURCE
-// Ask every composed entry (fd-backed but not fd-authoritative, e.g. SSL) once,
-// unconditionally, before poll_set_poll_until_ready_or_timeout() computes its first
-// timeout -- not gated on poll_obj_should_be_asked(), because a readiness left over from
-// before this call has no fd signal to filter on (e.g. a TLS record larger than the
-// caller's last read() left a remainder decrypted-but-unread). See poll_set_all_are_fds()'s
-// doc comment for why this ask has to happen before the deadline-sleep gate is consulted,
-// not only after poll() returns.
-//
-// An entry with no fd at all is not this function's concern: poll_set_all_are_fds()'s count
-// check already excludes it from the deadline-sleep gate whenever it is registered, so there
-// is no block for it to be stranded behind, and poll_set_resolve_readiness() already asks it
-// unconditionally on every pass regardless.
-//
-// Once per poll_set_poll_until_ready_or_timeout() call is sufficient, and not merely
-// convenient: within a single call, no caller read happens until this function has already
-// returned, so no new leftover readiness can appear between this ask and the poll() that
-// follows it. The only source of leftover readiness is a read the caller made *before*
-// calling in, which precedes this call and so is already covered by the one unconditional
-// ask. Gating this on poll_obj_should_be_asked() like poll_set_resolve_readiness() does would
-// look like a reasonable simplification and would reopen exactly the hole this function
-// exists to close, because should_be_asked() answers "did the fd fire", not "is there
-// leftover readiness from before this wait" -- the two coincide for a wake, never for a
-// pre-existing state, which is the entire case this function is for.
 // Clears every registered entry's resolved readiness back to "nothing known yet this
 // call". Called once, before the pre-block ask below has a chance to return without ever
 // running poll(): without this, an entry whose readiness this call never touches before
 // that early return (a fd_is_readiness entry, resolved only by the poll() syscall further
 // down this same loop and so not yet run this call, or a fd-less entry that
-// poll_set_resolve_composed_pre_block() below does not ask) would still carry whatever
-// non-zero value poll() left in it from a previous, unrelated call to this same poll set.
-// The caller then walks every registered entry and collects every non-zero one into a
-// list sized for the n_ready this function returned, so a stale non-zero here is a
-// mismatched count, not just a wrong answer -- one entry too many for the list's
-// allocation.
+// poll_set_resolve_pre_block() below does not ask) would still carry whatever non-zero
+// value poll() left in it from a previous, unrelated call to this same poll set. The
+// caller then walks every registered entry and collects every non-zero one into a list
+// sized for the n_ready this function returned, so a stale non-zero here is a mismatched
+// count, not just a wrong answer -- one entry too many for the list's allocation.
 static void poll_set_reset_revents(poll_set_t *poll_set) {
     for (mp_uint_t i = 0; i < poll_set->map.alloc; ++i) {
         if (!mp_map_slot_is_filled(&poll_set->map, i)) {
@@ -555,14 +584,42 @@ static void poll_set_reset_revents(poll_set_t *poll_set) {
     }
 }
 
-static mp_uint_t poll_set_resolve_composed_pre_block(poll_set_t *poll_set) {
+// Ask every non-fd-authoritative entry that needs it before
+// poll_set_poll_until_ready_or_timeout() computes its first timeout, not only after poll()
+// returns. Two cadences share this function because they are asked here for two different
+// reasons, and an entry may qualify for either or both:
+//
+// - A composed entry (fd-backed but not fd-authoritative, e.g. SSL) is asked once,
+//   unconditionally, on `first_pass`. Its readiness can only change as the result of this
+//   loop's own ioctl call, never spontaneously, so the one thing this ask has to catch is
+//   readiness left over from before this call began (e.g. a TLS record larger than the
+//   caller's last read() left a remainder decrypted-but-unread), which has no fd signal to
+//   filter on. Nothing changes for it between one pass and the next beyond what its own fd
+//   firing already reports, so `first_pass` is enough; asking it again on `signalled` would
+//   just be extra ioctls for an answer poll_set_resolve_readiness() already has.
+// - A SOURCE_SIGNAL entry (fd-backed or not) is asked on `first_pass`, for the same
+//   leftover-readiness reason, and again whenever `signalled` is true. Its readiness can
+//   change from an ISR or another thread at any point, including while this loop is
+//   between passes running scheduled callbacks; the intervening work can drain the wake
+//   token that would otherwise have carried news of the raise (mp_hal_wake_event_wait_tv()
+//   is a counting drain, not one this loop controls), so the counter checked via
+//   `signalled` is the only thing left that still catches it.
+//
+// See poll_set_all_are_fds()'s doc comment for why the composed-entry ask in particular
+// has to happen before the deadline-sleep gate is consulted.
+static mp_uint_t poll_set_resolve_pre_block(poll_set_t *poll_set, bool first_pass, bool signalled) {
     mp_uint_t n_ready = 0;
     for (mp_uint_t i = 0; i < poll_set->map.alloc; ++i) {
         if (!mp_map_slot_is_filled(&poll_set->map, i)) {
             continue;
         }
         poll_obj_t *poll_obj = MP_OBJ_TO_PTR(poll_set->map.table[i].value);
-        if (poll_obj->pollfd == NULL || poll_obj_fd_is_readiness(poll_obj)) {
+        if (poll_obj_fd_is_readiness(poll_obj)) {
+            continue;
+        }
+        bool is_signal = (poll_obj->event_flags & MP_STREAM_EVENT_SOURCE_SIGNAL) != 0;
+        bool composed_fd = poll_obj->pollfd != NULL;
+        if (!((composed_fd && first_pass) || (is_signal && (first_pass || signalled)))) {
             continue;
         }
         int errcode;
@@ -585,11 +642,17 @@ static mp_uint_t poll_set_resolve_composed_pre_block(poll_set_t *poll_set) {
 // entry takes its readiness from exactly one place, decided by poll_obj_fd_is_readiness():
 // a plain read of pollfd->revents (cheap, never filtered), or its own MP_STREAM_POLL ioctl,
 // filtered by poll_obj_should_be_asked() so a wake-source-only fd is asked exactly when its
-// own fd fired. An entry with no fd at all is always asked: poll_obj_should_be_asked()
-// returns true unconditionally for it, since it has no fd signal to filter on and no other
-// caller ever asks it first (poll_set_resolve_composed_pre_block() above skips it).
+// own fd fired, or a SOURCE_SIGNAL entry is asked exactly when it declared or its fd fired.
+// An entry with no fd at all is always asked: poll_obj_should_be_asked() returns true
+// unconditionally for it, since it has no fd signal to filter on and no other caller ever
+// asks it first (poll_set_resolve_pre_block() above skips a fd-less non-signal entry).
 static mp_uint_t poll_set_resolve_readiness(poll_set_t *poll_set) {
     mp_uint_t n_ready = 0;
+    #if MICROPY_PY_SELECT_EVENT_SOURCE
+    bool signalled = poll_set_take_signal(poll_set);
+    #else
+    bool signalled = false;
+    #endif
     for (mp_uint_t i = 0; i < poll_set->map.alloc; ++i) {
         if (!mp_map_slot_is_filled(&poll_set->map, i)) {
             continue;
@@ -604,7 +667,7 @@ static mp_uint_t poll_set_resolve_readiness(poll_set_t *poll_set) {
             continue;
         }
 
-        if (poll_obj_should_be_asked(poll_obj)) {
+        if (poll_obj_should_be_asked(poll_obj, signalled)) {
             int errcode;
             mp_int_t ret = poll_obj->ioctl(poll_obj->obj, MP_STREAM_POLL, poll_obj_get_events(poll_obj), &errcode);
             if (ret == -1) {
@@ -613,7 +676,7 @@ static mp_uint_t poll_set_resolve_readiness(poll_set_t *poll_set) {
             poll_obj_set_revents(poll_obj, ret);
         }
         // Else skipped: poll_obj->revents keeps the value from the previous pass, which is
-        // necessarily 0 -- a non-zero value here would have made the previous pass return
+        // necessarily 0; a non-zero value here would have made the previous pass return
         // rather than call poll() and loop back round.
 
         if (poll_obj->revents != 0) {
@@ -638,9 +701,10 @@ static mp_uint_t poll_set_poll_until_ready_or_timeout(poll_set_t *poll_set, size
 
     #if MICROPY_PY_SELECT_EVENT_SOURCE
     // Whether this is the first iteration of the loop below, used only by the pre-block
-    // ask: a composed entry needs a leftover-readiness check before the first poll() of
-    // this call, never on later passes. Meaningless without event sources, since nothing
-    // else in this loop varies by iteration count.
+    // ask: composed and signal entries need a leftover-readiness check before the first
+    // poll() of this call, never on later passes for the composed half (see
+    // poll_set_resolve_pre_block()'s doc comment). Meaningless without event sources, since
+    // nothing else in this loop varies by iteration count.
     bool first_pass = true;
     #endif
 
@@ -648,9 +712,12 @@ static mp_uint_t poll_set_poll_until_ready_or_timeout(poll_set_t *poll_set, size
         #if MICROPY_PY_SELECT_EVENT_SOURCE
         poll_set_refresh_fd_events(poll_set);
 
-        if (first_pass) {
-            poll_set_reset_revents(poll_set);
-            mp_uint_t n_ready = poll_set_resolve_composed_pre_block(poll_set);
+        bool signalled = poll_set_take_signal(poll_set);
+        if (first_pass || signalled) {
+            if (first_pass) {
+                poll_set_reset_revents(poll_set);
+            }
+            mp_uint_t n_ready = poll_set_resolve_pre_block(poll_set, first_pass, signalled);
             if (n_ready > 0) {
                 return n_ready;
             }
@@ -854,11 +921,37 @@ static mp_obj_t poll_unregister(mp_obj_t self_in, mp_obj_t obj_in) {
     #if MICROPY_PY_SELECT_POSIX_OPTIMISATIONS
     if (elem != NULL) {
         poll_obj_t *poll_obj = (poll_obj_t *)MP_OBJ_TO_PTR(elem->value);
+        #if MICROPY_PY_SELECT_EVENT_SOURCE
+        bool is_signal = (poll_obj->event_flags & MP_STREAM_EVENT_SOURCE_SIGNAL) != 0;
+        #endif
         if (poll_obj->pollfd != NULL) {
             poll_obj->pollfd->fd = -1;
             --self->poll_set.used;
+            #if MICROPY_PY_SELECT_EVENT_SOURCE
+            // Cleared so nothing can reach this pollfd through poll_obj between here and
+            // the Unregister ioctl below, which can re-enter Python. Not needed without
+            // that ioctl call: no code below this point ever reads poll_obj->pollfd again.
+            poll_obj->pollfd = NULL;
+            #endif
         }
         elem->value = MP_OBJ_NULL;
+        #if MICROPY_PY_SELECT_EVENT_SOURCE
+        // Issued only for a stream that declared SOURCE_SIGNAL, after every poll-set
+        // mutation above is complete: mp_map_lookup() with MP_MAP_LOOKUP_REMOVE_IF_FOUND
+        // has already cleared this slot's key and decremented map->used, so poll_obj is
+        // already invisible to poll_set_add_fd()'s realloc fixup loop, and elem->value and
+        // pollfd are cleared above, so a driver that re-enters Python from its own
+        // unregister handling can only observe a poll set that is already fully consistent
+        // without this entry.
+        if (is_signal) {
+            mp_stream_event_source_t source = {
+                .cb = NULL, .ctx = NULL, .events = 0, .op = MP_STREAM_EVENT_OP_UNREGISTER,
+                .fd = -1, .fd_events = 0, .flags = 0,
+            };
+            int errcode;
+            poll_obj->ioctl(poll_obj->obj, MP_STREAM_SET_EVENT_SOURCE, (uintptr_t)&source, &errcode);
+        }
+        #endif
     }
     #else
     (void)elem;

--- a/extmod/modselect.c
+++ b/extmod/modselect.c
@@ -903,6 +903,31 @@ static mp_uint_t poll_set_poll_until_ready_or_timeout(poll_set_t *poll_set, size
         #endif
         poll_set->pollfds[0].events = POLLIN;
         poll_set->pollfds[0].revents = 0;
+
+        #if MICROPY_HAL_HAS_WAKE_OBJ && MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
+        // A wake object the port could not back has no descriptor to inject, so nothing in
+        // the set below can be woken by a raise. Every way of reaching poll() from here
+        // absorbs that except one: a zero timeout returns immediately, a finite one is
+        // bounded by what the caller already asked for, and a set with no SOURCE_SIGNAL
+        // entries never depended on the slot at all. An indefinite wait holding entries
+        // whose only wake source is a raise has nothing left able to end it, so it raises
+        // here instead of blocking forever.
+        //
+        // This also raises where the set holds fd-backed entries that could have satisfied
+        // the poll on their own, which is deliberate. Proceeding would run the poll with
+        // its signal half inoperative: returning when a descriptor happened to fire, and
+        // hanging when only a raise would have, which is a lost wakeup presenting as a hang
+        // triggered by unrelated traffic. Failing where we know part of what was asked for
+        // cannot be honoured is the behaviour that stays diagnosable.
+        //
+        // Checked with the GIL still held, since it raises, and before the timeout is
+        // computed below, where all four of its inputs are already settled.
+        if (poll_set->pollfds[0].fd < 0 && poll_set->n_signal > 0
+            && timeout == (mp_uint_t)-1 && !pre_block_ready
+            && poll_set_all_have_wake_sources(poll_set)) {
+            mp_raise_OSError(MP_EMFILE);
+        }
+        #endif
         #endif
 
         MP_THREAD_GIL_EXIT();

--- a/extmod/modselect.c
+++ b/extmod/modselect.c
@@ -361,22 +361,30 @@ static struct pollfd *poll_set_add_fd(poll_set_t *poll_set, int fd) {
 }
 
 #if MICROPY_PY_SELECT_EVENT_SOURCE
-// Whether the calling thread is the sole possible consumer of the shared wake event's
-// token, and that token exists. A SOURCE_SIGNAL entry's deadline block depends on the
-// token surviving from the raise that fires it to the poll() that is woken by it; if any
-// other thread could drain the same token first, that block can miss the wake it was
-// waiting for with nothing left to notice, unlike a period-capped sweep, which just polls
-// again on the next tick regardless.
+// Whether the calling thread is the sole possible consumer of whatever wake token its
+// deadline block depends on. A SOURCE_SIGNAL entry's block depends on that token surviving
+// from the raise that fires it to the poll() that is woken by it; if any other thread
+// could drain the same token first, the block can miss the wake it was waiting for with
+// nothing left to notice, unlike a period-capped sweep, which just polls again on the next
+// tick regardless.
 //
-// False unconditionally under a GIL build: every thread there drains the same wake event
-// (see MICROPY_PY_THREAD_GIL's effect on mp_sched_thread_can_run_callbacks()), so a token
-// raised for this thread's block can be taken by another thread's time.sleep() or its own
-// select.poll() first. Otherwise true only for the thread that actually owns the wake
-// event: mp_sched_thread_can_run_callbacks() is false for every thread but the main one,
-// and mp_hal_wake_event_fd() can be unavailable regardless (e.g. before HAL init).
+// With a per-thread wake object (MICROPY_HAL_HAS_WAKE_OBJ and its POSIX descriptor), every
+// thread that reaches here has its own token: mp_hal_wake_obj_signal_all() raises every
+// claimed object independently, so no other thread's wait can consume this one's. That
+// holds under a GIL build exactly as it does without one, since it depends only on the
+// object being this thread's own, never on which thread is entitled to run scheduled
+// callbacks. Reliable unless the pool has no slot left to give this thread, or the HAL has
+// not handed out a descriptor for it yet.
+//
+// Without a wake object, the fallback is the single shared wake event, reliable only for
+// the one thread entitled to drain it: mp_sched_thread_can_run_callbacks() is false for
+// every thread but the main one on a non-GIL build, and true for every thread on a GIL
+// build, where any of them draining it first defeats every other's block. This is the same
+// entitlement mp_hal_wake_event_wait_tv() uses to decide who may wait on it.
 static bool poll_set_signal_wake_is_reliable(void) {
-    #if MICROPY_PY_THREAD && MICROPY_PY_THREAD_GIL
-    return false;
+    #if MICROPY_HAL_HAS_WAKE_OBJ && MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
+    mp_hal_wake_obj_t *wake_obj = mp_hal_wake_obj_this_thread();
+    return wake_obj != NULL && mp_hal_wake_obj_posix_fd(wake_obj) >= 0;
     #else
     return mp_sched_thread_can_run_callbacks() && mp_hal_wake_event_fd() >= 0;
     #endif
@@ -806,22 +814,26 @@ static mp_uint_t poll_set_poll_until_ready_or_timeout(poll_set_t *poll_set, size
 
         #if MICROPY_PY_SELECT_EVENT_SOURCE
         // Refresh the reserved slot immediately before poll() blocks on it. -1 when this
-        // thread may not act on the wake event (mp_sched_thread_can_run_callbacks(), see the
-        // caveat at its definition): registering the real fd here on a thread that will
-        // never drain it would be a lost wakeup for whichever thread actually needed it, so
-        // this thread's poll() falls back to the periodic sweep below instead.
+        // thread may not act on the fd it would otherwise use, whether that is its own
+        // wake object (pool exhausted, or none handed out yet) or the shared wake event
+        // (mp_sched_thread_can_run_callbacks(), see the caveat at its definition):
+        // registering the real fd here on a thread that will never drain it would be a
+        // lost wakeup for whichever thread actually needed it, so this thread's poll()
+        // falls back to the periodic sweep below instead.
         //
-        // On a GIL build, mp_sched_thread_can_run_callbacks() returns true for every thread,
-        // not just the one that owns this wait, so two threads each running their own
-        // select.poll() with the wake fd both injected race to drain it, and whichever loses
-        // sees no wakeup from this fd on that pass. This is exactly the race
-        // poll_set_signal_wake_is_reliable() is false for on every GIL build: a SOURCE_SIGNAL
-        // entry never depends on this fd surviving to end a deadline block, since
-        // poll_set_all_have_wake_sources() falls back to the period-capped sweep below
-        // whenever the set holds one, bounding a lost drain to one sweep period rather than
-        // the full timeout. A purely fd-backed or composed entry is unaffected either way, as
-        // neither relies on this reserved slot for its own readiness.
+        // A per-thread wake object (see poll_set_signal_wake_is_reliable()) belongs to no
+        // other thread, so injecting it here carries none of the shared wake event's
+        // cross-thread drain race; a SOURCE_SIGNAL entry only ever depends on this slot to
+        // end a deadline block when poll_set_signal_wake_is_reliable() is true for it, and
+        // otherwise falls back to the period-capped sweep below regardless of what this
+        // slot is wired to. A purely fd-backed or composed entry is unaffected either way,
+        // as neither relies on this reserved slot for its own readiness.
+        #if MICROPY_HAL_HAS_WAKE_OBJ && MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
+        mp_hal_wake_obj_t *wake_obj = mp_hal_wake_obj_this_thread();
+        poll_set->pollfds[0].fd = wake_obj != NULL ? mp_hal_wake_obj_posix_fd(wake_obj) : -1;
+        #else
         poll_set->pollfds[0].fd = mp_sched_thread_can_run_callbacks() ? mp_hal_wake_event_fd() : -1;
+        #endif
         poll_set->pollfds[0].events = POLLIN;
         poll_set->pollfds[0].revents = 0;
         #endif
@@ -868,11 +880,17 @@ static mp_uint_t poll_set_poll_until_ready_or_timeout(poll_set_t *poll_set, size
         }
 
         #if MICROPY_PY_SELECT_EVENT_SOURCE
-        // Drain only after polling readable, never before: the event is level-triggered and
-        // counting, so draining ahead of the wait it was meant to end discards the raise and
-        // leaves that wait with nothing to wake it (mp_hal_wake_event_fd()'s contract).
+        // Drain only after polling readable, never before: the reserved slot's fd is
+        // level-triggered and counting, so draining ahead of the wait it was meant to end
+        // discards the raise and leaves that wait with nothing to wake it.
         if (poll_set->pollfds[0].revents != 0) {
+            #if MICROPY_HAL_HAS_WAKE_OBJ && MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
+            if (wake_obj != NULL) {
+                mp_hal_wake_obj_drain(wake_obj);
+            }
+            #else
             mp_hal_wake_event_drain();
+            #endif
         }
         #endif
 

--- a/extmod/modselect.c
+++ b/extmod/modselect.c
@@ -82,11 +82,12 @@ typedef struct _poll_obj_t {
 
     #if MICROPY_PY_SELECT_POSIX_OPTIMISATIONS
     // If non-NULL, points into poll_set_t::pollfds and gives this object something the
-    // kernel can sleep on. pollfd->events carries the fd-level direction to watch; today
-    // that always mirrors `events` above (see poll_obj_set_events), because every fd-backed
-    // object is currently also authoritative for its own readiness. pollfd->revents is raw
-    // kernel output: read directly by poll_obj_get_revents() for such an object, and never
-    // written by anything but poll() itself.
+    // kernel can sleep on. pollfd->events carries the fd-level direction to watch: `events`
+    // above for a fd-authoritative object (poll_obj_fd_is_readiness() true, the only case
+    // before MICROPY_PY_SELECT_EVENT_SOURCE existed), or event_fd_events below for a
+    // composed one, which the caller's requested mask has no bearing on. pollfd->revents is
+    // raw kernel output: read directly by poll_obj_get_revents() for a fd-authoritative
+    // object, and never written by anything but poll() itself.
     struct pollfd *pollfd;
 
     #if MICROPY_PY_SELECT_EVENT_SOURCE
@@ -95,7 +96,11 @@ typedef struct _poll_obj_t {
     // py/stream.h). All zero if the object does not implement the ioctl, which is the
     // compatibility path: such an object is handled exactly as it would be without this
     // config, keyed only off GET_FILENO. event_flags is read by poll_obj_fd_is_readiness()
-    // and poll_set_all_have_wake_sources(); event_fd_events by poll_set_refresh_fd_events().
+    // and poll_set_all_have_wake_sources(). event_fd_events seeds pollfd->events for a
+    // composed entry at registration (poll_set_add_obj()) and is what
+    // poll_obj_fd_level_events() restores whenever such an entry's requested mask returns
+    // to non-zero; for one that also declares FD_DYNAMIC it is additionally re-read and
+    // re-applied before every block by poll_set_refresh_fd_events().
     // The cb/ctx passed to the stream at Register are not stored here: every SOURCE_SIGNAL
     // entry is armed with the same (poll_signal_cb, NULL) pair (see poll_set_add_obj), so
     // there is no per-entry value to remember, and the stream itself is what holds onto
@@ -178,16 +183,6 @@ static mp_uint_t poll_obj_get_events(poll_obj_t *poll_obj) {
     return poll_obj->events;
 }
 
-static void poll_obj_set_events(poll_obj_t *poll_obj, mp_uint_t events) {
-    poll_obj->events = events;
-    if (poll_obj->pollfd != NULL) {
-        // Legacy fd-authoritative path: the fd-level direction to watch is exactly the
-        // requested mask. A wake-source-only fd (not authoritative for readiness) would
-        // resolve fd_events independently instead of mirroring this write.
-        poll_obj->pollfd->events = events;
-    }
-}
-
 // Whether this entry's readiness is exactly its fd's kernel revents, as opposed to being
 // resolved by its own MP_STREAM_POLL ioctl. An entry with no fd at all can never be
 // fd-authoritative.
@@ -204,6 +199,41 @@ static bool poll_obj_fd_is_readiness(poll_obj_t *poll_obj) {
     // implement MP_STREAM_SET_EVENT_SOURCE): every fd-backed object is authoritative for
     // its own readiness, exactly as every fd-backed object was before this ioctl existed.
     return true;
+}
+
+// The fd-level direction to watch for an entry, which is not the caller's requested mask
+// unless the fd is authoritative for readiness. For a composed entry it is the direction
+// the driver declared, because what kernel activity should end a block is the driver's
+// call and not the caller's: an SSL read waits on a writable socket.
+//
+// A requested mask of zero is the exception, and is not a direction at all. It is
+// modify(obj, 0), an exhausted ONESHOT or register(obj, 0) saying stop reporting this
+// entry, and an entry nothing will be reported for must not keep waking the poll: left
+// armed against a persistently ready fd it returns from poll() every pass while the
+// entry's own ioctl, asked for nothing, answers nothing, which is a spin with no sleep in
+// it. Note this does not buy the POSIX "report errors only" behaviour a zero mask gives a
+// fd-authoritative entry: a composed entry's readiness is its ioctl's answer, so
+// POLLERR/POLLHUP/POLLNVAL on its descriptor never reach the caller either way.
+//
+// Every write to pollfd->events goes through here, so arming and disarming cannot drift
+// apart: a mask that returns to non-zero restores the declared direction by construction
+// rather than by a second special case.
+static mp_uint_t poll_obj_fd_level_events(poll_obj_t *poll_obj, mp_uint_t events) {
+    if (poll_obj_fd_is_readiness(poll_obj)) {
+        return events;
+    }
+    #if MICROPY_PY_SELECT_EVENT_SOURCE
+    return events == 0 ? 0 : poll_obj->event_fd_events;
+    #else
+    return events;
+    #endif
+}
+
+static void poll_obj_set_events(poll_obj_t *poll_obj, mp_uint_t events) {
+    poll_obj->events = events;
+    if (poll_obj->pollfd != NULL) {
+        poll_obj->pollfd->events = poll_obj_fd_level_events(poll_obj, events);
+    }
 }
 
 #if MICROPY_PY_SELECT_EVENT_SOURCE
@@ -412,8 +442,9 @@ static bool poll_set_signal_wake_is_reliable(void) {
 // FD_IS_READINESS), readiness resolved by its own MP_STREAM_POLL ioctl -- qualifies for the
 // same deadline block as a fully authoritative one, given two things elsewhere in this loop
 // that make it safe: its own fd is already in poll_set->pollfds regardless of authoritative-
-// ness (poll_obj_set_events() puts it there unconditionally), so new kernel activity on it
-// wakes poll() directly, and its readiness can only change as the result of this loop's own
+// ness (poll_set_add_obj() adds it via poll_set_add_fd() and seeds pollfd->events from its
+// own declared fd_events), so new kernel activity on it wakes poll() directly, and its
+// readiness can only change as the result of this loop's own
 // ioctl call -- never spontaneously while nothing is polling it -- so there is nothing for a
 // deadline block to miss between one wake and the next. What it cannot do on its own is
 // surface readiness that already existed *before* this wait began (e.g. a TLS record larger
@@ -540,6 +571,14 @@ static void poll_set_add_obj(poll_set_t *poll_set, const mp_obj_t *obj, mp_uint_
             if (fd >= 0) {
                 // Object has a file descriptor so add it to pollfds.
                 poll_obj->pollfd = poll_set_add_fd(poll_set, fd);
+                #if MICROPY_PY_SELECT_EVENT_SOURCE
+                if (!poll_obj_fd_is_readiness(poll_obj)) {
+                    // Composed entry: this fd is a wake source only, not authoritative for
+                    // readiness, so its own declared fd_events, not the caller's requested
+                    // mask below, decides what kernel activity should end a poll() block.
+                    poll_obj->pollfd->events = poll_obj_fd_level_events(poll_obj, poll_obj->events);
+                }
+                #endif
             } else {
                 // Object doesn't have a file descriptor.
                 poll_obj->pollfd = NULL;
@@ -635,6 +674,14 @@ static void poll_set_refresh_fd_events(poll_set_t *poll_set) {
 
         poll_obj_t *poll_obj = MP_OBJ_TO_PTR(poll_set->map.table[i].value);
         if (poll_obj->pollfd == NULL || !(poll_obj->event_flags & MP_STREAM_EVENT_FD_DYNAMIC)) {
+            continue;
+        }
+        if (poll_obj->events == 0) {
+            // Disarmed, so do not ask: a driver is entitled to keep naming a direction
+            // regardless of what it was asked with (modtls_mbedtls.c latches a poll_mask
+            // across calls), and honouring that here would re-arm the descriptor behind
+            // poll_obj_set_events()'s back.
+            poll_obj->pollfd->events = 0;
             continue;
         }
 

--- a/extmod/modselect.c
+++ b/extmod/modselect.c
@@ -45,6 +45,7 @@
 
 #if MICROPY_PY_SELECT_POSIX_OPTIMISATIONS
 
+#include <assert.h>
 #include <string.h>
 #include <poll.h>
 
@@ -94,7 +95,7 @@ typedef struct _poll_obj_t {
     // py/stream.h). All zero if the object does not implement the ioctl, which is the
     // compatibility path: such an object is handled exactly as it would be without this
     // config, keyed only off GET_FILENO. event_flags is read by poll_obj_fd_is_readiness()
-    // and poll_set_all_are_fds(); event_fd_events by poll_set_refresh_fd_events().
+    // and poll_set_all_have_wake_sources(); event_fd_events by poll_set_refresh_fd_events().
     // The cb/ctx passed to the stream at Register are not stored here: every SOURCE_SIGNAL
     // entry is armed with the same (poll_signal_cb, NULL) pair (see poll_set_add_obj), so
     // there is no per-entry value to remember, and the stream itself is what holds onto
@@ -123,6 +124,15 @@ typedef struct _poll_set_t {
     // poll set sees every raise since its own last check regardless of what any other
     // poll set has already consumed.
     uint32_t signal_seen;
+
+    // Registered entries declaring SOURCE_SIGNAL (n_signal) and, of those, the ones with
+    // no pollfd at all (n_signal_nofd). Maintained alongside map.used: incremented at the
+    // end of a successful registration, decremented in poll_unregister() before any call
+    // that can raise or re-enter, so no failure path can leave them out of step with what
+    // is actually registered. Read by poll_set_all_have_wake_sources() to decide whether a
+    // SOURCE_SIGNAL entry may join the deadline-sleep gate.
+    unsigned short n_signal;
+    unsigned short n_signal_nofd;
     #endif
     #endif
 } poll_set_t;
@@ -145,6 +155,8 @@ static void poll_set_init(poll_set_t *poll_set, size_t n) {
     // Snapshot rather than 0, so a raise that happened before this set existed is not
     // mistaken for one that happened after.
     poll_set->signal_seen = mp_event_signal_count;
+    poll_set->n_signal = 0;
+    poll_set->n_signal_nofd = 0;
     #else
     poll_set->alloc = 0;
     poll_set->max_used = 0;
@@ -193,6 +205,22 @@ static bool poll_obj_fd_is_readiness(poll_obj_t *poll_obj) {
     // its own readiness, exactly as every fd-backed object was before this ioctl existed.
     return true;
 }
+
+#if MICROPY_PY_SELECT_EVENT_SOURCE
+// Whether this entry genuinely depends on the SOURCE_SIGNAL wake path for its own
+// deadline block, i.e. whether it should count toward poll_set_t::n_signal/n_signal_nofd.
+// FD_IS_READINESS together with SOURCE_SIGNAL is not a meaningful combination: such an
+// entry's readiness is read straight from pollfd->revents (poll_obj_fd_is_readiness()
+// above), so its MP_STREAM_POLL ioctl is never consulted by this loop at all, and nothing
+// here ever needs its wake callback. Counting it as a signal entry anyway would force
+// poll_set_all_have_wake_sources() to require poll_set_signal_wake_is_reliable() for a
+// deadline block this entry never actually depends on that for; its own fd is already
+// sufficient. A driver should declare one or the other, not both (see py/stream.h).
+static bool poll_obj_counts_as_signal(poll_obj_t *poll_obj) {
+    return (poll_obj->event_flags & MP_STREAM_EVENT_SOURCE_SIGNAL) != 0
+           && (poll_obj->event_flags & MP_STREAM_EVENT_FD_IS_READINESS) == 0;
+}
+#endif
 
 // Whether poll_set_resolve_readiness() must invoke this entry's MP_STREAM_POLL ioctl on
 // the current pass, for an entry that is not fd-authoritative (poll_obj_fd_is_readiness()
@@ -332,10 +360,33 @@ static struct pollfd *poll_set_add_fd(poll_set_t *poll_set, int fd) {
     return free_slot;
 }
 
+#if MICROPY_PY_SELECT_EVENT_SOURCE
+// Whether the calling thread is the sole possible consumer of the shared wake event's
+// token, and that token exists. A SOURCE_SIGNAL entry's deadline block depends on the
+// token surviving from the raise that fires it to the poll() that is woken by it; if any
+// other thread could drain the same token first, that block can miss the wake it was
+// waiting for with nothing left to notice, unlike a period-capped sweep, which just polls
+// again on the next tick regardless.
+//
+// False unconditionally under a GIL build: every thread there drains the same wake event
+// (see MICROPY_PY_THREAD_GIL's effect on mp_sched_thread_can_run_callbacks()), so a token
+// raised for this thread's block can be taken by another thread's time.sleep() or its own
+// select.poll() first. Otherwise true only for the thread that actually owns the wake
+// event: mp_sched_thread_can_run_callbacks() is false for every thread but the main one,
+// and mp_hal_wake_event_fd() can be unavailable regardless (e.g. before HAL init).
+static bool poll_set_signal_wake_is_reliable(void) {
+    #if MICROPY_PY_THREAD && MICROPY_PY_THREAD_GIL
+    return false;
+    #else
+    return mp_sched_thread_can_run_callbacks() && mp_hal_wake_event_fd() >= 0;
+    #endif
+}
+#endif
+
 // Whether the wait loop may block on poll() for the full remaining deadline instead of the
-// period-capped sweep below. True when every registered entry has a pollfd: the map/used
-// count comparison below is exactly that, since poll_set_add_fd() is invoked for every
-// registered entry that has any fd at all, composed or fully authoritative.
+// period-capped sweep below. True when every registered entry has a wake source the loop
+// can block on: either a pollfd, or (with MICROPY_PY_SELECT_EVENT_SOURCE) a declared
+// SOURCE_SIGNAL callback whose wake token this thread is entitled to rely on.
 //
 // A composed entry -- fd-backed but not fd-authoritative (e.g. SSL: SOURCE_FD without
 // FD_IS_READINESS), readiness resolved by its own MP_STREAM_POLL ioctl -- qualifies for the
@@ -351,15 +402,27 @@ static struct pollfd *poll_set_add_fd(poll_set_t *poll_set, int fd) {
 // poll_set_poll_until_ready_or_timeout() below asks every composed entry once, unconditionally,
 // before ever computing this gate's timeout -- not only after poll() returns.
 //
-// An entry with no fd at all still cannot qualify, and does not reach the reasoning above: it
-// has nothing in poll_set->pollfds to wake it in the first place, composed or not, so the
-// count check alone already excludes it.
-static bool poll_set_all_are_fds(poll_set_t *poll_set) {
+// A SOURCE_SIGNAL entry, fd-backed or not, qualifies once poll_set_signal_wake_is_reliable()
+// is true: its readiness can change at arbitrary times from an ISR or another thread, with
+// nothing in poll_set->pollfds to wake a block for a fd-less one, so the block can only be
+// trusted to end on time because the wake event's token is guaranteed to survive until this
+// thread's own poll() consumes it. When that guarantee does not hold, every entry in the set
+// falls back to the period-capped sweep below, including any composed or fully authoritative
+// one also registered here, since the sweep is a property of the whole wait, not of one entry.
+//
+// An entry with no fd and no declared wake source at all still cannot qualify: it has nothing
+// to wake a block for, composed, signalled, or otherwise.
+static bool poll_set_all_have_wake_sources(poll_set_t *poll_set) {
     #if MICROPY_PY_SELECT_EVENT_SOURCE
+    assert(poll_set->n_signal_nofd <= poll_set->n_signal && poll_set->n_signal <= poll_set->map.used);
     // poll_set->used counts the reserved wake-event slot at pollfds[0] (see poll_set_init),
-    // which is not a registered object, so map.used is one less than used whenever every
-    // registered entry also has a pollfd.
-    return poll_set->map.used == (mp_uint_t)(poll_set->used - 1);
+    // which is not a registered object, so map.used is one less than used for every
+    // registered entry that has a pollfd, plus one for each fd-less SOURCE_SIGNAL entry,
+    // which has no pollfd but does have a wake source.
+    if (poll_set->map.used != (mp_uint_t)(poll_set->used - 1) + poll_set->n_signal_nofd) {
+        return false;
+    }
+    return poll_set->n_signal == 0 || poll_set_signal_wake_is_reliable();
     #else
     return poll_set->map.used == poll_set->used;
     #endif
@@ -461,6 +524,14 @@ static void poll_set_add_obj(poll_set_t *poll_set, const mp_obj_t *obj, mp_uint_
                 // Object doesn't have a file descriptor.
                 poll_obj->pollfd = NULL;
             }
+            #if MICROPY_PY_SELECT_EVENT_SOURCE
+            if (poll_obj_counts_as_signal(poll_obj)) {
+                poll_set->n_signal++;
+                if (poll_obj->pollfd == NULL) {
+                    poll_set->n_signal_nofd++;
+                }
+            }
+            #endif
             #else
             const mp_stream_p_t *stream_p = mp_get_stream_raise(obj[i], MP_STREAM_OP_IOCTL);
             poll_obj->ioctl = stream_p->ioctl;
@@ -605,7 +676,7 @@ static void poll_set_reset_revents(poll_set_t *poll_set) {
 //   is a counting drain, not one this loop controls), so the counter checked via
 //   `signalled` is the only thing left that still catches it.
 //
-// See poll_set_all_are_fds()'s doc comment for why the composed-entry ask in particular
+// See poll_set_all_have_wake_sources()'s doc comment for why the composed-entry ask in particular
 // has to happen before the deadline-sleep gate is consulted.
 static mp_uint_t poll_set_resolve_pre_block(poll_set_t *poll_set, bool first_pass, bool signalled) {
     mp_uint_t n_ready = 0;
@@ -675,9 +746,13 @@ static mp_uint_t poll_set_resolve_readiness(poll_set_t *poll_set) {
             }
             poll_obj_set_revents(poll_obj, ret);
         }
-        // Else skipped: poll_obj->revents keeps the value from the previous pass, which is
-        // necessarily 0; a non-zero value here would have made the previous pass return
-        // rather than call poll() and loop back round.
+        // Else skipped: poll_obj->revents keeps whatever this entry was last resolved to.
+        // For a fd-authoritative entry that is necessarily 0, carried over from a previous
+        // pass (a non-zero value there would have already ended that pass). For a composed
+        // or hybrid-signal entry it may instead be the non-zero value poll_set_resolve_pre_block()
+        // left here earlier in this same pass, before poll() ran with a forced zero timeout to
+        // collect fresh state for the rest of the set; that value is still current since
+        // nothing between the two calls could have changed it.
 
         if (poll_obj->revents != 0) {
             n_ready += 1;
@@ -712,15 +787,20 @@ static mp_uint_t poll_set_poll_until_ready_or_timeout(poll_set_t *poll_set, size
         #if MICROPY_PY_SELECT_EVENT_SOURCE
         poll_set_refresh_fd_events(poll_set);
 
+        // Whether the pre-block ask below found an entry already ready. Never returned on
+        // directly: doing so would report only the entries this ask resolves (composed and
+        // signal entries) without ever calling poll(), leaving every fd-authoritative entry's
+        // pollfd->revents at the zero poll_set_reset_revents() left it, so a fd-authoritative
+        // entry that was already readable when this call began would go unreported. Recorded
+        // here and forced into the timeout below instead, so poll() still runs, non-blocking,
+        // and poll_set_resolve_readiness() after it resolves every entry in one place.
+        bool pre_block_ready = false;
         bool signalled = poll_set_take_signal(poll_set);
         if (first_pass || signalled) {
             if (first_pass) {
                 poll_set_reset_revents(poll_set);
             }
-            mp_uint_t n_ready = poll_set_resolve_pre_block(poll_set, first_pass, signalled);
-            if (n_ready > 0) {
-                return n_ready;
-            }
+            pre_block_ready = poll_set_resolve_pre_block(poll_set, first_pass, signalled) > 0;
         }
         #endif
 
@@ -731,12 +811,16 @@ static mp_uint_t poll_set_poll_until_ready_or_timeout(poll_set_t *poll_set, size
         // never drain it would be a lost wakeup for whichever thread actually needed it, so
         // this thread's poll() falls back to the periodic sweep below instead.
         //
-        // KNOWN GAP: on a GIL build, mp_sched_thread_can_run_callbacks() returns true for
-        // every thread, not just the one that owns this wait. Two threads each running their
-        // own select.poll() with the wake fd both injected would race to drain it, and
-        // whichever loses never sees its own wakeup. Fine for this branch's single-threaded
-        // asyncio measurement; not a resolved answer for increment 1 in general (unix-sleep-
-        // process-pending flagged this, 2026-07-29).
+        // On a GIL build, mp_sched_thread_can_run_callbacks() returns true for every thread,
+        // not just the one that owns this wait, so two threads each running their own
+        // select.poll() with the wake fd both injected race to drain it, and whichever loses
+        // sees no wakeup from this fd on that pass. This is exactly the race
+        // poll_set_signal_wake_is_reliable() is false for on every GIL build: a SOURCE_SIGNAL
+        // entry never depends on this fd surviving to end a deadline block, since
+        // poll_set_all_have_wake_sources() falls back to the period-capped sweep below
+        // whenever the set holds one, bounding a lost drain to one sweep period rather than
+        // the full timeout. A purely fd-backed or composed entry is unaffected either way, as
+        // neither relies on this reserved slot for its own readiness.
         poll_set->pollfds[0].fd = mp_sched_thread_can_run_callbacks() ? mp_hal_wake_event_fd() : -1;
         poll_set->pollfds[0].events = POLLIN;
         poll_set->pollfds[0].revents = 0;
@@ -746,7 +830,15 @@ static mp_uint_t poll_set_poll_until_ready_or_timeout(poll_set_t *poll_set, size
 
         // Compute the timeout.
         int t = MICROPY_PY_SELECT_IOCTL_CALL_PERIOD_MS;
-        if (poll_set_all_are_fds(poll_set)) {
+        #if MICROPY_PY_SELECT_EVENT_SOURCE
+        if (pre_block_ready) {
+            // Never block: the pre-block ask above already found something ready, so this
+            // call to poll() exists only to collect fresh kernel state for the rest of the
+            // set (see pre_block_ready's declaration above), not to wait for anything.
+            t = 0;
+        } else
+        #endif
+        if (poll_set_all_have_wake_sources(poll_set)) {
             // All our pollables are file descriptors, so we can use a blocking
             // poll and let it (the underlying system) handle the timeout.
             if (timeout == (mp_uint_t)-1) {
@@ -922,7 +1014,14 @@ static mp_obj_t poll_unregister(mp_obj_t self_in, mp_obj_t obj_in) {
     if (elem != NULL) {
         poll_obj_t *poll_obj = (poll_obj_t *)MP_OBJ_TO_PTR(elem->value);
         #if MICROPY_PY_SELECT_EVENT_SOURCE
+        // is_signal drives the Unregister ioctl call below, issued for any stream that
+        // declared SOURCE_SIGNAL so it can release its stored cb/ctx, regardless of
+        // whether that declaration also counted toward n_signal/n_signal_nofd. counts_as_signal
+        // mirrors the condition poll_set_add_obj() incremented under, so the decrement
+        // here can never touch a counter this entry never contributed to.
         bool is_signal = (poll_obj->event_flags & MP_STREAM_EVENT_SOURCE_SIGNAL) != 0;
+        bool counts_as_signal = poll_obj_counts_as_signal(poll_obj);
+        bool is_signal_nofd = counts_as_signal && poll_obj->pollfd == NULL;
         #endif
         if (poll_obj->pollfd != NULL) {
             poll_obj->pollfd->fd = -1;
@@ -936,6 +1035,16 @@ static mp_obj_t poll_unregister(mp_obj_t self_in, mp_obj_t obj_in) {
         }
         elem->value = MP_OBJ_NULL;
         #if MICROPY_PY_SELECT_EVENT_SOURCE
+        // n_signal/n_signal_nofd are brought back in step with map.used here, before the
+        // Unregister ioctl below that can re-enter Python: poll_set_all_have_wake_sources()
+        // must never see a registration this entry no longer holds, even if that ioctl call
+        // triggers nested access to this poll set.
+        if (counts_as_signal) {
+            --self->poll_set.n_signal;
+            if (is_signal_nofd) {
+                --self->poll_set.n_signal_nofd;
+            }
+        }
         // Issued only for a stream that declared SOURCE_SIGNAL, after every poll-set
         // mutation above is complete: mp_map_lookup() with MP_MAP_LOOKUP_REMOVE_IF_FOUND
         // has already cleared this slot's key and decremented map->used, so poll_obj is

--- a/extmod/modselect.c
+++ b/extmod/modselect.c
@@ -443,20 +443,20 @@ static bool poll_set_signal_wake_is_reliable(poll_set_t *poll_set) {
 // can block on: either a pollfd, or (with MICROPY_PY_SELECT_EVENT_SOURCE) a declared
 // SOURCE_SIGNAL callback whose wake token this thread is entitled to rely on.
 //
-// A composed entry -- fd-backed but not fd-authoritative (e.g. SSL: SOURCE_FD without
-// FD_IS_READINESS), readiness resolved by its own MP_STREAM_POLL ioctl -- qualifies for the
+// A composed entry, fd-backed but not fd-authoritative (e.g. SSL: SOURCE_FD without
+// FD_IS_READINESS), readiness resolved by its own MP_STREAM_POLL ioctl, qualifies for the
 // same deadline block as a fully authoritative one, given two things elsewhere in this loop
 // that make it safe: its own fd is already in poll_set->pollfds regardless of authoritative-
 // ness (poll_set_add_obj() adds it via poll_set_add_fd() and seeds pollfd->events from its
 // own declared fd_events), so new kernel activity on it wakes poll() directly, and its
 // readiness can only change as the result of this loop's own
-// ioctl call -- never spontaneously while nothing is polling it -- so there is nothing for a
+// ioctl call, never spontaneously while nothing is polling it, so there is nothing for a
 // deadline block to miss between one wake and the next. What it cannot do on its own is
 // surface readiness that already existed *before* this wait began (e.g. a TLS record larger
 // than the caller's last read() left a remainder decrypted-but-unread, with nothing new at
 // the fd level to signal it): that has no fd signal to wake a block on, which is exactly why
 // poll_set_poll_until_ready_or_timeout() below asks every composed entry once, unconditionally,
-// before ever computing this gate's timeout -- not only after poll() returns.
+// before ever computing this gate's timeout, not only after poll() returns.
 //
 // A SOURCE_SIGNAL entry, fd-backed or not, qualifies once poll_set_signal_wake_is_reliable()
 // is true: its readiness can change at arbitrary times from an ISR or another thread, with
@@ -713,7 +713,7 @@ static void poll_set_refresh_fd_events(poll_set_t *poll_set) {
 // value poll() left in it from a previous, unrelated call to this same poll set. The
 // caller then walks every registered entry and collects every non-zero one into a list
 // sized for the n_ready this function returned, so a stale non-zero here is a mismatched
-// count, not just a wrong answer -- one entry too many for the list's allocation.
+// count, not just a wrong answer; one entry too many for the list's allocation.
 static void poll_set_reset_revents(poll_set_t *poll_set) {
     for (mp_uint_t i = 0; i < poll_set->map.alloc; ++i) {
         if (!mp_map_slot_is_filled(&poll_set->map, i)) {

--- a/extmod/modtls_mbedtls.c
+++ b/extmod/modtls_mbedtls.c
@@ -1006,7 +1006,7 @@ static mp_uint_t socket_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t arg, i
             // whenever the socket is known non-blocking, so a pump can safely force
             // decryption; on a socket that may block, readiness falls back to "the library
             // has some buffered record" (mbedtls_ssl_check_pending) instead, since pumping
-            // there risks a real blocking syscall -- see the sock_may_block branch below.
+            // there risks a real blocking syscall; see the sock_may_block branch below.
             bool has_data = mbedtls_ssl_get_bytes_avail(&self->ssl) > 0;
             if (!has_data && mbedtls_ssl_check_pending(&self->ssl)) {
                 // A record is buffered but not yet decrypted (a held handshake message, or
@@ -1014,22 +1014,22 @@ static mp_uint_t socket_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t arg, i
                 if (self->sock_may_block) {
                     // The pump below calls mbedtls_ssl_read, which reaches the underlying
                     // socket's recv() via the BIO callback. On a blocking socket that recv()
-                    // is a real synchronous syscall -- nothing in mbedtls error codes can
+                    // is a real synchronous syscall, and nothing in mbedtls error codes can
                     // prevent it. MP_STREAM_POLL is contractually non-blocking (called from
                     // poll()'s wait loop), so pumping here could make poll(timeout) block
                     // past its own timeout. When the socket may block, skip the pump and
                     // report ready on check_pending alone, exactly as the pre-event-source
                     // code does: a held handshake message polls ready with no progress until
                     // a real read processes it, the same narrow spin risk that already
-                    // exists without this mechanism. The alternative -- reporting not-ready
-                    // here -- would be a regression: nothing else will ever wake this poll
+                    // exists without this mechanism. The alternative, reporting not-ready
+                    // here, would be a regression: nothing else will ever wake this poll
                     // for a record that already fully arrived on the wire, so the caller
                     // would wait out its full timeout instead of spinning.
                     has_data = true;
                 } else {
                     // Pump with a zero-length read to force decryption without consuming
-                    // any application bytes -- mbedtls_ssl_read copies min(len, avail), and
-                    // len == 0 copies nothing -- then re-check. A held handshake message is
+                    // any application bytes; mbedtls_ssl_read copies min(len, avail), and
+                    // len == 0 copies nothing. Then re-check: a held handshake message is
                     // processed and yields no application data, so this correctly converges
                     // to not-ready; a complete application record decrypts and correctly
                     // becomes ready on the re-check below.

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -390,7 +390,6 @@ static MP_DEFINE_CONST_DICT(signal_stream_locals_dict, signal_stream_locals_dict
 // the degraded path deliberately: the real trigger is descriptor or memory exhaustion,
 // which a test cannot produce without taking the harness around it down too.
 static mp_obj_t signal_stream_force_wake_obj_failure(mp_obj_t enable_in) {
-    extern bool mp_hal_wake_obj_force_open_failure;
     mp_hal_wake_obj_force_open_failure = mp_obj_is_true(enable_in);
     return mp_const_none;
 }

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -385,6 +385,17 @@ static const mp_rom_map_elem_t signal_stream_locals_dict_table[] = {
 };
 static MP_DEFINE_CONST_DICT(signal_stream_locals_dict, signal_stream_locals_dict_table);
 
+// Makes this port report that it cannot create a wake primitive, so a thread claiming one
+// from here on is handed the backing-less object instead. Exposed only so a test can reach
+// the degraded path deliberately: the real trigger is descriptor or memory exhaustion,
+// which a test cannot produce without taking the harness around it down too.
+static mp_obj_t signal_stream_force_wake_obj_failure(mp_obj_t enable_in) {
+    extern bool mp_hal_wake_obj_force_open_failure;
+    mp_hal_wake_obj_force_open_failure = mp_obj_is_true(enable_in);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(mp_select_force_wake_obj_failure_obj, signal_stream_force_wake_obj_failure);
+
 static const mp_stream_p_t signal_stream_p = {
     .ioctl = signal_stream_ioctl,
 };

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -1,6 +1,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
 
 #include "py/obj.h"
 #include "py/objfun.h"
@@ -20,6 +23,7 @@
 #include "py/binary.h"
 #include "py/bc.h"
 #include "py/mphal.h"
+#include "py/mperrno.h"
 
 // expected output of this file is found in extra_coverage.py.exp
 
@@ -147,6 +151,254 @@ static MP_DEFINE_CONST_OBJ_TYPE(
     protocol, &textio_stream_p2,
     locals_dict, &rawfile_locals_dict2
     );
+
+#if MICROPY_PY_SELECT_EVENT_SOURCE
+
+// A stream that answers MP_STREAM_SET_EVENT_SOURCE itself, standing in for a hardware
+// driver so the SOURCE_SIGNAL wake path is testable on unix without real hardware. Built
+// with no fd (SelectSignalStream()) it registers as a bare wake source; built with_fd=True
+// it opens its own pipe(2) pair and registers as SOURCE_FD, FD_DYNAMIC and SOURCE_SIGNAL
+// together, matching a driver that is both fd-backed and able to raise spontaneously (e.g.
+// an interrupt landing between two poll() calls on its own fd). The pipe is internal, not
+// Python's os.pipe, because the unix port exposes no fd-returning call a test could use to
+// supply one from outside.
+//
+// ready is this stream's answer to MP_STREAM_POLL, set independently of any fd; signal()
+// updates it and then invokes the armed callback synchronously, standing in for an ISR or
+// another thread calling mp_event_signal() through it. write_fd() and drain_fd() drive and
+// clear real activity on the pipe's read end, for cases that must exercise the kernel's own
+// poll() wake rather than this stream's readiness answer. arm_count follows the O3b
+// contract: a stream declaring SOURCE_SIGNAL can be registered into more than one poll set
+// sharing this one cb/ctx pair, so it counts registrations and releases them only when the
+// count returns to zero, never on every individual Unregister.
+typedef struct _mp_obj_signal_stream_t {
+    mp_obj_base_t base;
+    int fd;    // read end registered with select.poll(), or -1 if this entry has no fd
+    int wr_fd; // write end for write_fd(), or -1 if this entry has no fd
+    uint16_t ready;
+    uint16_t poll_count;
+    uint8_t arm_count;
+    // 0xff before the first MP_STREAM_SET_EVENT_SOURCE call; otherwise one of the
+    // MP_STREAM_EVENT_OP_* values from py/stream.h.
+    uint8_t last_op;
+    void (*cb)(void *ctx);
+    void *ctx;
+} mp_obj_signal_stream_t;
+
+static mp_obj_t signal_stream_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 0, 1, false);
+    mp_obj_signal_stream_t *o = mp_obj_malloc(mp_obj_signal_stream_t, type);
+    o->fd = -1;
+    o->wr_fd = -1;
+    if (n_args > 0 && mp_obj_is_true(args[0])) {
+        int fds[2];
+        if (pipe(fds) != 0) {
+            mp_raise_OSError(errno);
+        }
+        // Non-blocking so drain_fd() can read until empty without risking a wait of its
+        // own; a blocking pipe would hang there once the last pending byte is consumed.
+        if (fcntl(fds[0], F_SETFL, O_NONBLOCK) != 0 || fcntl(fds[1], F_SETFL, O_NONBLOCK) != 0) {
+            int e = errno;
+            close(fds[0]);
+            close(fds[1]);
+            mp_raise_OSError(e);
+        }
+        o->fd = fds[0];
+        o->wr_fd = fds[1];
+    }
+    o->ready = 0;
+    o->poll_count = 0;
+    o->arm_count = 0;
+    o->last_op = 0xff;
+    o->cb = NULL;
+    o->ctx = NULL;
+    return MP_OBJ_FROM_PTR(o);
+}
+
+static mp_obj_t signal_stream_set_ready(mp_obj_t self_in, mp_obj_t mask_in) {
+    mp_obj_signal_stream_t *self = MP_OBJ_TO_PTR(self_in);
+    self->ready = mp_obj_get_int(mask_in);
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_2(signal_stream_set_ready_obj, signal_stream_set_ready);
+
+static mp_obj_t signal_stream_write_fd(mp_obj_t self_in) {
+    mp_obj_signal_stream_t *self = MP_OBJ_TO_PTR(self_in);
+    if (self->wr_fd < 0) {
+        mp_raise_OSError(MP_EINVAL);
+    }
+    if (write(self->wr_fd, "x", 1) != 1) {
+        mp_raise_OSError(errno);
+    }
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(signal_stream_write_fd_obj, signal_stream_write_fd);
+
+// Reads self->fd empty and returns the byte count read, or 0 if the stream has no fd.
+// Shared by drain_fd() and the MP_STREAM_POLL case: a hybrid SOURCE_FD+SOURCE_SIGNAL entry
+// must not leave its fd readable once it has told the wait loop it is not ready, or the
+// kernel poll() call at the top of every remaining loop iteration wakes on the fd and spins
+// until the timeout expires.
+static mp_int_t signal_stream_drain(mp_obj_signal_stream_t *self) {
+    if (self->fd < 0) {
+        return 0;
+    }
+    char buf[64];
+    mp_int_t total = 0;
+    for (;;) {
+        ssize_t n = read(self->fd, buf, sizeof(buf));
+        if (n < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                break;
+            }
+            mp_raise_OSError(errno);
+        }
+        if (n == 0) {
+            break;
+        }
+        total += n;
+    }
+    return total;
+}
+
+static mp_obj_t signal_stream_drain_fd(mp_obj_t self_in) {
+    mp_obj_signal_stream_t *self = MP_OBJ_TO_PTR(self_in);
+    if (self->fd < 0) {
+        mp_raise_OSError(MP_EINVAL);
+    }
+    return mp_obj_new_int(signal_stream_drain(self));
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(signal_stream_drain_fd_obj, signal_stream_drain_fd);
+
+static mp_obj_t signal_stream_close(mp_obj_t self_in) {
+    mp_obj_signal_stream_t *self = MP_OBJ_TO_PTR(self_in);
+    if (self->fd >= 0) {
+        close(self->fd);
+        self->fd = -1;
+    }
+    if (self->wr_fd >= 0) {
+        close(self->wr_fd);
+        self->wr_fd = -1;
+    }
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(signal_stream_close_obj, signal_stream_close);
+
+static mp_obj_t signal_stream_signal(mp_obj_t self_in, mp_obj_t mask_in) {
+    mp_obj_signal_stream_t *self = MP_OBJ_TO_PTR(self_in);
+    self->ready = mp_obj_get_int(mask_in);
+    if (self->cb != NULL) {
+        self->cb(self->ctx);
+    }
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_2(signal_stream_signal_obj, signal_stream_signal);
+
+static mp_obj_t signal_stream_poll_count(mp_obj_t self_in) {
+    mp_obj_signal_stream_t *self = MP_OBJ_TO_PTR(self_in);
+    return mp_obj_new_int(self->poll_count);
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(signal_stream_poll_count_obj, signal_stream_poll_count);
+
+static mp_obj_t signal_stream_arm_count(mp_obj_t self_in) {
+    mp_obj_signal_stream_t *self = MP_OBJ_TO_PTR(self_in);
+    return mp_obj_new_int(self->arm_count);
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(signal_stream_arm_count_obj, signal_stream_arm_count);
+
+static mp_obj_t signal_stream_last_op(mp_obj_t self_in) {
+    mp_obj_signal_stream_t *self = MP_OBJ_TO_PTR(self_in);
+    if (self->last_op == 0xff) {
+        return mp_const_none;
+    }
+    return mp_obj_new_int(self->last_op);
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(signal_stream_last_op_obj, signal_stream_last_op);
+
+static mp_uint_t signal_stream_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t arg, int *errcode) {
+    mp_obj_signal_stream_t *o = MP_OBJ_TO_PTR(o_in);
+    switch (request) {
+        case MP_STREAM_POLL:
+            ++o->poll_count;
+            if ((o->ready & arg) == 0 && o->fd >= 0) {
+                // Not ready by this stream's own answer: drain the fd so it stops
+                // satisfying the kernel poll() that the wait loop layers on top of it.
+                signal_stream_drain(o);
+            }
+            return o->ready & arg;
+
+        case MP_STREAM_GET_FILENO:
+            if (o->fd < 0) {
+                *errcode = MP_EINVAL;
+                return MP_STREAM_ERROR;
+            }
+            return o->fd;
+
+        case MP_STREAM_SET_EVENT_SOURCE: {
+            mp_stream_event_source_t *source = (mp_stream_event_source_t *)arg;
+            o->last_op = source->op;
+            switch (source->op) {
+                case MP_STREAM_EVENT_OP_REGISTER:
+                    o->cb = source->cb;
+                    o->ctx = source->ctx;
+                    ++o->arm_count;
+                    source->fd = o->fd;
+                    source->flags = MP_STREAM_EVENT_SOURCE_SIGNAL;
+                    if (o->fd >= 0) {
+                        source->flags |= MP_STREAM_EVENT_SOURCE_FD | MP_STREAM_EVENT_FD_DYNAMIC;
+                        source->fd_events = source->events;
+                    } else {
+                        source->fd_events = 0;
+                    }
+                    break;
+                case MP_STREAM_EVENT_OP_REFRESH:
+                    source->fd_events = source->events;
+                    break;
+                case MP_STREAM_EVENT_OP_UNREGISTER:
+                    // arm_count is never 0 here: an Unregister is issued only for an entry
+                    // that is currently registered, and every Register that reached this
+                    // stream incremented it first.
+                    --o->arm_count;
+                    if (o->arm_count == 0) {
+                        o->cb = NULL;
+                        o->ctx = NULL;
+                    }
+                    break;
+            }
+            return 0;
+        }
+
+        default:
+            return 0;
+    }
+}
+
+static const mp_rom_map_elem_t signal_stream_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_set_ready), MP_ROM_PTR(&signal_stream_set_ready_obj) },
+    { MP_ROM_QSTR(MP_QSTR_signal), MP_ROM_PTR(&signal_stream_signal_obj) },
+    { MP_ROM_QSTR(MP_QSTR_poll_count), MP_ROM_PTR(&signal_stream_poll_count_obj) },
+    { MP_ROM_QSTR(MP_QSTR_arm_count), MP_ROM_PTR(&signal_stream_arm_count_obj) },
+    { MP_ROM_QSTR(MP_QSTR_last_op), MP_ROM_PTR(&signal_stream_last_op_obj) },
+    { MP_ROM_QSTR(MP_QSTR_write_fd), MP_ROM_PTR(&signal_stream_write_fd_obj) },
+    { MP_ROM_QSTR(MP_QSTR_drain_fd), MP_ROM_PTR(&signal_stream_drain_fd_obj) },
+    { MP_ROM_QSTR(MP_QSTR_close), MP_ROM_PTR(&signal_stream_close_obj) },
+};
+static MP_DEFINE_CONST_DICT(signal_stream_locals_dict, signal_stream_locals_dict_table);
+
+static const mp_stream_p_t signal_stream_p = {
+    .ioctl = signal_stream_ioctl,
+};
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    mp_type_signal_stream,
+    MP_QSTR_SelectSignalStream,
+    MP_TYPE_FLAG_NONE,
+    make_new, signal_stream_make_new,
+    protocol, &signal_stream_p,
+    locals_dict, &signal_stream_locals_dict
+    );
+
+#endif // MICROPY_PY_SELECT_EVENT_SOURCE
 
 // str/bytes objects without a valid hash
 static const mp_obj_str_t str_no_hash_obj = {{&mp_type_str}, 0, 10, (const byte *)"0123456789"};

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -580,7 +580,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
         mp_store_global(MP_QSTR_SelectSignalStream, MP_OBJ_FROM_PTR(&mp_type_signal_stream));
         // Forces the port to report that it cannot create a wake primitive, so a test can
         // reach the degraded claim without exhausting real descriptors (see coverage.c).
-        extern const mp_obj_fun_builtin_fixed_t mp_select_force_wake_obj_failure_obj;
+        MP_DECLARE_CONST_FUN_OBJ_1(mp_select_force_wake_obj_failure_obj);
         mp_store_global(MP_QSTR_select_force_wake_obj_failure, MP_OBJ_FROM_PTR(&mp_select_force_wake_obj_failure_obj));
         #endif
     }

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -573,6 +573,12 @@ MP_NOINLINE int main_(int argc, char **argv) {
         MP_DECLARE_CONST_FUN_OBJ_0(extra_cpp_coverage_obj);
         mp_store_global(MP_QSTR_extra_coverage, MP_OBJ_FROM_PTR(&extra_coverage_obj));
         mp_store_global(MP_QSTR_extra_cpp_coverage, MP_OBJ_FROM_PTR(&extra_cpp_coverage_obj));
+        #if MICROPY_PY_SELECT_EVENT_SOURCE
+        // A synthetic stream driving MP_STREAM_SET_EVENT_SOURCE itself (see coverage.c),
+        // so the SOURCE_SIGNAL wake path has coverage on unix without real hardware.
+        extern const mp_obj_type_t mp_type_signal_stream;
+        mp_store_global(MP_QSTR_SelectSignalStream, MP_OBJ_FROM_PTR(&mp_type_signal_stream));
+        #endif
     }
     #endif
 

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -578,6 +578,10 @@ MP_NOINLINE int main_(int argc, char **argv) {
         // so the SOURCE_SIGNAL wake path has coverage on unix without real hardware.
         extern const mp_obj_type_t mp_type_signal_stream;
         mp_store_global(MP_QSTR_SelectSignalStream, MP_OBJ_FROM_PTR(&mp_type_signal_stream));
+        // Forces the port to report that it cannot create a wake primitive, so a test can
+        // reach the degraded claim without exhausting real descriptors (see coverage.c).
+        extern const mp_obj_fun_builtin_fixed_t mp_select_force_wake_obj_failure_obj;
+        mp_store_global(MP_QSTR_select_force_wake_obj_failure, MP_OBJ_FROM_PTR(&mp_select_force_wake_obj_failure_obj));
         #endif
     }
     #endif

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -168,6 +168,16 @@ typedef long mp_off_t;
 
 #define MICROPY_PY_SOCKET_LISTEN_BACKLOG_DEFAULT (SOMAXCONN < 128 ? SOMAXCONN : 128)
 
+// Raises reach mp_event_signal() from other threads and from POSIX signal handlers, so two
+// can interleave and a plain increment would lose one. Release/acquire rather than relaxed:
+// a waiter that observes movement must also observe the driver's state write that preceded
+// the raise, and pairing it here rather than leaning on the write() to the wake descriptor
+// keeps that guarantee attached to the counter the waiter actually reads (py/mphal.h).
+#define MICROPY_EVENT_SIGNAL_COUNT_INC() \
+    __atomic_fetch_add(&mp_event_signal_count, 1, __ATOMIC_RELEASE)
+#define MICROPY_EVENT_SIGNAL_COUNT_GET() \
+    __atomic_load_n(&mp_event_signal_count, __ATOMIC_ACQUIRE)
+
 // Per-thread wake objects (py/mphal.h), implemented in unix_mphal.c. Declared here
 // rather than in mphalport.h: ports/windows/windows_mphal.h includes that header
 // wholesale while ports/windows/Makefile compiles windows_mphal.c instead of

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -168,6 +168,25 @@ typedef long mp_off_t;
 
 #define MICROPY_PY_SOCKET_LISTEN_BACKLOG_DEFAULT (SOMAXCONN < 128 ? SOMAXCONN : 128)
 
+// Per-thread wake objects (py/mphal.h), implemented in unix_mphal.c. Declared here
+// rather than in mphalport.h: ports/windows/windows_mphal.h includes that header
+// wholesale while ports/windows/Makefile compiles windows_mphal.c instead of
+// unix_mphal.c, so a capability declared in mphalport.h would make core code call a
+// symbol windows does not link. windows never includes this file.
+//
+// Gated on MICROPY_PY_THREAD: with a single thread, the shared wake event already has
+// exactly one possible consumer, so a dedicated pool of descriptors per thread buys
+// nothing and only costs open file descriptors.
+#define MICROPY_HAL_HAS_WAKE_OBJ (MICROPY_PY_THREAD)
+#define MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD (MICROPY_PY_THREAD)
+
+// How many threads can hold a wake object at once. Past it,
+// mp_hal_wake_obj_this_thread() answers NULL and that thread falls back to the shared
+// wake event and its entitlement-gated, period-capped sweep.
+#ifndef MICROPY_HAL_WAKE_OBJ_MAX
+#define MICROPY_HAL_WAKE_OBJ_MAX (4)
+#endif
+
 // Bare-metal ports don't have stderr. Printing debug to stderr may give tests
 // which check stdout a chance to pass, etc.
 extern const struct _mp_print_t mp_stderr_print;

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -190,6 +190,11 @@ typedef long mp_off_t;
 #define MICROPY_HAL_HAS_WAKE_OBJ (MICROPY_PY_THREAD)
 #define MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD (MICROPY_PY_THREAD)
 
+// The shared wake event is opened, and so has a descriptor to offer, only on a build with
+// no per-thread objects; with them every waiter has its own and the shared one has no
+// reader (see mp_hal_wake_event_init()).
+#define MICROPY_HAL_WAKE_EVENT_HAS_POSIX_FD (!MICROPY_HAL_HAS_WAKE_OBJ)
+
 // Bare-metal ports don't have stderr. Printing debug to stderr may give tests
 // which check stdout a chance to pass, etc.
 extern const struct _mp_print_t mp_stderr_print;

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -185,17 +185,10 @@ typedef long mp_off_t;
 // symbol windows does not link. windows never includes this file.
 //
 // Gated on MICROPY_PY_THREAD: with a single thread, the shared wake event already has
-// exactly one possible consumer, so a dedicated pool of descriptors per thread buys
-// nothing and only costs open file descriptors.
+// exactly one possible consumer, so a dedicated object per thread buys nothing and only
+// costs open file descriptors.
 #define MICROPY_HAL_HAS_WAKE_OBJ (MICROPY_PY_THREAD)
 #define MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD (MICROPY_PY_THREAD)
-
-// How many threads can hold a wake object at once. Past it,
-// mp_hal_wake_obj_this_thread() answers NULL and that thread falls back to the shared
-// wake event and its entitlement-gated, period-capped sweep.
-#ifndef MICROPY_HAL_WAKE_OBJ_MAX
-#define MICROPY_HAL_WAKE_OBJ_MAX (4)
-#endif
 
 // Bare-metal ports don't have stderr. Printing debug to stderr may give tests
 // which check stdout a chance to pass, etc.

--- a/ports/unix/mphalport.h
+++ b/ports/unix/mphalport.h
@@ -47,9 +47,9 @@
     } while (0)
 
 #if MICROPY_HAL_HAS_WAKE_OBJ
-// Gives this thread's claimed wake object, if any, back to the pool. Called from
-// mp_thread_finish(); never from a wait, since a wake object is held for a thread's
-// whole lifetime rather than borrowed per wait.
+// Returns this thread's claimed wake object, if any, for another thread to claim.
+// Called from mp_thread_finish(); never from a wait, since a wake object is held for a
+// thread's whole lifetime rather than borrowed per wait.
 void mp_hal_wake_obj_release_this_thread(void);
 #endif
 

--- a/ports/unix/mphalport.h
+++ b/ports/unix/mphalport.h
@@ -46,6 +46,13 @@
         MP_THREAD_GIL_ENTER(); \
     } while (0)
 
+#if MICROPY_HAL_HAS_WAKE_OBJ
+// Gives this thread's claimed wake object, if any, back to the pool. Called from
+// mp_thread_finish(); never from a wait, since a wake object is held for a thread's
+// whole lifetime rather than borrowed per wait.
+void mp_hal_wake_obj_release_this_thread(void);
+#endif
+
 // The port provides `mp_hal_stdio_mode_raw()` and `mp_hal_stdio_mode_orig()`.
 #define MICROPY_HAL_HAS_STDIO_MODE_SWITCH (1)
 

--- a/ports/unix/mphalport.h
+++ b/ports/unix/mphalport.h
@@ -145,21 +145,8 @@ void mp_hal_wake_event_wait_ms(mp_uint_t timeout_ms);
 // timeout.  Returns 0 on timeout, or -1 with errno EINTR if cut short.
 int mp_hal_wake_event_wait_tv(struct timeval *tv);
 
-// The descriptor the wake event can be waited on, for a caller that runs its own
-// poll set and wants the event in it alongside its own descriptors, or -1 when
-// there is none to give.  Defined only where the wake event is backed by a
-// descriptor, so on this port and not on Windows.
-//
-// Drain it after, and only after, it has polled readable.  It is
-// level-triggered, so it stays readable until drained, and draining before a
-// wait instead discards a raise and leaves that wait with nothing to end it.
-//
-// Declared only where per-thread wake objects are unavailable: with them, a poll set
-// injects this thread's own object instead and these have no caller.
-#if !MICROPY_HAL_HAS_WAKE_OBJ
-int mp_hal_wake_event_fd(void);
-void mp_hal_wake_event_drain(void);
-#endif
+// mp_hal_wake_event_fd() and mp_hal_wake_event_drain() are declared in py/mphal.h, behind
+// MICROPY_HAL_WAKE_EVENT_HAS_POSIX_FD, because extmod/modselect.c calls them.
 
 #if MICROPY_PY_BLUETOOTH
 enum {

--- a/ports/unix/mphalport.h
+++ b/ports/unix/mphalport.h
@@ -51,6 +51,13 @@
 // Called from mp_thread_finish(); never from a wait, since a wake object is held for a
 // thread's whole lifetime rather than borrowed per wait.
 void mp_hal_wake_obj_release_this_thread(void);
+
+#if defined(MICROPY_UNIX_COVERAGE)
+// Test hook: while set, this port reports that it cannot create a wake primitive, so the
+// degraded claim is reachable without exhausting the process's real descriptors. Declared
+// here rather than as a local extern in coverage.c so both sides are type-checked.
+extern bool mp_hal_wake_obj_force_open_failure;
+#endif
 #endif
 
 // The port provides `mp_hal_stdio_mode_raw()` and `mp_hal_stdio_mode_orig()`.

--- a/ports/unix/mphalport.h
+++ b/ports/unix/mphalport.h
@@ -146,8 +146,13 @@ int mp_hal_wake_event_wait_tv(struct timeval *tv);
 // Drain it after, and only after, it has polled readable.  It is
 // level-triggered, so it stays readable until drained, and draining before a
 // wait instead discards a raise and leaves that wait with nothing to end it.
+//
+// Declared only where per-thread wake objects are unavailable: with them, a poll set
+// injects this thread's own object instead and these have no caller.
+#if !MICROPY_HAL_HAS_WAKE_OBJ
 int mp_hal_wake_event_fd(void);
 void mp_hal_wake_event_drain(void);
+#endif
 
 #if MICROPY_PY_BLUETOOTH
 enum {

--- a/ports/unix/mpthreadport.c
+++ b/ports/unix/mpthreadport.c
@@ -29,6 +29,7 @@
 #include <errno.h>
 
 #include "py/runtime.h"
+#include "py/mphal.h"
 #include "py/mpthread.h"
 #include "py/gc.h"
 #include "stack_size.h"
@@ -322,6 +323,11 @@ void mp_thread_finish(void) {
         prev = th;
     }
     mp_thread_unix_end_atomic_section();
+    #if MICROPY_HAL_HAS_WAKE_OBJ
+    // Give this thread's wake object, if it claimed one, back to the pool. Outside the
+    // atomic section above: mp_hal_wake_obj_release_this_thread() takes its own.
+    mp_hal_wake_obj_release_this_thread();
+    #endif
 }
 
 void mp_thread_mutex_init(mp_thread_mutex_t *mutex) {

--- a/ports/unix/mpthreadport.c
+++ b/ports/unix/mpthreadport.c
@@ -324,8 +324,9 @@ void mp_thread_finish(void) {
     }
     mp_thread_unix_end_atomic_section();
     #if MICROPY_HAL_HAS_WAKE_OBJ
-    // Give this thread's wake object, if it claimed one, back to the pool. Outside the
-    // atomic section above: mp_hal_wake_obj_release_this_thread() takes its own.
+    // Return this thread's wake object, if it claimed one, for another thread to claim.
+    // Outside the atomic section above: mp_hal_wake_obj_release_this_thread() takes its
+    // own.
     mp_hal_wake_obj_release_this_thread();
     #endif
 }

--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -51,8 +51,12 @@ typedef uint8_t wake_event_token_t;
 // The wake event: a Linux eventfd, or a self-pipe elsewhere.  Reading
 // wake_event_fd drains it, writing wake_event_wr_fd raises it; on Linux both
 // are the same descriptor, and both are negative when not initialised.
+// Only exists where something waits on it; with per-thread wake objects every waiter has
+// its own and this pair has no reader (see mp_hal_wake_event_init()).
+#if !MICROPY_HAL_HAS_WAKE_OBJ
 static int wake_event_fd = -1;
 static int wake_event_wr_fd = -1;
+#endif
 
 #ifndef __linux__
 static int set_cloexec_nonblock(int fd) {
@@ -152,14 +156,35 @@ static __thread mp_hal_wake_obj_t *tls_wake_obj;
 #endif
 
 void mp_hal_wake_event_init(void) {
+    #if !MICROPY_HAL_HAS_WAKE_OBJ
+    // Only opened where something waits on it. With per-thread wake objects every waiter
+    // has its own, so both the raise in mp_hal_signal_event() and the wait in
+    // mp_hal_wake_event_wait_tv() take their wake-object branch and this descriptor would
+    // sit open for the life of the process with no reader.
     open_wake_fds(&wake_event_fd, &wake_event_wr_fd);
-    // Wake objects are not opened here: mp_hal_wake_obj_this_thread() opens each one
-    // lazily, on the thread's first blocking wait, so the FD_SETSIZE check inside
-    // open_wake_fds() only ever aborts a thread that is actually about to exceed it,
-    // rather than up front for a fixed count this process may never reach.
+    #else
+    // Claims the main thread's wake object here, where no user code has run and so no file
+    // descriptor of the caller's choosing has ever existed. That property is categorical:
+    // the number this object is handed cannot be one a poll set still holds a stale
+    // registration for, because there has been nothing to register. Claimed after user
+    // code starts, it gets whatever number the kernel hands out then, which can be one a
+    // closed-but-still-registered fd used to hold, and poll() resolves that stale entry
+    // against this object instead of reporting POLLNVAL for it.
+    //
+    // Only the main thread can have that property, so every other thread claims on its
+    // first blocking wait instead. Claiming earlier in such a thread's life is
+    // monotonically safer, fewer intervening closes meaning fewer numbers to collide
+    // with, but only marginally: the descriptor churn that creates the hazard happens
+    // before the thread exists, so an earlier claim buys a smaller window and never the
+    // guarantee. The price would be an eventfd per thread whether or not it ever blocks,
+    // each one bounded by FD_SETSIZE because mp_hal_wake_event_wait_tv() waits with
+    // select().
+    mp_hal_wake_obj_this_thread();
+    #endif
 }
 
 void mp_hal_wake_event_deinit(void) {
+    #if !MICROPY_HAL_HAS_WAKE_OBJ
     // Cleared before closing, so a concurrent raise is dropped rather than
     // written to a reused descriptor.
     int rd = wake_event_fd;
@@ -170,7 +195,7 @@ void mp_hal_wake_event_deinit(void) {
         close(wr);
     }
     close(rd);
-    #if MICROPY_HAL_HAS_WAKE_OBJ
+    #else
     // The only place a wake object's descriptors are closed: a thread that claimed one
     // never closes it at exit, only returns it (mp_hal_wake_obj_release_this_thread()),
     // so every node ever pushed is still open right up to this walk. A raise racing this
@@ -179,8 +204,8 @@ void mp_hal_wake_event_deinit(void) {
     // since nothing exits a thread past this point.
     for (mp_hal_wake_obj_t *w = __atomic_load_n(&wake_obj_list_head, __ATOMIC_ACQUIRE); w != NULL; w = w->next) {
         w->claimed = false;
-        rd = w->rd_fd;
-        wr = w->wr_fd;
+        int rd = w->rd_fd;
+        int wr = w->wr_fd;
         w->rd_fd = -1;
         w->wr_fd = -1;
         if (wr != rd) {
@@ -215,12 +240,13 @@ mp_hal_wake_obj_t *mp_hal_wake_obj_this_thread(void) {
     if (tls_wake_obj != NULL) {
         return tls_wake_obj;
     }
-    // Claiming happens once per thread, on its first blocking wait, never once per wait,
-    // so this atomic section is never on the poll loop's hot path. It serialises this
-    // scan and push against every other claim, release and push (writer-versus-writer),
-    // but a raise reaches this list from a signal handler that cannot take it, which is
-    // why the head pointer itself still goes through an explicit acquire/release below
-    // rather than relying on the section's mutex for that.
+    // Claiming happens once per thread, never once per wait, so this atomic section is
+    // never on the poll loop's hot path. The main thread claims from
+    // mp_hal_wake_event_init(); every other thread reaches here on its first blocking
+    // wait. It serialises this scan and push against every other claim, release and push
+    // (writer-versus-writer), but a raise reaches this list from a signal handler that
+    // cannot take it, which is why the head pointer itself still goes through an explicit
+    // acquire/release below rather than relying on the section's mutex for that.
     mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
     mp_hal_wake_obj_t *w = NULL;
     for (mp_hal_wake_obj_t *n = __atomic_load_n(&wake_obj_list_head, __ATOMIC_ACQUIRE); n != NULL; n = n->next) {
@@ -357,6 +383,10 @@ int mp_hal_wake_event_wait_tv(struct timeval *tv) {
     return select(0, NULL, NULL, NULL, tv);
 }
 
+#if !MICROPY_HAL_HAS_WAKE_OBJ
+// The shared event's descriptor, for a poll set to sleep on alongside its own entries.
+// Only where per-thread wake objects are unavailable: with them, extmod/modselect.c
+// injects this thread's own object instead and these have no caller.
 int mp_hal_wake_event_fd(void) {
     // Re-read for the same reason the wait does: a thread outliving the main one
     // can reach this after deinitialisation, when there is no descriptor to give.
@@ -369,6 +399,7 @@ void mp_hal_wake_event_drain(void) {
         wake_event_drain(fd);
     }
 }
+#endif
 
 void mp_hal_wake_event_wait_ms(mp_uint_t timeout_ms) {
     if (timeout_ms == MP_HAL_WAKE_EVENT_FOREVER) {

--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -69,13 +69,26 @@ static int set_cloexec_nonblock(int fd) {
 }
 #endif
 
-// Opens one wake primitive: a Linux eventfd (rd == wr) or a self-pipe elsewhere. Exits
-// the process on failure: a HAL that cannot allocate its own wake descriptors cannot run
-// correctly regardless of what fails next, which is why the shared wake event has always
-// failed this way and every wake object shares the rule.
-static void open_wake_fds(int *rd_out, int *wr_out) {
+#if defined(MICROPY_UNIX_COVERAGE)
+// Test hook: while set, this port reports that it cannot create a wake primitive. It makes
+// the degraded claim below reachable without exhausting the process's real descriptors,
+// which a test cannot do without also breaking the harness around it.
+bool mp_hal_wake_obj_force_open_failure;
+#endif
+
+// Opens one wake primitive: a Linux eventfd (rd == wr) or a self-pipe elsewhere. Returns
+// false with the outputs untouched if none can be created, leaving the caller to decide
+// what that failure means: fatal where it happens before any user code has run, degraded
+// to a backing-less object otherwise (mp_hal_wake_obj_this_thread()).
+static bool open_wake_fds(int *rd_out, int *wr_out) {
     int rd = -1;
     int wr = -1;
+    #if defined(MICROPY_UNIX_COVERAGE)
+    if (mp_hal_wake_obj_force_open_failure) {
+        errno = EMFILE;
+        return false;
+    }
+    #endif
     #ifdef __linux__
     rd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
     wr = rd;
@@ -92,16 +105,21 @@ static void open_wake_fds(int *rd_out, int *wr_out) {
     }
     #endif
     if (rd < 0) {
-        fprintf(stderr, "FATAL: cannot create wake event: %s\n", strerror(errno));
-        exit(1);
+        return false;
     }
     if (rd >= FD_SETSIZE) {
-        // Waiting on it uses select(), and FD_SET() is undefined from here up.
-        fprintf(stderr, "FATAL: wake event fd %d exceeds FD_SETSIZE\n", rd);
-        exit(1);
+        // Waiting on it uses select(), and FD_SET() is undefined from here up. Closed
+        // rather than kept, so a descriptor too high to wait on does not hold a slot that
+        // would let a later, lower-numbered claim succeed.
+        if (wr != rd) {
+            close(wr);
+        }
+        close(rd);
+        return false;
     }
     *rd_out = rd;
     *wr_out = wr;
+    return true;
 }
 
 static void wake_event_drain(int fd) {
@@ -153,6 +171,21 @@ static mp_hal_wake_obj_t *wake_obj_list_head;
 // with no atomic section and no scan.
 static __thread mp_hal_wake_obj_t *tls_wake_obj;
 
+// Handed out when a claim cannot be serviced, so mp_hal_wake_obj_this_thread() keeps its
+// promise of a valid object without one having been created. Static, because the failures
+// it stands in for are exactly no memory and no descriptors. Never linked into the list
+// and never claimed, so mp_hal_wake_obj_signal_all() cannot reach it and no other thread
+// can be handed it. Its negative descriptors make every operation on it degrade through
+// code that already exists: raising hits wake_fd_raise()'s fd < 0 guard, a negative fd in
+// a pollfd is a POSIX-defined no-op with revents zeroed, and mp_hal_wake_event_wait_tv()
+// already falls through to its untimed wait when the descriptor is negative.
+static mp_hal_wake_obj_t wake_obj_degraded = {
+    .rd_fd = -1,
+    .wr_fd = -1,
+    .claimed = false,
+    .next = NULL,
+};
+
 #endif
 
 void mp_hal_wake_event_init(void) {
@@ -161,7 +194,10 @@ void mp_hal_wake_event_init(void) {
     // has its own, so both the raise in mp_hal_signal_event() and the wait in
     // mp_hal_wake_event_wait_tv() take their wake-object branch and this descriptor would
     // sit open for the life of the process with no reader.
-    open_wake_fds(&wake_event_fd, &wake_event_wr_fd);
+    if (!open_wake_fds(&wake_event_fd, &wake_event_wr_fd)) {
+        fprintf(stderr, "FATAL: cannot create wake event: %s\n", strerror(errno));
+        exit(1);
+    }
     #else
     // Claims the main thread's wake object here, where no user code has run and so no file
     // descriptor of the caller's choosing has ever existed. That property is categorical:
@@ -179,7 +215,15 @@ void mp_hal_wake_event_init(void) {
     // guarantee. The price would be an eventfd per thread whether or not it ever blocks,
     // each one bounded by FD_SETSIZE because mp_hal_wake_event_wait_tv() waits with
     // select().
-    mp_hal_wake_obj_this_thread();
+    //
+    // Fatal here, where a claim elsewhere degrades: this runs before any user code, so
+    // there is no caller to report to and no timeout to fall back on, and a main thread
+    // that cannot be woken makes the rest of the process's behaviour undefined rather
+    // than merely late.
+    if (mp_hal_wake_obj_this_thread() == &wake_obj_degraded) {
+        fprintf(stderr, "FATAL: cannot create wake event: %s\n", strerror(errno));
+        exit(1);
+    }
     #endif
 }
 
@@ -261,11 +305,23 @@ mp_hal_wake_obj_t *mp_hal_wake_obj_this_thread(void) {
         // storage grows to the peak number of concurrently-blocking threads and stops
         // there; a thread that later exits returns its node instead of shrinking this.
         w = malloc(sizeof(mp_hal_wake_obj_t));
-        if (w == NULL) {
-            fprintf(stderr, "FATAL: cannot allocate wake object: %s\n", strerror(errno));
-            exit(1);
+        if (w == NULL || !open_wake_fds(&w->rd_fd, &w->wr_fd)) {
+            free(w);
+            MICROPY_END_ATOMIC_SECTION(atomic_state);
+            // Degraded rather than fatal, because what the caller loses depends on what it
+            // is waiting for and only one case cannot absorb it. A wait with a timeout
+            // still returns on that timeout, and a thread whose only stake is running
+            // scheduled callbacks still runs them, late, when its own wait expires. The
+            // one case with nothing left to end it is an indefinite wait a SOURCE_SIGNAL
+            // entry was to have ended, and extmod/modselect.c raises there rather than
+            // blocking forever.
+            //
+            // Not cached in tls_wake_obj: a claim that failed on a transient shortage
+            // succeeds once the shortage passes, and a thread that kept the degraded
+            // object would stay degraded for its whole life instead. The retry costs one
+            // scan and one failed allocation per wait, and only while degraded.
+            return &wake_obj_degraded;
         }
-        open_wake_fds(&w->rd_fd, &w->wr_fd);
         w->claimed = true;
         w->next = __atomic_load_n(&wake_obj_list_head, __ATOMIC_ACQUIRE);
         __atomic_store_n(&wake_obj_list_head, w, __ATOMIC_RELEASE);
@@ -342,7 +398,7 @@ int mp_hal_wake_event_wait_tv(struct timeval *tv) {
     // so no other thread's wait depends on this call being woken early either; reaching
     // this point with no such entitlement, a thread falls through to the bare select()
     // below and runs for its full duration regardless of an unrelated raise, even though
-    // that raise reaches every *claimed* wake object (mp_hal_wake_obj_signal_all()) --
+    // that raise reaches every *claimed* wake object (mp_hal_wake_obj_signal_all());
     // such a thread simply never claims one here.
     #if MICROPY_HAL_HAS_WAKE_OBJ
     if (mp_sched_thread_can_run_callbacks()) {
@@ -378,8 +434,16 @@ int mp_hal_wake_event_wait_tv(struct timeval *tv) {
         return ret;
     }
     #endif
-    // No entitlement to a live wake source: this is the fallback of last resort, and it
-    // cannot be woken early.
+    // Reached with no live wake source to wait on, either because this thread has no
+    // entitlement to one or because its claim could not be serviced and it holds the
+    // backing-less object. Waits out `tv` and cannot be woken early in either case.
+    //
+    // A caller passing NULL therefore waits forever. Every caller on this port passes a
+    // finite `tv`: MP_HAL_WAKE_EVENT_FOREVER reaches here only via
+    // mp_event_wait_indefinite(), which on unix is used by btstack rather than by
+    // time.sleep() or by select.poll(), the latter running its own poll() set and never
+    // reaching this function. That is a pre-existing property of the untimed wait rather
+    // than something the degraded object introduces, and it is fixed in the waiter.
     return select(0, NULL, NULL, NULL, tv);
 }
 

--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -192,13 +192,21 @@ void mp_hal_wake_event_deinit(void) {
 }
 
 void mp_hal_signal_event(void) {
-    wake_fd_raise(wake_event_wr_fd);
-    // Every thread that has claimed a wake object needs this raise too: it may carry a
-    // scheduled exception or other queued work that thread must act on, and it may be the
-    // only notice a SOURCE_SIGNAL entry that thread is polling gets. See
-    // mp_hal_wake_obj_signal_all()'s own doc comment for why this is safe to call
-    // unconditionally from here.
+    #if MICROPY_HAL_HAS_WAKE_OBJ
+    // Every thread that has claimed a wake object needs this: it may carry a scheduled
+    // exception or other queued work that thread must act on, and it may be the only
+    // notice a SOURCE_SIGNAL entry that thread is polling gets. No separate raise to the
+    // shared wake event: every thread with a stake in one claims its own object instead
+    // (mp_hal_wake_event_wait_tv()), so that descriptor has no reader left to wake here.
+    // See mp_hal_wake_obj_signal_all()'s own doc comment for why this is safe to call
+    // unconditionally from anywhere this function itself may be called.
     mp_hal_wake_obj_signal_all();
+    #else
+    // No per-thread objects on this build (MICROPY_PY_THREAD is off): the shared wake
+    // event is this process's only thread, so it is also that thread's only consumer,
+    // and remains the mechanism.
+    wake_fd_raise(wake_event_wr_fd);
+    #endif
 }
 
 #if MICROPY_HAL_HAS_WAKE_OBJ
@@ -302,27 +310,17 @@ int mp_hal_wake_obj_posix_fd(mp_hal_wake_obj_t *w) {
 #endif // MICROPY_HAL_HAS_WAKE_OBJ
 
 int mp_hal_wake_event_wait_tv(struct timeval *tv) {
-    // The thread that runs scheduled callbacks waits on the shared wake event: draining
-    // it is also how that thread learns queued work exists, so it must be the one to
-    // consume it. Any other thread waits on its own claimed object instead of sharing
-    // that token, so a raise ends its wait without depending on being the one thread
-    // entitled to the shared descriptor.
-    if (mp_sched_thread_can_run_callbacks() && wake_event_fd >= 0) {
-        int fd = wake_event_fd;
-        fd_set rfds;
-        FD_ZERO(&rfds);
-        FD_SET(fd, &rfds);
-        int ret = select(fd + 1, &rfds, NULL, NULL, tv);
-        if (ret > 0) {
-            wake_event_drain(fd);
-            errno = EINTR;
-            return -1;
-        }
-        return ret;
-    }
+    // Only the thread entitled to run scheduled callbacks has a stake in a live wake
+    // source here: draining it is how that thread learns queued work exists, so nothing
+    // else may claim credit for the same raise. A sleeper never registers a poll entry,
+    // so no other thread's wait depends on this call being woken early either; reaching
+    // this point with no such entitlement, a thread falls through to the bare select()
+    // below and runs for its full duration regardless of an unrelated raise, even though
+    // that raise reaches every *claimed* wake object (mp_hal_wake_obj_signal_all()) --
+    // such a thread simply never claims one here.
     #if MICROPY_HAL_HAS_WAKE_OBJ
-    mp_hal_wake_obj_t *w = mp_hal_wake_obj_this_thread();
-    if (w != NULL) {
+    if (mp_sched_thread_can_run_callbacks()) {
+        mp_hal_wake_obj_t *w = mp_hal_wake_obj_this_thread();
         int fd = w->rd_fd;
         if (fd >= 0) {
             fd_set rfds;
@@ -337,10 +335,25 @@ int mp_hal_wake_event_wait_tv(struct timeval *tv) {
             return ret;
         }
     }
+    #else
+    // No per-thread objects on this build: the shared wake event is this process's only
+    // thread, so it is also that thread's only consumer.
+    if (mp_sched_thread_can_run_callbacks() && wake_event_fd >= 0) {
+        int fd = wake_event_fd;
+        fd_set rfds;
+        FD_ZERO(&rfds);
+        FD_SET(fd, &rfds);
+        int ret = select(fd + 1, &rfds, NULL, NULL, tv);
+        if (ret > 0) {
+            wake_event_drain(fd);
+            errno = EINTR;
+            return -1;
+        }
+        return ret;
+    }
     #endif
-    // No object of its own either: this is the fallback of last resort, and it cannot be
-    // woken early. Kept only for a port build with MICROPY_HAL_HAS_WAKE_OBJ off, or a
-    // pool exhausted by more concurrently-polling threads than it was sized for.
+    // No entitlement to a live wake source: this is the fallback of last resort, and it
+    // cannot be woken early.
     return select(0, NULL, NULL, NULL, tv);
 }
 

--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -123,39 +123,40 @@ static void wake_fd_raise(int fd) {
 
 #if MICROPY_HAL_HAS_WAKE_OBJ
 
-// A thread's claimed wake object. Every descriptor in wake_obj_pool is opened once in
-// mp_hal_wake_event_init(), before any thread but the main one exists, and closed once in
-// mp_hal_wake_event_deinit(); .claimed alone tracks whether a thread currently owns the
-// slot. A raiser observing claimed == true therefore always reads a descriptor that has
-// been open since before any thread existed, so no publication barrier is needed between
-// "descriptor is valid" and "slot is claimed".
+// A thread's claimed wake object. Nodes are allocated on demand by
+// mp_hal_wake_obj_this_thread() and never freed or unlinked: they form an append-only
+// list so mp_hal_wake_obj_signal_all() can walk it from a signal handler, with no lock
+// and nothing that could vanish or move underneath it. Thread exit only clears .claimed
+// (mp_hal_wake_obj_release_this_thread()), returning the node for the next thread to
+// claim rather than closing its descriptors; see mp_hal_wake_event_deinit() for where
+// they are actually closed.
 struct _mp_hal_wake_obj_t {
+    int rd_fd;
+    int wr_fd; // the same descriptor as rd_fd for an eventfd
     volatile bool claimed;
-    volatile int rd_fd;
-    volatile int wr_fd; // the same descriptor as rd_fd for an eventfd
+    mp_hal_wake_obj_t *next;
 };
 
-static mp_hal_wake_obj_t wake_obj_pool[MICROPY_HAL_WAKE_OBJ_MAX];
+// Head of the append-only wake object list. A push publishes a fully-initialised node
+// with a release store here, and every read, whether walking from the head to claim a
+// returned node or to broadcast a raise, pairs it with an acquire load: the object is
+// reachable from another thread or a signal handler with no mutex in between (a handler
+// cannot take one), so the ordering has to come from this variable itself on every hop,
+// not from incidentally being inside the atomic section below.
+static mp_hal_wake_obj_t *wake_obj_list_head;
 
-// This thread's claimed slot, cached after the first claim so every later wait finds it
-// with no atomic section and no scan. NULL both before the first claim and when the pool
-// was exhausted at that first call; either way the thread keeps re-trying the scan below
-// on every subsequent call, which is harmless since a pool that was full may free up.
+// This thread's claimed node, cached after the first claim so every later wait finds it
+// with no atomic section and no scan.
 static __thread mp_hal_wake_obj_t *tls_wake_obj;
 
 #endif
 
 void mp_hal_wake_event_init(void) {
     open_wake_fds(&wake_event_fd, &wake_event_wr_fd);
-    #if MICROPY_HAL_HAS_WAKE_OBJ
-    for (int i = 0; i < MICROPY_HAL_WAKE_OBJ_MAX; i++) {
-        int rd, wr;
-        open_wake_fds(&rd, &wr);
-        wake_obj_pool[i].rd_fd = rd;
-        wake_obj_pool[i].wr_fd = wr;
-        wake_obj_pool[i].claimed = false;
-    }
-    #endif
+    // Wake objects are not opened here: mp_hal_wake_obj_this_thread() opens each one
+    // lazily, on the thread's first blocking wait, so the FD_SETSIZE check inside
+    // open_wake_fds() only ever aborts a thread that is actually about to exceed it,
+    // rather than up front for a fixed count this process may never reach.
 }
 
 void mp_hal_wake_event_deinit(void) {
@@ -170,15 +171,18 @@ void mp_hal_wake_event_deinit(void) {
     }
     close(rd);
     #if MICROPY_HAL_HAS_WAKE_OBJ
-    for (int i = 0; i < MICROPY_HAL_WAKE_OBJ_MAX; i++) {
-        // Same invalidate-before-close ordering as the shared event above, and for the
-        // same reason: a thread that outlives this call must never write() into, or be
-        // told to select() on, a descriptor that has already been handed back to the OS.
-        wake_obj_pool[i].claimed = false;
-        rd = wake_obj_pool[i].rd_fd;
-        wr = wake_obj_pool[i].wr_fd;
-        wake_obj_pool[i].rd_fd = -1;
-        wake_obj_pool[i].wr_fd = -1;
+    // The only place a wake object's descriptors are closed: a thread that claimed one
+    // never closes it at exit, only returns it (mp_hal_wake_obj_release_this_thread()),
+    // so every node ever pushed is still open right up to this walk. A raise racing this
+    // teardown is the same clear-before-close race accepted for the shared event above,
+    // occurring at most once for the whole process rather than once per thread exit,
+    // since nothing exits a thread past this point.
+    for (mp_hal_wake_obj_t *w = __atomic_load_n(&wake_obj_list_head, __ATOMIC_ACQUIRE); w != NULL; w = w->next) {
+        w->claimed = false;
+        rd = w->rd_fd;
+        wr = w->wr_fd;
+        w->rd_fd = -1;
+        w->wr_fd = -1;
         if (wr != rd) {
             close(wr);
         }
@@ -204,16 +208,44 @@ mp_hal_wake_obj_t *mp_hal_wake_obj_this_thread(void) {
         return tls_wake_obj;
     }
     // Claiming happens once per thread, on its first blocking wait, never once per wait,
-    // so this atomic section is never on the poll loop's hot path.
+    // so this atomic section is never on the poll loop's hot path. It serialises this
+    // scan and push against every other claim, release and push (writer-versus-writer),
+    // but a raise reaches this list from a signal handler that cannot take it, which is
+    // why the head pointer itself still goes through an explicit acquire/release below
+    // rather than relying on the section's mutex for that.
     mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
     mp_hal_wake_obj_t *w = NULL;
-    for (int i = 0; i < MICROPY_HAL_WAKE_OBJ_MAX; i++) {
-        if (!wake_obj_pool[i].claimed) {
-            wake_obj_pool[i].claimed = true;
-            w = &wake_obj_pool[i];
+    for (mp_hal_wake_obj_t *n = __atomic_load_n(&wake_obj_list_head, __ATOMIC_ACQUIRE); n != NULL; n = n->next) {
+        if (!n->claimed) {
+            n->claimed = true;
+            w = n;
             break;
         }
     }
+    if (w == NULL) {
+        // No returned node to reuse: allocate one. Never freed and never unlinked, so
+        // storage grows to the peak number of concurrently-blocking threads and stops
+        // there; a thread that later exits returns its node instead of shrinking this.
+        w = malloc(sizeof(mp_hal_wake_obj_t));
+        if (w == NULL) {
+            fprintf(stderr, "FATAL: cannot allocate wake object: %s\n", strerror(errno));
+            exit(1);
+        }
+        open_wake_fds(&w->rd_fd, &w->wr_fd);
+        w->claimed = true;
+        w->next = __atomic_load_n(&wake_obj_list_head, __ATOMIC_ACQUIRE);
+        __atomic_store_n(&wake_obj_list_head, w, __ATOMIC_RELEASE);
+    }
+    // Latch it before returning, whether this claim just reused a returned node or
+    // published a freshly allocated one: a raise landing between the claim taking effect
+    // and this thread's first wait would otherwise find a claimed object with nothing
+    // written to it, and be lost, since mp_hal_wake_obj_signal_all() only ever writes to
+    // what it finds already claimed. For a freshly allocated node this also closes the
+    // narrower window between the node existing and its claim becoming visible from
+    // wake_obj_list_head. Seeding costs one spurious wake on this thread's first block,
+    // absorbed by its condition recheck, rather than widening every future raise into a
+    // walk-and-write-all to close this window on every claim.
+    wake_fd_raise(w->wr_fd);
     MICROPY_END_ATOMIC_SECTION(atomic_state);
     tls_wake_obj = w;
     return w;
@@ -240,17 +272,21 @@ void mp_hal_wake_obj_drain(mp_hal_wake_obj_t *w) {
 // exactly as safe to call as that already is: reachable from a hard ISR, a second core, a
 // non-MicroPython RTOS task or a POSIX signal handler. It allocates nothing, takes no
 // lock and no atomic section (mutation of .claimed is confined to claim and release,
-// neither of which this function performs), and dereferences no caller-supplied pointer,
-// only the fixed pool array. errno is saved and restored once for the whole walk rather
-// than once per write(), since every write() shares the same failure mode (the event is
-// already raised) and none of them needs to be told apart from the others.
+// neither of which this function performs), and dereferences no caller-supplied pointer.
+// The list itself is safe to walk unlocked because it is append-only: nothing is ever
+// unlinked, and the acquire load pairs with the release store that publishes each node
+// (mp_hal_wake_obj_this_thread()), so every field of a node this walk reaches is the
+// value its owning thread set before publishing it, never a partial write in progress.
+// errno is saved and restored once for the whole walk rather than once per write(),
+// since every write() shares the same failure mode (the event is already raised) and
+// none of them needs to be told apart from the others.
 void mp_hal_wake_obj_signal_all(void) {
     int errno_save = errno;
-    for (int i = 0; i < MICROPY_HAL_WAKE_OBJ_MAX; i++) {
-        if (!wake_obj_pool[i].claimed) {
+    for (mp_hal_wake_obj_t *w = __atomic_load_n(&wake_obj_list_head, __ATOMIC_ACQUIRE); w != NULL; w = w->next) {
+        if (!w->claimed) {
             continue;
         }
-        wake_fd_raise(wake_obj_pool[i].wr_fd);
+        wake_fd_raise(w->wr_fd);
     }
     errno = errno_save;
 }

--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -52,7 +52,10 @@ typedef uint8_t wake_event_token_t;
 // wake_event_fd drains it, writing wake_event_wr_fd raises it; on Linux both
 // are the same descriptor, and both are negative when not initialised.
 // Only exists where something waits on it; with per-thread wake objects every waiter has
-// its own and this pair has no reader (see mp_hal_wake_event_init()).
+// its own and this pair has no reader (see mp_hal_wake_event_init()). Keyed on the wake
+// mechanism, not on MICROPY_HAL_WAKE_EVENT_HAS_POSIX_FD: that macro says whether this port hands
+// the descriptor out to extmod, which is a different question from whether the event
+// exists at all.
 #if !MICROPY_HAL_HAS_WAKE_OBJ
 static int wake_event_fd = -1;
 static int wake_event_wr_fd = -1;
@@ -435,7 +438,7 @@ int mp_hal_wake_event_wait_tv(struct timeval *tv) {
     return select(0, NULL, NULL, NULL, tv);
 }
 
-#if !MICROPY_HAL_HAS_WAKE_OBJ
+#if MICROPY_HAL_WAKE_EVENT_HAS_POSIX_FD
 // The shared event's descriptor, for a poll set to sleep on alongside its own entries.
 // Only where per-thread wake objects are unavailable: with them, extmod/modselect.c
 // injects this thread's own object instead and these have no caller.

--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -65,31 +65,97 @@ static int set_cloexec_nonblock(int fd) {
 }
 #endif
 
-void mp_hal_wake_event_init(void) {
+// Opens one wake primitive: a Linux eventfd (rd == wr) or a self-pipe elsewhere. Exits
+// the process on failure: a HAL that cannot allocate its own wake descriptors cannot run
+// correctly regardless of what fails next, which is why the shared wake event has always
+// failed this way and every wake object shares the rule.
+static void open_wake_fds(int *rd_out, int *wr_out) {
+    int rd = -1;
+    int wr = -1;
     #ifdef __linux__
-    wake_event_fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
-    wake_event_wr_fd = wake_event_fd;
+    rd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+    wr = rd;
     #else
     int fds[2];
     if (pipe(fds) == 0) {
         if (set_cloexec_nonblock(fds[0]) == 0 && set_cloexec_nonblock(fds[1]) == 0) {
-            wake_event_fd = fds[0];
-            wake_event_wr_fd = fds[1];
+            rd = fds[0];
+            wr = fds[1];
         } else {
             close(fds[0]);
             close(fds[1]);
         }
     }
     #endif
-    if (wake_event_fd < 0) {
+    if (rd < 0) {
         fprintf(stderr, "FATAL: cannot create wake event: %s\n", strerror(errno));
         exit(1);
     }
-    if (wake_event_fd >= FD_SETSIZE) {
+    if (rd >= FD_SETSIZE) {
         // Waiting on it uses select(), and FD_SET() is undefined from here up.
-        fprintf(stderr, "FATAL: wake event fd %d exceeds FD_SETSIZE\n", wake_event_fd);
+        fprintf(stderr, "FATAL: wake event fd %d exceeds FD_SETSIZE\n", rd);
         exit(1);
     }
+    *rd_out = rd;
+    *wr_out = wr;
+}
+
+static void wake_event_drain(int fd) {
+    // Empty it fully or the next wait returns at once: an eventfd reads its
+    // counter in one go, a self-pipe holds a byte per raise.
+    char buf[64];
+    while (read(fd, buf, sizeof(buf)) > 0) {
+    }
+}
+
+static void wake_fd_raise(int fd) {
+    if (fd < 0) {
+        return;
+    }
+    // Reachable from a signal handler, so no allocation, and errno is
+    // preserved.  A failed write means the event is already raised.
+    int errno_save = errno;
+    wake_event_token_t token = 1;
+    ssize_t ret = write(fd, &token, sizeof(token));
+    (void)ret;
+    errno = errno_save;
+}
+
+#if MICROPY_HAL_HAS_WAKE_OBJ
+
+// A thread's claimed wake object. Every descriptor in wake_obj_pool is opened once in
+// mp_hal_wake_event_init(), before any thread but the main one exists, and closed once in
+// mp_hal_wake_event_deinit(); .claimed alone tracks whether a thread currently owns the
+// slot. A raiser observing claimed == true therefore always reads a descriptor that has
+// been open since before any thread existed, so no publication barrier is needed between
+// "descriptor is valid" and "slot is claimed".
+struct _mp_hal_wake_obj_t {
+    volatile bool claimed;
+    volatile int rd_fd;
+    volatile int wr_fd; // the same descriptor as rd_fd for an eventfd
+};
+
+static mp_hal_wake_obj_t wake_obj_pool[MICROPY_HAL_WAKE_OBJ_MAX];
+
+// This thread's claimed slot, cached after the first claim so every later wait finds it
+// with no atomic section and no scan. NULL both before the first claim and when the pool
+// was exhausted at that first call; either way the thread keeps re-trying the scan below
+// on every subsequent call, which is harmless since a pool that was full may free up.
+static __thread mp_hal_wake_obj_t *tls_wake_obj;
+
+#endif
+
+void mp_hal_wake_event_init(void) {
+    open_wake_fds(&wake_event_fd, &wake_event_wr_fd);
+    #if MICROPY_HAL_HAS_WAKE_OBJ
+    for (int i = 0; i < MICROPY_HAL_WAKE_OBJ_MAX; i++) {
+        int rd, wr;
+        open_wake_fds(&rd, &wr);
+        wake_obj_pool[i].rd_fd = rd;
+        wake_obj_pool[i].wr_fd = wr;
+        wake_obj_pool[i].claimed = false;
+    }
+    #endif
 }
 
 void mp_hal_wake_event_deinit(void) {
@@ -103,48 +169,143 @@ void mp_hal_wake_event_deinit(void) {
         close(wr);
     }
     close(rd);
-}
-
-static void wake_event_drain(int fd) {
-    // Empty it fully or the next wait returns at once: an eventfd reads its
-    // counter in one go, a self-pipe holds a byte per raise.
-    char buf[64];
-    while (read(fd, buf, sizeof(buf)) > 0) {
+    #if MICROPY_HAL_HAS_WAKE_OBJ
+    for (int i = 0; i < MICROPY_HAL_WAKE_OBJ_MAX; i++) {
+        // Same invalidate-before-close ordering as the shared event above, and for the
+        // same reason: a thread that outlives this call must never write() into, or be
+        // told to select() on, a descriptor that has already been handed back to the OS.
+        wake_obj_pool[i].claimed = false;
+        rd = wake_obj_pool[i].rd_fd;
+        wr = wake_obj_pool[i].wr_fd;
+        wake_obj_pool[i].rd_fd = -1;
+        wake_obj_pool[i].wr_fd = -1;
+        if (wr != rd) {
+            close(wr);
+        }
+        close(rd);
     }
+    #endif
 }
 
 void mp_hal_signal_event(void) {
-    int fd = wake_event_wr_fd;
-    if (fd < 0) {
+    wake_fd_raise(wake_event_wr_fd);
+    // Every thread that has claimed a wake object needs this raise too: it may carry a
+    // scheduled exception or other queued work that thread must act on, and it may be the
+    // only notice a SOURCE_SIGNAL entry that thread is polling gets. See
+    // mp_hal_wake_obj_signal_all()'s own doc comment for why this is safe to call
+    // unconditionally from here.
+    mp_hal_wake_obj_signal_all();
+}
+
+#if MICROPY_HAL_HAS_WAKE_OBJ
+
+mp_hal_wake_obj_t *mp_hal_wake_obj_this_thread(void) {
+    if (tls_wake_obj != NULL) {
+        return tls_wake_obj;
+    }
+    // Claiming happens once per thread, on its first blocking wait, never once per wait,
+    // so this atomic section is never on the poll loop's hot path.
+    mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+    mp_hal_wake_obj_t *w = NULL;
+    for (int i = 0; i < MICROPY_HAL_WAKE_OBJ_MAX; i++) {
+        if (!wake_obj_pool[i].claimed) {
+            wake_obj_pool[i].claimed = true;
+            w = &wake_obj_pool[i];
+            break;
+        }
+    }
+    MICROPY_END_ATOMIC_SECTION(atomic_state);
+    tls_wake_obj = w;
+    return w;
+}
+
+void mp_hal_wake_obj_release_this_thread(void) {
+    if (tls_wake_obj == NULL) {
         return;
     }
-    // Reachable from a signal handler, so no allocation, and errno is
-    // preserved.  A failed write means the event is already raised.
+    mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+    tls_wake_obj->claimed = false;
+    MICROPY_END_ATOMIC_SECTION(atomic_state);
+    tls_wake_obj = NULL;
+}
+
+void mp_hal_wake_obj_drain(mp_hal_wake_obj_t *w) {
+    int fd = w->rd_fd;
+    if (fd >= 0) {
+        wake_event_drain(fd);
+    }
+}
+
+// Raises every currently claimed object. Called from mp_hal_signal_event(), so it must be
+// exactly as safe to call as that already is: reachable from a hard ISR, a second core, a
+// non-MicroPython RTOS task or a POSIX signal handler. It allocates nothing, takes no
+// lock and no atomic section (mutation of .claimed is confined to claim and release,
+// neither of which this function performs), and dereferences no caller-supplied pointer,
+// only the fixed pool array. errno is saved and restored once for the whole walk rather
+// than once per write(), since every write() shares the same failure mode (the event is
+// already raised) and none of them needs to be told apart from the others.
+void mp_hal_wake_obj_signal_all(void) {
     int errno_save = errno;
-    wake_event_token_t token = 1;
-    ssize_t ret = write(fd, &token, sizeof(token));
-    (void)ret;
+    for (int i = 0; i < MICROPY_HAL_WAKE_OBJ_MAX; i++) {
+        if (!wake_obj_pool[i].claimed) {
+            continue;
+        }
+        wake_fd_raise(wake_obj_pool[i].wr_fd);
+    }
     errno = errno_save;
 }
 
+#if MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
+int mp_hal_wake_obj_posix_fd(mp_hal_wake_obj_t *w) {
+    // Re-read for the same reason mp_hal_wake_event_fd() does: a thread outliving
+    // mp_hal_wake_event_deinit() can reach this with no descriptor to give.
+    return w->rd_fd;
+}
+#endif
+
+#endif // MICROPY_HAL_HAS_WAKE_OBJ
+
 int mp_hal_wake_event_wait_tv(struct timeval *tv) {
-    // Only the thread that runs scheduled callbacks may consume the event: one
-    // taken by another thread is one the thread that can act on it never sees.
-    // Other threads just wait out the timeout.
-    int fd = wake_event_fd;
-    if (fd < 0 || !mp_sched_thread_can_run_callbacks()) {
-        return select(0, NULL, NULL, NULL, tv);
+    // The thread that runs scheduled callbacks waits on the shared wake event: draining
+    // it is also how that thread learns queued work exists, so it must be the one to
+    // consume it. Any other thread waits on its own claimed object instead of sharing
+    // that token, so a raise ends its wait without depending on being the one thread
+    // entitled to the shared descriptor.
+    if (mp_sched_thread_can_run_callbacks() && wake_event_fd >= 0) {
+        int fd = wake_event_fd;
+        fd_set rfds;
+        FD_ZERO(&rfds);
+        FD_SET(fd, &rfds);
+        int ret = select(fd + 1, &rfds, NULL, NULL, tv);
+        if (ret > 0) {
+            wake_event_drain(fd);
+            errno = EINTR;
+            return -1;
+        }
+        return ret;
     }
-    fd_set rfds;
-    FD_ZERO(&rfds);
-    FD_SET(fd, &rfds);
-    int ret = select(fd + 1, &rfds, NULL, NULL, tv);
-    if (ret > 0) {
-        wake_event_drain(fd);
-        errno = EINTR;
-        return -1;
+    #if MICROPY_HAL_HAS_WAKE_OBJ
+    mp_hal_wake_obj_t *w = mp_hal_wake_obj_this_thread();
+    if (w != NULL) {
+        int fd = w->rd_fd;
+        if (fd >= 0) {
+            fd_set rfds;
+            FD_ZERO(&rfds);
+            FD_SET(fd, &rfds);
+            int ret = select(fd + 1, &rfds, NULL, NULL, tv);
+            if (ret > 0) {
+                mp_hal_wake_obj_drain(w);
+                errno = EINTR;
+                return -1;
+            }
+            return ret;
+        }
     }
-    return ret;
+    #endif
+    // No object of its own either: this is the fallback of last resort, and it cannot be
+    // woken early. Kept only for a port build with MICROPY_HAL_HAS_WAKE_OBJ off, or a
+    // pool exhausted by more concurrently-polling threads than it was sized for.
+    return select(0, NULL, NULL, NULL, tv);
 }
 
 int mp_hal_wake_event_fd(void) {

--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -400,28 +400,17 @@ int mp_hal_wake_event_wait_tv(struct timeval *tv) {
     // below and runs for its full duration regardless of an unrelated raise, even though
     // that raise reaches every *claimed* wake object (mp_hal_wake_obj_signal_all());
     // such a thread simply never claims one here.
-    #if MICROPY_HAL_HAS_WAKE_OBJ
+    int fd = -1;
     if (mp_sched_thread_can_run_callbacks()) {
-        mp_hal_wake_obj_t *w = mp_hal_wake_obj_this_thread();
-        int fd = w->rd_fd;
-        if (fd >= 0) {
-            fd_set rfds;
-            FD_ZERO(&rfds);
-            FD_SET(fd, &rfds);
-            int ret = select(fd + 1, &rfds, NULL, NULL, tv);
-            if (ret > 0) {
-                mp_hal_wake_obj_drain(w);
-                errno = EINTR;
-                return -1;
-            }
-            return ret;
-        }
+        #if MICROPY_HAL_HAS_WAKE_OBJ
+        fd = mp_hal_wake_obj_this_thread()->rd_fd;
+        #else
+        // No per-thread objects on this build: the shared wake event is this process's only
+        // thread, so it is also that thread's only consumer.
+        fd = wake_event_fd;
+        #endif
     }
-    #else
-    // No per-thread objects on this build: the shared wake event is this process's only
-    // thread, so it is also that thread's only consumer.
-    if (mp_sched_thread_can_run_callbacks() && wake_event_fd >= 0) {
-        int fd = wake_event_fd;
+    if (fd >= 0) {
         fd_set rfds;
         FD_ZERO(&rfds);
         FD_SET(fd, &rfds);
@@ -433,7 +422,6 @@ int mp_hal_wake_event_wait_tv(struct timeval *tv) {
         }
         return ret;
     }
-    #endif
     // Reached with no live wake source to wait on, either because this thread has no
     // entitlement to one or because its claim could not be serviced and it holds the
     // backing-less object. Waits out `tv` and cannot be woken early in either case.

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1963,6 +1963,16 @@ typedef time_t mp_timestamp_t;
 #define MICROPY_PY_ASYNCIO_TASK_QUEUE_PUSH_CALLBACK (0)
 #endif
 
+// Whether _asyncio provides a native ThreadSafeFlag base class that declares its wake
+// source to the "select" module (MP_STREAM_SET_EVENT_SOURCE), so a set() from another
+// thread or an IRQ ends a blocked poll() directly instead of waiting for the next
+// period-capped sweep. Meaningless without MICROPY_PY_SELECT_EVENT_SOURCE, which is what
+// makes a declared wake source do anything; defaults to it for that reason. The
+// pure-Python fallback in extmod/asyncio/event.py is used instead when this is 0.
+#ifndef MICROPY_PY_ASYNCIO_THREADSAFEFLAG
+#define MICROPY_PY_ASYNCIO_THREADSAFEFLAG (MICROPY_PY_SELECT_EVENT_SOURCE)
+#endif
+
 #ifndef MICROPY_PY_UCTYPES
 #define MICROPY_PY_UCTYPES (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
 #endif

--- a/py/mphal.h
+++ b/py/mphal.h
@@ -165,8 +165,12 @@ void mp_hal_wake_obj_signal_all(void);
 // How a waiter composes its own object with everything else it is waiting on has no
 // port-neutral spelling, so it is deliberately not part of the contract above. Each port
 // that adopts wake objects exports whatever composition primitive it has behind its own
-// capability macro, and core code that uses one is guarded to match. The descriptor below
-// is the only such primitive today.
+// capability macro, and core code that uses one is guarded to match. A POSIX descriptor is
+// the only such primitive today, for either flavour of wake primitive: the one below for a
+// per-thread object, and MICROPY_HAL_WAKE_EVENT_HAS_POSIX_FD further down for a port whose
+// wake primitive is process-wide. Both are consumed only inside
+// MICROPY_PY_SELECT_POSIX_OPTIMISATIONS, since a struct pollfd is the only thing that
+// wants them.
 #ifndef MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
 #define MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD (0)
 #endif
@@ -181,6 +185,28 @@ void mp_hal_wake_obj_signal_all(void);
 // part of the generic contract above: a port whose wake object is not descriptor-backed
 // leaves MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD at 0 and never declares this.
 int mp_hal_wake_obj_posix_fd(mp_hal_wake_obj_t *w);
+#endif
+
+// A port with one process-wide wake primitive rather than per-thread objects may still be
+// able to hand its descriptor to a caller running its own poll()/select() set. That
+// primitive has exactly one legitimate consumer, whichever waiter drains it first, so a
+// caller must satisfy itself that this thread is the one entitled to it
+// (mp_sched_thread_can_run_callbacks()) before waiting on the descriptor.
+//
+// Independent of the wake-object capability above rather than its negation: a port may
+// have neither, and core code must then fall back to a bounded re-check instead of
+// blocking on something nothing can end.
+#ifndef MICROPY_HAL_WAKE_EVENT_HAS_POSIX_FD
+#define MICROPY_HAL_WAKE_EVENT_HAS_POSIX_FD (0)
+#endif
+
+#if MICROPY_HAL_WAKE_EVENT_HAS_POSIX_FD
+// The shared wake primitive's descriptor, or negative when there is none to give (the HAL
+// has been torn down). Drain it after, and only after, it has polled readable: it is
+// level-triggered, so draining ahead of a wait discards the raise and leaves that wait
+// with nothing to end it.
+int mp_hal_wake_event_fd(void);
+void mp_hal_wake_event_drain(void);
 #endif
 
 #if MICROPY_PY_SELECT_EVENT_SOURCE

--- a/py/mphal.h
+++ b/py/mphal.h
@@ -120,4 +120,32 @@ uint64_t mp_hal_time_ns(void);
 #define mp_hal_signal_event() (void)0
 #endif
 
+#if MICROPY_PY_SELECT_EVENT_SOURCE
+
+// Monotonic count of mp_event_signal() calls, safe from a hard ISR, a second
+// core, or a non-MicroPython RTOS task, on the same terms as
+// mp_hal_signal_event(). A waiter compares a snapshot of this against the
+// current value to learn whether a SOURCE_SIGNAL entry may have readied
+// since the snapshot was taken; it is never read-and-cleared, so a raise is
+// visible to every waiter rather than only the first to notice it. Wrap is
+// harmless because every use is an inequality test against a snapshot taken
+// before the raises being detected.
+extern volatile uint32_t mp_event_signal_count;
+
+// The external wake-source entry point: bumps mp_event_signal_count and
+// then calls mp_hal_signal_event() to end a blocking wait. Distinct from
+// calling mp_hal_signal_event() directly, which the scheduler's own
+// queued-work hooks do without touching the count; routing a plain
+// "runnable work exists" wake through here would make every scheduled
+// callback trigger a sweep of every registered SOURCE_SIGNAL entry.
+void mp_event_signal(void);
+
+#else
+
+// The count does not exist when the feature is off, so a driver's call site
+// stays portable: this collapses to exactly mp_hal_signal_event().
+#define mp_event_signal() mp_hal_signal_event()
+
+#endif
+
 #endif // MICROPY_INCLUDED_PY_MPHAL_H

--- a/py/mphal.h
+++ b/py/mphal.h
@@ -171,6 +171,10 @@ void mp_hal_wake_obj_signal_all(void);
 #define MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD (0)
 #endif
 
+#if MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD && !MICROPY_HAL_HAS_WAKE_OBJ
+#error "MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD describes a wake object, so it requires MICROPY_HAL_HAS_WAKE_OBJ"
+#endif
+
 #if MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
 // A descriptor that polls readable while the object is raised, for a caller running its
 // own poll()/select() set. Negative once the HAL has been torn down. Deliberately not

--- a/py/mphal.h
+++ b/py/mphal.h
@@ -194,11 +194,41 @@ int mp_hal_wake_obj_posix_fd(mp_hal_wake_obj_t *w);
 // A port whose raise primitive carries no release semantics of its own must supply one,
 // since this variable's declaration alone does not provide it.
 //
-// A raise that interleaves with the increment can coalesce two raises into one bump, but
-// the stored value still differs from any snapshot taken before either raise, so movement
-// is never lost; coalescing is harmless because a waiter re-derives readiness from the
-// source's own ioctl rather than from the count itself.
+// Movement here is the only thing that tells a waiter to re-ask a SOURCE_SIGNAL entry
+// whose own descriptor did not fire, so a lost increment is a missed wake rather than a
+// missed optimisation. MICROPY_EVENT_SIGNAL_COUNT_INC() below is what makes it lossless.
 extern volatile uint32_t mp_event_signal_count;
+
+// PORT OBLIGATION, two parts. The default of each is enough only where raises cannot
+// preempt one another; a port whose raises can (threads, or an ISR interrupting a raise)
+// must override both.
+//
+// Lossless. Two raisers must not coalesce into one bump: were the second to land between
+// the first's load and store, a waiter snapshotting the intermediate value would then see
+// the first's store leave the count where that snapshot already sits, hiding the second
+// raise from every later pass.
+//
+// Ordered. The increment must be a release and the read an acquire, so that a waiter
+// observing movement also observes the driver's state write that preceded it. Not because
+// the count carries data, but because it is the sole trigger for re-asking an entry, and
+// the ioctl that ask performs reads exactly that state. Release/acquire puts the guarantee
+// on the object the reader actually consults. A port could instead lean on its raise
+// primitive, whose syscall or barrier happens to order these anyway, but that guarantee
+// lives in an unrelated object and disappears the day two apparently independent lines are
+// reordered; the pairing here has to keep being satisfied to compile as written.
+// Deliberately no default. The obvious one, a plain read-modify-write and a plain read,
+// satisfies neither obligation above: on a single-core MCU `++count` is load/add/store, so a
+// raise from an ISR landing between the load and the store drops an increment, which is a
+// missed wake. A default that silently fails the contract stated directly above it is worse
+// than a compile error naming it, and enabling this feature is exactly the moment a port
+// should be made to decide.
+//
+// A port whose raises genuinely cannot preempt one another - no ISR raises, no second core,
+// no threads - may define these as the plain operations, but must say so rather than
+// inherit it by absence.
+#if !defined(MICROPY_EVENT_SIGNAL_COUNT_INC) || !defined(MICROPY_EVENT_SIGNAL_COUNT_GET)
+#error "MICROPY_PY_SELECT_EVENT_SOURCE requires the port to define both MICROPY_EVENT_SIGNAL_COUNT_INC() and MICROPY_EVENT_SIGNAL_COUNT_GET(); see py/mphal.h for the lossless and ordered obligations they carry"
+#endif
 
 // The external wake-source entry point: bumps mp_event_signal_count and
 // then calls mp_hal_signal_event() to end a blocking wait. Distinct from

--- a/py/mphal.h
+++ b/py/mphal.h
@@ -138,8 +138,9 @@ uint64_t mp_hal_time_ns(void);
 typedef struct _mp_hal_wake_obj_t mp_hal_wake_obj_t;
 
 // This thread's wake object, claimed on the first call and held until the thread ends.
-// NULL if the port has none left to give, which is a supported answer, not a failure: the
-// caller falls back to whatever bounded-wait cadence it used without one. Claiming once
+// Always returns a valid object: a port that cannot service a claim must fail some other
+// way (unix, for example, aborts the process on allocation failure) rather than answer
+// NULL here, since core code that uses this contract does not check for it. Claiming once
 // per thread rather than once per wait means nothing has to be released when a wait
 // returns, including when an exception unwinds out of it, and a nested wait on the same
 // thread shares the one object rather than needing a second.

--- a/py/mphal.h
+++ b/py/mphal.h
@@ -120,16 +120,84 @@ uint64_t mp_hal_time_ns(void);
 #define mp_hal_signal_event() (void)0
 #endif
 
+// Per-thread wake objects. A polling thread that has claimed one waits on that object
+// instead of on a single process-wide primitive, so a raise reaches it directly and no
+// other thread can consume the same token first. Distinct from mp_hal_signal_event(),
+// which pokes one primitive shared by every waiter: that one has exactly one legitimate
+// consumer, whichever waiter reads it first, and is not reliable for a thread that is not
+// entitled to it.
+#ifndef MICROPY_HAL_HAS_WAKE_OBJ
+#define MICROPY_HAL_HAS_WAKE_OBJ (0)
+#endif
+
+#if MICROPY_HAL_HAS_WAKE_OBJ
+
+// Opaque; the port defines the struct in its own mphalport.h. Storage belongs to the port
+// and outlives every caller, so nothing outside the port ever holds a pointer into caller
+// memory.
+typedef struct _mp_hal_wake_obj_t mp_hal_wake_obj_t;
+
+// This thread's wake object, claimed on the first call and held until the thread ends.
+// NULL if the port has none left to give, which is a supported answer, not a failure: the
+// caller falls back to whatever bounded-wait cadence it used without one. Claiming once
+// per thread rather than once per wait means nothing has to be released when a wait
+// returns, including when an exception unwinds out of it, and a nested wait on the same
+// thread shares the one object rather than needing a second.
+mp_hal_wake_obj_t *mp_hal_wake_obj_this_thread(void);
+
+// Consumes the object's raised state. Call only after a wait on it has reported it
+// raised: the backing latches, so draining ahead of a wait discards the raise and leaves
+// that wait with nothing to end it.
+void mp_hal_wake_obj_drain(mp_hal_wake_obj_t *w);
+
+// Raises every currently claimed object. Must be safe to call from anywhere
+// mp_hal_signal_event() itself is safe to call: a hard ISR, a second core, a
+// non-MicroPython RTOS task, or a POSIX signal handler.
+void mp_hal_wake_obj_signal_all(void);
+
+#else
+
+#define mp_hal_wake_obj_signal_all() (void)0
+
+#endif
+
+// How a waiter composes its own object with everything else it is waiting on has no
+// port-neutral spelling, so it is deliberately not part of the contract above. Each port
+// that adopts wake objects exports whatever composition primitive it has behind its own
+// capability macro, and core code that uses one is guarded to match. The descriptor below
+// is the only such primitive today.
+#ifndef MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
+#define MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD (0)
+#endif
+
+#if MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD
+// A descriptor that polls readable while the object is raised, for a caller running its
+// own poll()/select() set. Negative once the HAL has been torn down. Deliberately not
+// part of the generic contract above: a port whose wake object is not descriptor-backed
+// leaves MICROPY_HAL_WAKE_OBJ_HAS_POSIX_FD at 0 and never declares this.
+int mp_hal_wake_obj_posix_fd(mp_hal_wake_obj_t *w);
+#endif
+
 #if MICROPY_PY_SELECT_EVENT_SOURCE
 
-// Monotonic count of mp_event_signal() calls, safe from a hard ISR, a second
-// core, or a non-MicroPython RTOS task, on the same terms as
-// mp_hal_signal_event(). A waiter compares a snapshot of this against the
-// current value to learn whether a SOURCE_SIGNAL entry may have readied
-// since the snapshot was taken; it is never read-and-cleared, so a raise is
-// visible to every waiter rather than only the first to notice it. Wrap is
-// harmless because every use is an inequality test against a snapshot taken
-// before the raises being detected.
+// Monotonic count of mp_event_signal() calls. A waiter compares a snapshot of this
+// against the current value to learn whether a SOURCE_SIGNAL entry may have readied
+// since the snapshot was taken; it is never read-and-cleared, so a raise is visible to
+// every waiter rather than only the first to notice it. Wrap is harmless because every
+// use is an inequality test against a snapshot taken before the raises being detected.
+//
+// The count is bumped before mp_event_signal() invokes the port's raise primitive
+// (mp_hal_signal_event()), and that primitive is the ordering point a waiter's own wait
+// call pairs with: on unix, the write() to the wake descriptor, ordered against the
+// waiter's read() of it. A driver calling mp_event_signal() must complete its own state
+// write before the call, which the SOURCE_SIGNAL contract already requires (py/stream.h).
+// A port whose raise primitive carries no release semantics of its own must supply one,
+// since this variable's declaration alone does not provide it.
+//
+// A raise that interleaves with the increment can coalesce two raises into one bump, but
+// the stored value still differs from any snapshot taken before either raise, so movement
+// is never lost; coalescing is harmless because a waiter re-derives readiness from the
+// source's own ioctl rather than from the count itself.
 extern volatile uint32_t mp_event_signal_count;
 
 // The external wake-source entry point: bumps mp_event_signal_count and

--- a/py/scheduler.c
+++ b/py/scheduler.c
@@ -47,6 +47,20 @@ void MICROPY_WRAP_MP_SCHED_EXCEPTION(mp_sched_exception)(mp_obj_t exc) {
     mp_hal_signal_event();
 }
 
+#if MICROPY_PY_SELECT_EVENT_SOURCE
+volatile uint32_t mp_event_signal_count;
+
+// A SOURCE_SIGNAL stream calls this (never mp_hal_signal_event() directly)
+// to report that its readiness may have changed. Bumping the count before
+// poking the port's sleep primitive means a waiter that is already past its
+// pre-block sweep and into the block itself still learns of the raise on
+// its next pass, rather than only from the transport's own wake.
+void mp_event_signal(void) {
+    ++mp_event_signal_count;
+    mp_hal_signal_event();
+}
+#endif
+
 #if MICROPY_KBD_EXCEPTION
 // This function may be called asynchronously at any time so only do the bare minimum.
 void MICROPY_WRAP_MP_SCHED_KEYBOARD_INTERRUPT(mp_sched_keyboard_interrupt)(void) {

--- a/py/scheduler.c
+++ b/py/scheduler.c
@@ -56,7 +56,7 @@ volatile uint32_t mp_event_signal_count;
 // pre-block sweep and into the block itself still learns of the raise on
 // its next pass, rather than only from the transport's own wake.
 void mp_event_signal(void) {
-    ++mp_event_signal_count;
+    MICROPY_EVENT_SIGNAL_COUNT_INC();
     mp_hal_signal_event();
 }
 #endif

--- a/py/stream.h
+++ b/py/stream.h
@@ -99,11 +99,14 @@ struct mp_stream_seek_t {
 //                  readiness sweep and immediately before the block. Must
 //                  only update fd_events; must not touch cb/ctx, and must
 //                  not register or unregister any entry in the poll set.
-//   OP_UNREGISTER: called before the entry is released, with cb == NULL. A
-//                  stream that declares SOURCE_SIGNAL can be registered into
-//                  more than one poll set while sharing this one cb/ctx
-//                  pair, so it must count its registrations and disarm only
-//                  once the count reaches zero, not on every Unregister.
+//   OP_UNREGISTER: called only for an entry that declared SOURCE_SIGNAL,
+//                  before it is released from the poll set, with cb == NULL.
+//                  Like Refresh, must not register or unregister any entry
+//                  in the poll set. A stream that declares SOURCE_SIGNAL can
+//                  be registered into more than one poll set while sharing
+//                  this one cb/ctx pair, so it must count its registrations
+//                  and disarm only once the count reaches zero, not on
+//                  every Unregister.
 typedef struct _mp_stream_event_source_t {
     // In: supplied by the caller. The stream stores these if it declares
     // SOURCE_SIGNAL, and calls cb(ctx) when its readiness may have changed.

--- a/py/stream.h
+++ b/py/stream.h
@@ -83,6 +83,12 @@ struct mp_stream_seek_t {
 #define MP_STREAM_EVENT_FD_IS_READINESS  (0x04) // fd revents ARE readiness; skip my POLL
 #define MP_STREAM_EVENT_FD_DYNAMIC       (0x08) // re-query .fd_events every cycle
 
+// FD_IS_READINESS together with SOURCE_SIGNAL is not a useful combination: an entry whose
+// readiness comes straight from its own fd (FD_IS_READINESS) never has its MP_STREAM_POLL
+// ioctl consulted by the wait loop, so a callback armed through SOURCE_SIGNAL on the same
+// registration is never the thing that ends up reporting readiness for it. A driver should
+// declare one or the other, not both.
+
 // Cadences for MP_STREAM_SET_EVENT_SOURCE, distinguished by .op. cb == NULL
 // is not sufficient to tell Refresh and Unregister apart, since Refresh also
 // passes cb == NULL to avoid disturbing an existing arm.

--- a/py/stream.h
+++ b/py/stream.h
@@ -108,11 +108,21 @@ struct mp_stream_seek_t {
 //   OP_UNREGISTER: called only for an entry that declared SOURCE_SIGNAL,
 //                  before it is released from the poll set, with cb == NULL.
 //                  Like Refresh, must not register or unregister any entry
-//                  in the poll set. A stream that declares SOURCE_SIGNAL can
-//                  be registered into more than one poll set while sharing
-//                  this one cb/ctx pair, so it must count its registrations
-//                  and disarm only once the count reaches zero, not on
-//                  every Unregister.
+//                  in the poll set.
+//
+// A stream that declares SOURCE_SIGNAL can be registered into more than one poll set
+// while sharing this one cb/ctx pair. The caller's guarantee is only this: at most one
+// OP_UNREGISTER per successful OP_REGISTER, and none at all if the poll set itself is
+// garbage collected while still registered (a select.poll() object has no finaliser). A
+// stream may treat OP_REGISTER as idempotent and OP_UNREGISTER as advisory, staying armed
+// for its own lifetime once first registered; that is the recommended shape for any
+// stream without a real cost to staying armed, and it is what every in-tree consumer
+// does. A stream whose arming has a cost worth avoiding may count registrations instead
+// and disarm once the count reaches zero, but must accept that the count can never reach
+// zero if every poll set holding a registration is dropped without unregistering rather
+// than collected: declining a second OP_REGISTER because of an already-nonzero count is
+// not conforming, since the failure mode is a permanently inert stream rather than a
+// merely suboptimal one.
 typedef struct _mp_stream_event_source_t {
     // In: supplied by the caller. The stream stores these if it declares
     // SOURCE_SIGNAL, and calls cb(ctx) when its readiness may have changed.

--- a/tests/ports/unix/select_signal_source.py
+++ b/tests/ports/unix/select_signal_source.py
@@ -313,15 +313,13 @@ if r and dt < 200 and first == 1 and second == 0 and pc <= IDLE_POLL_COUNT_MAX:
 else:
     print("fd wake with ready FAIL:", r, dt, first, second, pc)
 
-# poll() called from a worker thread cannot rely on the deadline-block gate:
-# poll_set_signal_wake_is_reliable() only trusts the thread mp_sched_thread_can_run_
-# callbacks() names as the wake event's owner, which on the default unix build
-# (MICROPY_PY_THREAD=1, MICROPY_PY_THREAD_GIL=0) is the main thread only. A poll() from
-# any other thread therefore always falls back to the period-capped sweep, even for a
-# signal-only entry that would qualify for a deadline block if polled from the main
-# thread. A signal raised mid-wait must still be found by that sweep, and the sweep's
-# per-tick MP_STREAM_POLL calls give it a poll_count() far above the deadline-block cases
-# above.
+# poll() called from a worker thread gets the same deadline block as the main thread:
+# each thread claims its own wake object on first blocking wait
+# (mp_hal_wake_obj_this_thread(), ports/unix/unix_mphal.c), and poll_set_signal_wake_
+# is_reliable() trusts that object unconditionally, since no other thread can claim or
+# drain it. A signal raised mid-wait must still end the block promptly, with a
+# poll_count() as low as the main-thread deadline-block cases above, not the sweep's
+# per-tick cadence.
 s = SelectSignalStream()
 result = []
 
@@ -342,7 +340,7 @@ s.signal(select.POLLIN)
 while not result:
     time.sleep_ms(10)
 r, dt, pc = result[0]
-if r and dt < 500 and pc > IDLE_POLL_COUNT_MAX:
-    print("worker thread sweep ok")
+if r and dt < 500 and pc <= IDLE_POLL_COUNT_MAX:
+    print("worker thread wake ok")
 else:
-    print("worker thread sweep FAIL:", r, dt, pc)
+    print("worker thread wake FAIL:", r, dt, pc)

--- a/tests/ports/unix/select_signal_source.py
+++ b/tests/ports/unix/select_signal_source.py
@@ -17,8 +17,6 @@ except (ImportError, AttributeError, NameError):
     raise SystemExit
 
 _MP_STREAM_POLL = const(3)
-_MP_STREAM_GET_FILENO = const(10)
-_MP_STREAM_SET_EVENT_SOURCE = const(13)
 
 # Below this bound, a wait is presumed to have blocked to its deadline (or been woken)
 # rather than repeatedly re-checking readiness; at or above it, the wait is presumed to
@@ -26,26 +24,12 @@ _MP_STREAM_SET_EVENT_SOURCE = const(13)
 # (tens of ms at ~1ms cadence) and assert well above this bound, so there is no overlap.
 IDLE_POLL_COUNT_MAX = 5
 
-# Whether a main-thread poll() on a signal-only entry actually gets the deadline block
-# poll_set_signal_wake_is_reliable() is meant to grant it, probed at runtime rather than
-# assumed from build config: it is false unconditionally on a GIL build (see its doc
-# comment in extmod/modselect.c), and possibly false for other reasons this test does not
-# need to enumerate. A fd-less entry with nothing ready or signalling it takes the
-# deadline block when the entitlement holds, so its poll_count() over a short wait stays
-# at or below IDLE_POLL_COUNT_MAX; otherwise it takes the period-capped sweep instead and
-# poll_count() comes back well above that bound.
-_probe = SelectSignalStream()
-_pp = select.poll()
-_pp.register(_probe, select.POLLIN)
-_pp.poll(80)
-SIGNAL_DEADLINE_BLOCK = _probe.poll_count() <= IDLE_POLL_COUNT_MAX
-_pp.unregister(_probe)
-
-
-def pc_matches_block_cadence(pc):
-    if SIGNAL_DEADLINE_BLOCK:
-        return pc <= IDLE_POLL_COUNT_MAX
-    return pc > IDLE_POLL_COUNT_MAX
+# A signal-only entry gets the deadline block on every build this file runs on: the import
+# guard above skips without _thread, and unix ties MICROPY_HAL_HAS_WAKE_OBJ to
+# MICROPY_PY_THREAD, so a per-thread wake object always exists here and
+# poll_set_signal_wake_is_reliable() grants the block on GIL and non-GIL alike. Asserted
+# directly rather than probed: deriving the expected cadence by measuring it would let this
+# file pass with the mechanism it is testing removed.
 
 
 # Registering a fd-less stream installs its callback and counts the registration; the
@@ -110,7 +94,7 @@ r = p.poll(150)
 dt = time.ticks_diff(time.ticks_ms(), t0)
 pc = s.poll_count()
 p.unregister(s)
-if r == [] and 150 <= dt < 500 and pc_matches_block_cadence(pc):
+if r == [] and 150 <= dt < 500 and pc <= IDLE_POLL_COUNT_MAX:
     print("full timeout ok")
 else:
     print("full timeout FAIL:", r, dt, pc)
@@ -122,18 +106,20 @@ p = select.poll()
 p.register(s, select.POLLIN)
 
 
-def raise_after(ms, mask):
+# Takes the stream rather than reading the module global: the main thread rebinds that
+# name several times below, and this runs on a worker after a delay.
+def raise_after(stream, ms, mask):
     time.sleep_ms(ms)
-    s.signal(mask)
+    stream.signal(mask)
 
 
-_thread.start_new_thread(raise_after, (50, select.POLLIN))
+_thread.start_new_thread(raise_after, (s, 50, select.POLLIN))
 t0 = time.ticks_ms()
 r = p.poll(2000)
 dt = time.ticks_diff(time.ticks_ms(), t0)
 pc = s.poll_count()
 p.unregister(s)
-if r and dt < 500 and pc_matches_block_cadence(pc):
+if r and dt < 500 and pc <= IDLE_POLL_COUNT_MAX:
     print("cross thread wake ok")
 else:
     print("cross thread wake FAIL:", r, dt, pc)
@@ -149,12 +135,7 @@ p2.register(s, select.POLLIN)
 p1.unregister(s)
 
 
-def raise_after2(ms, mask):
-    time.sleep_ms(ms)
-    s.signal(mask)
-
-
-_thread.start_new_thread(raise_after2, (50, select.POLLIN))
+_thread.start_new_thread(raise_after, (s, 50, select.POLLIN))
 t0 = time.ticks_ms()
 r = p2.poll(2000)
 dt = time.ticks_diff(time.ticks_ms(), t0)
@@ -217,19 +198,14 @@ p = select.poll()
 p.register(s, select.POLLIN)
 
 
-def raise_after3(ms, mask):
-    time.sleep_ms(ms)
-    s.signal(mask)
-
-
-_thread.start_new_thread(raise_after3, (50, select.POLLIN))
+_thread.start_new_thread(raise_after, (s, 50, select.POLLIN))
 t0 = time.ticks_ms()
 r = p.poll(2000)
 dt = time.ticks_diff(time.ticks_ms(), t0)
 pc = s.poll_count()
 p.unregister(s)
 s.close()
-if r and dt < 500 and pc_matches_block_cadence(pc):
+if r and dt < 500 and pc <= IDLE_POLL_COUNT_MAX:
     print("hybrid cross thread wake ok")
 else:
     print("hybrid cross thread wake FAIL:", r, dt, pc)
@@ -288,7 +264,7 @@ pc = s.poll_count()
 drained = s.drain_fd()
 p.unregister(s)
 s.close()
-if r == [] and 150 <= dt < 500 and drained == 0 and pc_matches_block_cadence(pc):
+if r == [] and 150 <= dt < 500 and drained == 0 and pc <= IDLE_POLL_COUNT_MAX:
     print("fd wake without ready ok")
 else:
     print("fd wake without ready FAIL:", r, dt, drained, pc)
@@ -369,7 +345,7 @@ p.poll(80)
 pc = probe.poll_count()
 p.unregister(flag)
 p.unregister(probe)
-if pc_matches_block_cadence(pc):
+if pc <= IDLE_POLL_COUNT_MAX:
     print("threadsafeflag declares signal source ok")
 else:
     print("threadsafeflag declares signal source FAIL:", pc)
@@ -378,7 +354,7 @@ else:
 # same-thread set(), ending a blocking poll() promptly instead of only being found on
 # the next period-capped sweep. The poll() stays on the main thread (paired with
 # SelectSignalStream again, as above) rather than a worker thread, since only the main
-# thread is entitled to the deadline block that pc_matches_block_cadence() checks for
+# thread is entitled to the deadline block the poll_count bound below checks for
 # (see poll_set_signal_wake_is_reliable() in extmod/modselect.c); what this test needs
 # from the worker thread is only that set() called there reaches the callback safely,
 # which the main thread's own poll_count() already reveals.
@@ -401,7 +377,7 @@ dt = time.ticks_diff(time.ticks_ms(), t0)
 pc = probe.poll_count()
 p.unregister(flag)
 p.unregister(probe)
-if r and dt < 500 and pc_matches_block_cadence(pc) and flag.is_set():
+if r and dt < 500 and pc <= IDLE_POLL_COUNT_MAX and flag.is_set():
     print("threadsafeflag cross thread wake ok")
 else:
     print("threadsafeflag cross thread wake FAIL:", r, dt, pc)

--- a/tests/ports/unix/select_signal_source.py
+++ b/tests/ports/unix/select_signal_source.py
@@ -344,3 +344,64 @@ if r and dt < 500 and pc <= IDLE_POLL_COUNT_MAX:
     print("worker thread wake ok")
 else:
     print("worker thread wake FAIL:", r, dt, pc)
+
+# _asyncio._ThreadSafeFlag (extmod/modasyncio.c) is the production consumer of the
+# SOURCE_SIGNAL path this file otherwise exercises through the synthetic stream. It
+# exposes no poll_count() of its own, so its declaration is checked by pairing it with
+# SelectSignalStream in one poll() set: a single entry with no wake source drags the
+# whole set down to the sweep cadence (see "bare entry forces sweep" above), so the
+# probe's own poll_count staying at or below the deadline-block bound is only possible
+# if the flag's entry also declared a real wake source.
+try:
+    import _asyncio
+
+    _asyncio._ThreadSafeFlag
+except (ImportError, AttributeError):
+    print("SKIP")
+    raise SystemExit
+
+probe = SelectSignalStream()
+flag = _asyncio._ThreadSafeFlag()
+p = select.poll()
+p.register(probe, select.POLLIN)
+p.register(flag, select.POLLIN)
+p.poll(80)
+pc = probe.poll_count()
+p.unregister(flag)
+p.unregister(probe)
+if pc_matches_block_cadence(pc):
+    print("threadsafeflag declares signal source ok")
+else:
+    print("threadsafeflag declares signal source FAIL:", pc)
+
+# A set() called from another thread must reach the same registered callback as a
+# same-thread set(), ending a blocking poll() promptly instead of only being found on
+# the next period-capped sweep. The poll() stays on the main thread (paired with
+# SelectSignalStream again, as above) rather than a worker thread, since only the main
+# thread is entitled to the deadline block that pc_matches_block_cadence() checks for
+# (see poll_set_signal_wake_is_reliable() in extmod/modselect.c); what this test needs
+# from the worker thread is only that set() called there reaches the callback safely,
+# which the main thread's own poll_count() already reveals.
+flag = _asyncio._ThreadSafeFlag()
+probe = SelectSignalStream()
+p = select.poll()
+p.register(probe, select.POLLIN)
+p.register(flag, select.POLLIN)
+
+
+def set_after(ms):
+    time.sleep_ms(ms)
+    flag.set()
+
+
+_thread.start_new_thread(set_after, (50,))
+t0 = time.ticks_ms()
+r = p.poll(2000)
+dt = time.ticks_diff(time.ticks_ms(), t0)
+pc = probe.poll_count()
+p.unregister(flag)
+p.unregister(probe)
+if r and dt < 500 and pc_matches_block_cadence(pc) and flag.is_set():
+    print("threadsafeflag cross thread wake ok")
+else:
+    print("threadsafeflag cross thread wake FAIL:", r, dt, pc)

--- a/tests/ports/unix/select_signal_source.py
+++ b/tests/ports/unix/select_signal_source.py
@@ -1,0 +1,348 @@
+# Test the select.poll() SOURCE_SIGNAL wake path (MP_STREAM_SET_EVENT_SOURCE), using
+# SelectSignalStream, the synthetic stream defined in ports/unix/coverage.c that answers
+# the ioctl itself, standing in for a real driver.
+
+try:
+    import time
+    import select
+    import _thread
+    import io
+    import micropython
+    from micropython import const
+
+    select.poll
+    SelectSignalStream
+except (ImportError, AttributeError, NameError):
+    print("SKIP")
+    raise SystemExit
+
+_MP_STREAM_POLL = const(3)
+_MP_STREAM_GET_FILENO = const(10)
+_MP_STREAM_SET_EVENT_SOURCE = const(13)
+
+# Below this bound, a wait is presumed to have blocked to its deadline (or been woken)
+# rather than repeatedly re-checking readiness; at or above it, the wait is presumed to
+# have taken the period-capped sweep. The sweep case's own tests use much shorter waits
+# (tens of ms at ~1ms cadence) and assert well above this bound, so there is no overlap.
+IDLE_POLL_COUNT_MAX = 5
+
+# Whether a main-thread poll() on a signal-only entry actually gets the deadline block
+# poll_set_signal_wake_is_reliable() is meant to grant it, probed at runtime rather than
+# assumed from build config: it is false unconditionally on a GIL build (see its doc
+# comment in extmod/modselect.c), and possibly false for other reasons this test does not
+# need to enumerate. A fd-less entry with nothing ready or signalling it takes the
+# deadline block when the entitlement holds, so its poll_count() over a short wait stays
+# at or below IDLE_POLL_COUNT_MAX; otherwise it takes the period-capped sweep instead and
+# poll_count() comes back well above that bound.
+_probe = SelectSignalStream()
+_pp = select.poll()
+_pp.register(_probe, select.POLLIN)
+_pp.poll(80)
+SIGNAL_DEADLINE_BLOCK = _probe.poll_count() <= IDLE_POLL_COUNT_MAX
+_pp.unregister(_probe)
+
+
+def pc_matches_block_cadence(pc):
+    if SIGNAL_DEADLINE_BLOCK:
+        return pc <= IDLE_POLL_COUNT_MAX
+    return pc > IDLE_POLL_COUNT_MAX
+
+
+# Registering a fd-less stream installs its callback and counts the registration; the
+# Unregister cadence (py/stream.h) reverses both when the entry leaves the poll set.
+s = SelectSignalStream()
+if s.last_op() is not None or s.arm_count() != 0:
+    print("lifecycle FAIL: initial", s.last_op(), s.arm_count())
+else:
+    p = select.poll()
+    p.register(s, select.POLLIN)
+    reg_ok = s.last_op() == 0 and s.arm_count() == 1
+    p.unregister(s)
+    unreg_ok = s.last_op() == 2 and s.arm_count() == 0
+    if reg_ok and unreg_ok:
+        print("lifecycle ok")
+    else:
+        print("lifecycle FAIL:", reg_ok, unreg_ok)
+
+# A stream declaring SOURCE_SIGNAL may be registered into more than one poll set while
+# sharing one cb/ctx pair (the OP_UNREGISTER contract in py/stream.h), so it must count
+# registrations and release them only once the count returns to zero.
+s = SelectSignalStream()
+p1 = select.poll()
+p2 = select.poll()
+p1.register(s, select.POLLIN)
+p2.register(s, select.POLLIN)
+both = s.arm_count() == 2
+p1.unregister(s)
+one = s.arm_count() == 1
+p2.unregister(s)
+zero = s.arm_count() == 0
+if both and one and zero:
+    print("shared arm count ok")
+else:
+    print("shared arm count FAIL:", both, one, zero)
+
+# Readiness set before the wait begins is caught on the first pass, with no wake event
+# needed: the deadline block must never be entered for readiness that already exists.
+s = SelectSignalStream()
+s.set_ready(select.POLLIN)
+p = select.poll()
+p.register(s, select.POLLIN)
+t0 = time.ticks_ms()
+r = p.poll(2000)
+dt = time.ticks_diff(time.ticks_ms(), t0)
+p.unregister(s)
+if r and dt < 200:
+    print("pending ready ok")
+else:
+    print("pending ready FAIL:", r, dt)
+
+# A fd-less entry with nothing signalling it must still block for the full deadline, not
+# return early nor spin: poll_count() bounds how many times its MP_STREAM_POLL ioctl was
+# consulted, catching a busy-spin regression that a wall-clock timing check alone would
+# miss (a spin that happens to still finish inside the timing window would pass a
+# dt-only assertion).
+s = SelectSignalStream()
+p = select.poll()
+p.register(s, select.POLLIN)
+t0 = time.ticks_ms()
+r = p.poll(150)
+dt = time.ticks_diff(time.ticks_ms(), t0)
+pc = s.poll_count()
+p.unregister(s)
+if r == [] and 150 <= dt < 500 and pc_matches_block_cadence(pc):
+    print("full timeout ok")
+else:
+    print("full timeout FAIL:", r, dt, pc)
+
+# A raise from another thread (mp_event_signal(), via this stream's signal()) must end a
+# blocking poll() promptly, well before its deadline, and without spinning while idle.
+s = SelectSignalStream()
+p = select.poll()
+p.register(s, select.POLLIN)
+
+
+def raise_after(ms, mask):
+    time.sleep_ms(ms)
+    s.signal(mask)
+
+
+_thread.start_new_thread(raise_after, (50, select.POLLIN))
+t0 = time.ticks_ms()
+r = p.poll(2000)
+dt = time.ticks_diff(time.ticks_ms(), t0)
+pc = s.poll_count()
+p.unregister(s)
+if r and dt < 500 and pc_matches_block_cadence(pc):
+    print("cross thread wake ok")
+else:
+    print("cross thread wake FAIL:", r, dt, pc)
+
+# The callback installed at Register is a shared, global wake trigger, not state owned by
+# whichever registration last set it: unregistering the stream from one poll set must not
+# stop a signal from waking a different poll set that still has it registered.
+s = SelectSignalStream()
+p1 = select.poll()
+p2 = select.poll()
+p1.register(s, select.POLLIN)
+p2.register(s, select.POLLIN)
+p1.unregister(s)
+
+
+def raise_after2(ms, mask):
+    time.sleep_ms(ms)
+    s.signal(mask)
+
+
+_thread.start_new_thread(raise_after2, (50, select.POLLIN))
+t0 = time.ticks_ms()
+r = p2.poll(2000)
+dt = time.ticks_diff(time.ticks_ms(), t0)
+p2.unregister(s)
+if r and dt < 500:
+    print("unregister leaves sibling set ok")
+else:
+    print("unregister leaves sibling set FAIL:", r, dt)
+
+# A signal-only entry alongside a real fd must not disturb the fd's own readiness, and
+# must not itself report ready while its own ready mask is unset.
+s = SelectSignalStream()
+p = select.poll()
+p.register(1, select.POLLOUT)  # stdout, always writable
+p.register(s, select.POLLIN)
+r = p.poll(0)
+p.unregister(1)
+p.unregister(s)
+if len(r) == 1 and r[0][0] == 1:
+    print("mixed set ok")
+else:
+    print("mixed set FAIL:", r)
+
+
+# A registered entry with no file descriptor that also does not implement
+# MP_STREAM_SET_EVENT_SOURCE at all declares no wake source (the same compatibility path
+# as a stream written before SOURCE_SIGNAL existed).
+class NoWakeSource(io.IOBase):
+    def ioctl(self, cmd, arg):
+        if cmd == _MP_STREAM_POLL:
+            return 0
+        return -1
+
+
+# poll_set_all_have_wake_sources() is a property of the whole set, not of individual
+# entries: one such entry forces the period-capped sweep for everything registered
+# alongside it, even a signal-capable entry on the main thread that would otherwise
+# qualify for a deadline block on its own (see "full timeout" above).
+s = SelectSignalStream()
+n = NoWakeSource()
+p = select.poll()
+p.register(s, select.POLLIN)
+p.register(n, select.POLLIN)
+t0 = time.ticks_ms()
+r = p.poll(80)
+dt = time.ticks_diff(time.ticks_ms(), t0)
+pc = s.poll_count()
+p.unregister(s)
+p.unregister(n)
+if r == [] and 80 <= dt < 300 and pc > IDLE_POLL_COUNT_MAX:
+    print("bare entry forces sweep ok")
+else:
+    print("bare entry forces sweep FAIL:", r, dt, pc)
+
+# A hybrid entry (its own fd plus SOURCE_SIGNAL) raised from another thread must wake
+# promptly the same way a fd-less signal-only entry does, and without the fd (which stays
+# empty throughout) causing it to spin while idle.
+s = SelectSignalStream(True)
+p = select.poll()
+p.register(s, select.POLLIN)
+
+
+def raise_after3(ms, mask):
+    time.sleep_ms(ms)
+    s.signal(mask)
+
+
+_thread.start_new_thread(raise_after3, (50, select.POLLIN))
+t0 = time.ticks_ms()
+r = p.poll(2000)
+dt = time.ticks_diff(time.ticks_ms(), t0)
+pc = s.poll_count()
+p.unregister(s)
+s.close()
+if r and dt < 500 and pc_matches_block_cadence(pc):
+    print("hybrid cross thread wake ok")
+else:
+    print("hybrid cross thread wake FAIL:", r, dt, pc)
+
+# A raise whose wake-event token is drained by an intervening main-thread wait, between
+# one poll() pass and the next, must still end the block. The token itself
+# (mp_hal_wake_event_fd()) is a counting drain, not one this loop controls, so a
+# scheduled callback's own time.sleep_ms() can take it before this loop's poll() call
+# gets a chance to see it fire; the signal counter poll_set_take_signal() reads is the
+# only record of the raise left once the token is gone, and only the pre-block ask's own
+# `signalled` check (fed by the loop head's poll_set_take_signal() call, ahead of the
+# next poll()) still consults that counter before this loop would otherwise block for the
+# rest of the deadline.
+s = SelectSignalStream()
+p = select.poll()
+p.register(s, select.POLLIN)
+
+
+def drain_wake_event_mid_wait():
+    time.sleep_ms(200)
+
+
+def schedule_then_raise():
+    time.sleep_ms(30)
+    micropython.schedule(lambda _: drain_wake_event_mid_wait(), None)
+    time.sleep_ms(30)
+    s.signal(select.POLLIN)
+
+
+_thread.start_new_thread(schedule_then_raise, ())
+t0 = time.ticks_ms()
+r = p.poll(2000)
+dt = time.ticks_diff(time.ticks_ms(), t0)
+p.unregister(s)
+if r and dt < 500:
+    print("signalled survives a drained token ok")
+else:
+    print("signalled survives a drained token FAIL:", r, dt)
+
+# A hybrid entry (its own fd plus SOURCE_SIGNAL) wakes poll() when its fd fires, but its
+# readiness answer still comes from its own ioctl, not from the fd's kernel revents: the
+# stream never declared FD_IS_READINESS, so activity on the fd alone is not readiness.
+# MP_STREAM_POLL answering not-ready drains the fd itself (the auto-drain a hybrid driver
+# must perform per the wake-source invariant in py/stream.h), so by the time poll()
+# returns there is nothing left for the caller's own drain_fd() to collect; poll_count()
+# stays low because the drained fd then blocks for the rest of the deadline instead of
+# waking the kernel poll() again on every remaining iteration.
+s = SelectSignalStream(True)
+p = select.poll()
+p.register(s, select.POLLIN)
+t0 = time.ticks_ms()
+s.write_fd()
+r = p.poll(150)
+dt = time.ticks_diff(time.ticks_ms(), t0)
+pc = s.poll_count()
+drained = s.drain_fd()
+p.unregister(s)
+s.close()
+if r == [] and 150 <= dt < 500 and drained == 0 and pc_matches_block_cadence(pc):
+    print("fd wake without ready ok")
+else:
+    print("fd wake without ready FAIL:", r, dt, drained, pc)
+
+# The same hybrid entry reports ready once its own ready mask says so, ending the wait
+# promptly and leaving its pipe drainable down to empty.
+s = SelectSignalStream(True)
+p = select.poll()
+p.register(s, select.POLLIN)
+t0 = time.ticks_ms()
+s.write_fd()
+s.set_ready(select.POLLIN)
+r = p.poll(2000)
+dt = time.ticks_diff(time.ticks_ms(), t0)
+pc = s.poll_count()
+first = s.drain_fd()
+second = s.drain_fd()
+p.unregister(s)
+s.close()
+if r and dt < 200 and first == 1 and second == 0 and pc <= IDLE_POLL_COUNT_MAX:
+    print("fd wake with ready ok")
+else:
+    print("fd wake with ready FAIL:", r, dt, first, second, pc)
+
+# poll() called from a worker thread cannot rely on the deadline-block gate:
+# poll_set_signal_wake_is_reliable() only trusts the thread mp_sched_thread_can_run_
+# callbacks() names as the wake event's owner, which on the default unix build
+# (MICROPY_PY_THREAD=1, MICROPY_PY_THREAD_GIL=0) is the main thread only. A poll() from
+# any other thread therefore always falls back to the period-capped sweep, even for a
+# signal-only entry that would qualify for a deadline block if polled from the main
+# thread. A signal raised mid-wait must still be found by that sweep, and the sweep's
+# per-tick MP_STREAM_POLL calls give it a poll_count() far above the deadline-block cases
+# above.
+s = SelectSignalStream()
+result = []
+
+
+def poll_from_thread():
+    p = select.poll()
+    p.register(s, select.POLLIN)
+    t0 = time.ticks_ms()
+    r = p.poll(2000)
+    dt = time.ticks_diff(time.ticks_ms(), t0)
+    p.unregister(s)
+    result.append((r, dt, s.poll_count()))
+
+
+_thread.start_new_thread(poll_from_thread, ())
+time.sleep_ms(50)
+s.signal(select.POLLIN)
+while not result:
+    time.sleep_ms(10)
+r, dt, pc = result[0]
+if r and dt < 500 and pc > IDLE_POLL_COUNT_MAX:
+    print("worker thread sweep ok")
+else:
+    print("worker thread sweep FAIL:", r, dt, pc)

--- a/tests/ports/unix/select_signal_source.py.exp
+++ b/tests/ports/unix/select_signal_source.py.exp
@@ -1,0 +1,13 @@
+lifecycle ok
+shared arm count ok
+pending ready ok
+full timeout ok
+cross thread wake ok
+unregister leaves sibling set ok
+mixed set ok
+bare entry forces sweep ok
+hybrid cross thread wake ok
+signalled survives a drained token ok
+fd wake without ready ok
+fd wake with ready ok
+worker thread sweep ok

--- a/tests/ports/unix/select_signal_source.py.exp
+++ b/tests/ports/unix/select_signal_source.py.exp
@@ -11,3 +11,5 @@ signalled survives a drained token ok
 fd wake without ready ok
 fd wake with ready ok
 worker thread wake ok
+threadsafeflag declares signal source ok
+threadsafeflag cross thread wake ok

--- a/tests/ports/unix/select_signal_source.py.exp
+++ b/tests/ports/unix/select_signal_source.py.exp
@@ -10,4 +10,4 @@ hybrid cross thread wake ok
 signalled survives a drained token ok
 fd wake without ready ok
 fd wake with ready ok
-worker thread sweep ok
+worker thread wake ok

--- a/tests/ports/unix/select_wake_obj_degraded.py
+++ b/tests/ports/unix/select_wake_obj_degraded.py
@@ -1,0 +1,88 @@
+# Test what select.poll() does for a thread the port could not give a wake object to.
+#
+# A claim that cannot be serviced hands back a valid but backing-less object rather than
+# failing, so most callers degrade through code that already exists. The exception is an
+# indefinite wait holding SOURCE_SIGNAL entries: nothing is left that could end it, so it
+# raises instead of blocking forever.
+#
+# Runs in its own file because a wake object is returned rather than closed when a thread
+# ends: a worker started by another test in the same process would leave a node behind for
+# this one to reuse, and the claim would succeed without ever reaching the failure below.
+
+try:
+    import time
+    import select
+    import _thread
+
+    select.poll
+    SelectSignalStream
+    select_force_wake_obj_failure
+except (ImportError, AttributeError, NameError):
+    print("SKIP")
+    raise SystemExit
+
+# Spelled out because MicroPython's errno module carries a subset that excludes it, while
+# the raise itself uses MP_EMFILE (py/mperrno.h). 24 on both platforms this port runs on.
+EMFILE = 24
+
+# Only a worker thread can reach this: the main thread claims its object during HAL
+# init, before any of this could ask the port to start failing.
+results = {}
+done = _thread.allocate_lock()
+
+
+def worker():
+    stream = SelectSignalStream()
+    poller = select.poll()
+    poller.register(stream, select.POLLIN)
+
+    # Indefinite, with a registered signal source and no object able to carry a raise to
+    # this thread. If the raise below is ever lost this hangs rather than fails, and the
+    # test harness timeout is what reports it.
+    try:
+        poller.poll()
+        results["indefinite"] = "returned"
+    except OSError as er:
+        results["indefinite"] = er.errno
+    except BaseException as er:
+        results["indefinite"] = repr(er)
+
+    # The same set with a timeout the caller chose degrades silently instead, because that
+    # timeout still ends the wait: nothing here can hang, so nothing needs to raise.
+    try:
+        t0 = time.ticks_ms()
+        ready = poller.poll(120)
+        elapsed = time.ticks_diff(time.ticks_ms(), t0)
+        results["finite"] = (ready, elapsed >= 100)
+    except BaseException as er:
+        results["finite"] = repr(er)
+
+    poller.unregister(stream)
+    done.release()
+
+
+done.acquire()
+select_force_wake_obj_failure(True)
+_thread.start_new_thread(worker, ())
+done.acquire()
+select_force_wake_obj_failure(False)
+
+if results.get("indefinite") == EMFILE:
+    print("degraded indefinite raises ok")
+else:
+    print("degraded indefinite raises FAIL:", results.get("indefinite"))
+
+if results.get("finite") == ([], True):
+    print("degraded finite still returns ok")
+else:
+    print("degraded finite still returns FAIL:", results.get("finite"))
+
+# A set with no signal source never depended on a raise, so it is unaffected: the port is
+# still failing every claim here, and a plain timeout must still be honoured.
+t0 = time.ticks_ms()
+empty = select.poll()
+ready = empty.poll(60)
+if ready == [] and time.ticks_diff(time.ticks_ms(), t0) >= 50:
+    print("degraded without signal sources ok")
+else:
+    print("degraded without signal sources FAIL:", ready)

--- a/tests/ports/unix/select_wake_obj_degraded.py.exp
+++ b/tests/ports/unix/select_wake_obj_degraded.py.exp
@@ -1,0 +1,3 @@
+degraded indefinite raises ok
+degraded finite still returns ok
+degraded without signal sources ok


### PR DESCRIPTION
### Summary

Builds on #52. That one covered pollables whose wake source is a file descriptor; this covers the ones that have no descriptor at all - a completion ISR, a flag set from another thread - which today can only be discovered by re-asking every registered object on a 1 ms heartbeat.

A stream can now declare `SOURCE_SIGNAL` and be handed a callback to fire when its readiness may have changed. A `poll()` holding such an entry sleeps to the caller's deadline and is woken by the raise, instead of waking a thousand times a second to ask.

The demonstrator is `asyncio.ThreadSafeFlag`, and it is not a contrivance: it has no descriptor, so under the old rule one flag in an asyncio poll set drags the entire set onto the sweep. Measured on unix, asyncio awaiting a flag set from a `_thread` worker across a 2s idle window: **1658 poll() calls -> 2**.

Attribution matters more than that number, so each mechanism is quoted where it is solely responsible. The native `_ThreadSafeFlag` in `extmod/modasyncio.c` (the pure-Python class stays as the fallback) carries the whole main-thread result. The per-thread wake objects carry the non-GIL worker-thread case, 1660 -> 2, and nothing else - a claim I had wrong until I built a binary with them forced off and measured it.

Those wake objects are the other half of this PR. A single process-wide wake primitive has exactly one legitimate consumer, whichever waiter reads it first, so a second thread blocked on it either steals someone else's wake or misses its own. `py/mphal.h` gains an optional per-thread alternative, defaulted off so every port stays as it is, with unix implementing it over an append-only list of eventfds that is safe to walk from a signal handler.

### Testing

unix, per commit rather than only at the tip: all 24 commits build the coverage variant **and** pass `tests/ports/unix` individually. Building alone is not sufficient here - the option is off in the standard variant, so a broken hand-over between the two wake mechanisms compiles clean there. At the tip: coverage 1108/1109, standard 1052/1052, thread suite 27/27.

The single failure is `misc/sys_settrace_features.py`, CPython 3.12 tracing into local site-packages, which fails identically without this branch.

New tests cover the SOURCE_SIGNAL wake path, the native ThreadSafeFlag path including a cross-thread wake, and the degraded case where the port cannot give a thread a wake object - that last one verified to hang without its fix and pass with it.

Not tested on any port but unix, and again that is structural rather than an omission: no other port can enable `MICROPY_PY_SELECT_EVENT_SOURCE` at all.

### Trade-offs and Alternatives

Size, unix standard: 791610 off, 794226 on without the GIL, 795204 on with it. Nothing reaches a port that leaves the option off.

`mp_hal_signal_event()` on unix becomes a broadcast, one write per thread that has ever blocked, where it used to be a single write. That is inherent to a raise carrying no identity, and it costs a syscall per sleeping thread on every `micropython.schedule()`. It has not been benchmarked with many threads and should be before this goes upstream.

Known gaps I would rather state than have found: neither of two recently-fixed defects has a regression test, because the in-tree test double self-heals in both the ways that would expose them; and the multi-consumer race the per-thread objects exist to remove is argued rather than measured - two threads polling their own signal source pass with and without them, because each `set()` leaves its own token. The honest claim for the transport is the non-GIL worker case above.

This is a draft for review on the fork and is not ready for upstream. It is stacked on #52; the diff against master would include that PR's commits too.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the description above.