### PR TITLE
tools/mpremote: Ignore non-version tags when deriving the version.

### DIFF
--- a/tools/mpremote/pyproject.toml
+++ b/tools/mpremote/pyproject.toml
@@ -44,7 +44,13 @@ files = ["requirements.txt"]
 [tool.hatch.version]
 source = "vcs"
 tag-pattern = "(?P<version>v(\\d+).(\\d+).(\\d+)(-preview)?)"
-raw-options = { root = "../..", version_scheme = "post-release" }
+# `git describe` otherwise reports whatever tag is nearest, so any non-version
+# tag on the checked-out commit (a pin, a snapshot, a local marker) is handed to
+# tag-pattern and fails the build rather than being skipped. Restrict the search
+# to version tags; the rest of the command is setuptools_scm's own default.
+raw-options = { root = "../..", version_scheme = "post-release", git_describe_command = [
+    "git", "describe", "--dirty", "--tags", "--long", "--match", "v[0-9]*",
+] }
 
 [tool.hatch.build]
 packages = ["mpremote"]


### PR DESCRIPTION
### Summary

The package version comes from `git describe`, which reports whichever tag is nearest to the checked-out commit regardless of what that tag looks like. If the commit being built carries any tag that is not a release tag, that tag gets handed to `tag-pattern`, which cannot parse it, and the build fails outright instead of walking back to the last version tag:

```
ValueError: Error getting the version from source `vcs`: Can't parse version from
tag 'ampremote-pin-d865a7f9b110' (tag_regex='(?P<version>v(\d+).(\d+).(\d+)(-preview)?)')
```

So annotating a commit is enough to stop it building. I ran into it pinning a downstream consumer at a SHA. The commit was tagged to keep it reachable across later force-moves of the branch, and a SHA pin lands the consumer on exactly that commit, so the tag protecting the pin was also the thing breaking it. Snapshot and marker tags on a local checkout do the same.

`--match` restricts the search to version tags, so anything else is skipped rather than parsed. The rest of the describe command is setuptools_scm's own default, spelled out because passing `git_describe_command` replaces it wholesale.

### Testing

Built at a commit carrying a non-version tag, which failed before and succeeds now. The derived version is byte-identical with and without such a tag present, so nothing changes for an ordinary checkout. `v1.29.0` and `v1.29.0-preview` both still match, so release and preview versioning are unaffected. Finally installed from a git URL pinned at a tagged commit into a clean venv, since building a wheel and installing a pinned URL are not the same code path.

### Trade-offs and Alternatives

Passing `git_describe_command` pins the whole command, so if setuptools_scm changes its default flags this will not follow. That is the cost of the option existing only in all-or-nothing form.

The alternative is widening `tag-pattern` to tolerate and skip what it cannot parse. I preferred not to: `tag-pattern` describes what a version looks like, and the bug is about which tags are offered to it in the first place. Fixing it at the describe step keeps those two concerns where they belong.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the description above.
