### PR TITLE
tools/mpremote: Leave raw REPL when terminated by a signal.

### DIFF
--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -18,7 +18,7 @@ MicroPython device over a serial connection.  Commands supported are:
 """
 
 import argparse
-import os, sys, time
+import os, signal, sys, time
 from collections.abc import Mapping
 from textwrap import dedent
 
@@ -558,6 +558,25 @@ class State:
             self.transport.exit_raw_repl()
 
 
+def _exit_raw_repl_on_terminate():
+    # Make a terminating signal unwind through main()'s `finally` instead of
+    # killing the process outright, so do_disconnect() still gets to leave raw
+    # REPL. A device left in raw mode is not just untidy: where the REPL is
+    # driven by a single-threaded event loop, its raw-mode reader can be left
+    # blocked on input that will never arrive, stalling every other task on the
+    # target until something else writes to its console. SIGINT already unwinds
+    # this way, being delivered as KeyboardInterrupt.
+    # SIGHUP has no Windows equivalent, hence the getattr.
+    for sig in (signal.SIGTERM, getattr(signal, "SIGHUP", None)):
+        if sig is None:
+            continue
+        try:
+            signal.signal(sig, lambda *_args: sys.exit(1))
+        except ValueError:
+            # Not called from the main thread, so the signal is not ours to take.
+            pass
+
+
 def main():
     if sys.platform == "win32":
         # Configure stdout/stderr before any imports that might print: on some Windows
@@ -571,6 +590,8 @@ def main():
 
     remaining_args = sys.argv[1:]
     state = State()
+
+    _exit_raw_repl_on_terminate()
 
     try:
         while remaining_args:


### PR DESCRIPTION
### Summary

mpremote already leaves raw REPL on the way out: `main()` ends with `finally: do_disconnect(state)`, and `do_disconnect` sends ctrl-B before closing the port. An interactive ctrl-C gets there too, since SIGINT arrives as `KeyboardInterrupt` and unwinds normally. SIGTERM and SIGHUP keep their default disposition, so a shell `timeout`, a supervisor's kill, or a closed terminal ends the process without running any of that, and the device is left in raw mode.

I hit this driving a board whose REPL runs under asyncio on a single core. A device left in raw mode there has its raw-mode reader blocked on input that never arrives, which stalls every other task on the target until something else writes to its console. On that board the REPL was also the only management channel, so a host-side `timeout N mpremote ...` was enough to make it unreachable. Any long-lived tool that supervises mpremote can produce the same state.

The fix installs handlers for those two signals that raise `SystemExit`, so they unwind through the cleanup that already exists rather than adding a second teardown path. There is a guard for the same thing around the blocking mount wait already, but it does not cover `main()`.

### Testing

Against a pty that answers the raw-REPL handshake and then goes silent, so the host is blocked waiting on a response when the signal lands. Before, the last bytes on the wire are `\r\x03\r\x01\x04` and the process dies on signal 15. After, they are `\r\x03\r\x01\x04\r\x02` and it exits 1. Also exercised on a PYBD-SF6W over serial, where the escape is buffered while the device finishes executing and takes effect when it does.

Not tested on Windows, where only the SIGTERM half applies.

### Trade-offs and Alternatives

The exit code for a terminating signal becomes 1 rather than the shell's usual 128+N. That is the same code an interactive ctrl-C already produces, so it is at least consistent, but a supervisor distinguishing the two cases by exit code would notice.

I looked at sending ctrl-C before ctrl-B, so a device that is mid-execution consumes the escape immediately instead of whenever its current command finishes. I left it out: `exec --no-follow` exists specifically to leave code running on the device after mpremote exits, and an unconditional interrupt on teardown would silently kill that. It would need scoping to an aborted followed session, which is a bigger change than this one.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the description above.
