### PR TITLE
stm32: Enable FDCAN on STM32H5.

### DIFF
--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -20,7 +20,7 @@ concurrency:
 env:
    # Oldest and newest supported ESP-IDF versions, should match ports/esp32/README.md
    IDF_OLDEST_VER: &oldest "v5.3"
-   IDF_NEWEST_VER: &newest "v5.5.2"
+   IDF_NEWEST_VER: &newest "v5.5.5"
 
 jobs:
   build_idf:

--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -52,8 +52,8 @@ manage the ESP32 microcontroller, as well as a way to manage the required
 build environment and toolchains needed to build the firmware.
 
 The ESP-IDF changes quickly and MicroPython only supports certain versions. The
-current recommended version of ESP-IDF for MicroPython is v5.5.2. MicroPython
-also supports v5.3, v5.4, v5.4.1, v5.4.2, v5.5.1 and v5.5.4.
+current recommended version of ESP-IDF for MicroPython is v5.5.5. MicroPython
+also supports v5.3, v5.4, v5.4.1, v5.4.2, v5.5.1, v5.5.2 and v5.5.4.
 
 <!-- Important: If updating the above, please also update:
      * IDF_OLDEST_VER & IDF_NEWEST_VER in .github/workflows/port_esp32.yml

--- a/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
@@ -13,6 +13,9 @@
 
 #define MICROPY_PY_MACHINE_SDCARD           (1)
 #define MICROPY_HW_SDMMC_LDO_CHAN_ID        (4)
+// This board wires the SD/MMC card to SDMMC slot 0 with a full 4-bit bus.
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (0)
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (4)
 
 #ifndef USB_SERIAL_JTAG_PACKET_SZ_BYTES
 #define USB_SERIAL_JTAG_PACKET_SZ_BYTES (64)

--- a/ports/esp32/lockfiles/dependencies.lock.esp32
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32
@@ -25,7 +25,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/lan867x
 - espressif/mdns

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c2
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c3
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c5
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c5
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c6
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c6
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32h2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32h2
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32p4
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32p4
@@ -81,7 +81,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/esp_hosted
 - espressif/esp_wifi_remote

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s2
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s3
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/ports/esp32/machine_sdcard.h
+++ b/ports/esp32/machine_sdcard.h
@@ -26,6 +26,17 @@
 #ifndef MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
 #define MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
 
+// Default slot and bus width for a native SD/MMC machine.SDCard(). These are
+// conservative defaults (the historically usable slot 1, 1-bit); which slot is
+// wired and how many data lines are routed is board specific, so a board should
+// override these in its mpconfigboard.h to match its layout.
+#ifndef MICROPY_HW_SDMMC_DEFAULT_SLOT
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
+#endif
+#ifndef MICROPY_HW_SDMMC_DEFAULT_WIDTH
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (1)
+#endif
+
 // Default pins for the primary SPI-mode SD card bus (slot 2). SPI mode is
 // available on every ESP32 variant, so a board may override these in its
 // mpconfigboard.h to make machine.SDCard(slot=2) work without explicit pins.

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -150,8 +150,11 @@ soft_reset:
     machine_i2s_init0();
     #endif
 
-    // run boot-up scripts
-    pyexec_frozen_module("_boot.py", false);
+    // Run optional frozen boot code.
+    #ifdef MICROPY_BOARD_FROZEN_BOOT_FILE
+    pyexec_frozen_module(MICROPY_BOARD_FROZEN_BOOT_FILE, false);
+    #endif
+
     int ret = pyexec_file_if_exists("boot.py");
 
     #if MICROPY_HW_ENABLE_USBDEV

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -326,9 +326,7 @@ static mp_obj_t machine_wake_pins(void) {
 
     // Only a few (~8) pins might cause wakeup.
     // Therefore, we calculate the required space in a first pass.
-    for (index = 0, len = 0; index < 64; index++) {
-        len += (status & (1ULL << index)) ? 1 : 0;
-    }
+    len = mp_popcount(status >> 32) + mp_popcount(status & 0xFFFFFFFF);
     if (len) {
         mp_obj_tuple_t *tuple = MP_OBJ_TO_PTR(mp_obj_new_tuple(len, NULL));
 

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -224,20 +224,6 @@
 #ifndef MICROPY_HW_ENABLE_SDCARD
 #define MICROPY_HW_ENABLE_SDCARD            (1)
 #endif
-#ifndef MICROPY_HW_SDMMC_DEFAULT_SLOT
-#if CONFIG_IDF_TARGET_ESP32P4
-#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (0)
-#else
-#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
-#endif
-#endif
-#ifndef MICROPY_HW_SDMMC_DEFAULT_WIDTH
-#if CONFIG_IDF_TARGET_ESP32P4
-#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (4)
-#else
-#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (1)
-#endif
-#endif
 #define MICROPY_HW_SOFTSPI_MIN_DELAY        (0)
 #define MICROPY_HW_SOFTSPI_MAX_BAUDRATE     (esp_rom_get_cpu_ticks_per_us() * 1000000 / 200) // roughly
 #define MICROPY_PY_SSL                      (MICROPY_PY_NETWORK)

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -425,6 +425,10 @@ typedef long mp_off_t;
 #define MICROPY_BOARD_STARTUP boardctrl_startup
 #endif
 
+#ifndef MICROPY_BOARD_FROZEN_BOOT_FILE
+#define MICROPY_BOARD_FROZEN_BOOT_FILE "_boot.py"
+#endif
+
 void boardctrl_startup(void);
 
 #ifndef MICROPY_PY_NETWORK_LAN

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -425,7 +425,7 @@ endif
 
 ifeq ($(MCU_SERIES),$(filter $(MCU_SERIES),f0 f4 f7))
 HAL_SRC_C += $(addprefix $(STM32LIB_HAL_BASE)/Src/stm32$(MCU_SERIES)xx_, hal_can.c)
-else ifeq ($(MCU_SERIES),$(filter $(MCU_SERIES),g0 g4 h7 n6))
+else ifeq ($(MCU_SERIES),$(filter $(MCU_SERIES),g0 g4 h5 h7 n6))
 HAL_SRC_C += $(addprefix $(STM32LIB_HAL_BASE)/Src/stm32$(MCU_SERIES)xx_, hal_fdcan.c)
 else ifeq ($(MCU_SERIES),$(filter $(MCU_SERIES),l4))
 HAL_SRC_C += $(addprefix $(STM32LIB_HAL_BASE)/Src/Legacy/stm32$(MCU_SERIES)xx_, hal_can.c)

--- a/ports/stm32/boards/NUCLEO_H563ZI/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_H563ZI/mpconfigboard.h
@@ -39,6 +39,17 @@
 // There is an external 32kHz oscillator
 #define MICROPY_HW_RTC_USE_LSE              (1)
 
+// CAN config
+// Both FDCAN instances use AF9. An external CAN transceiver is required on
+// each; the board has none fitted. Check the board user manual for the
+// solder bridge and jumper configuration of these pins before wiring.
+#define MICROPY_HW_CAN1_NAME                "FDCAN1"
+#define MICROPY_HW_CAN1_TX                  (pin_D1)
+#define MICROPY_HW_CAN1_RX                  (pin_D0)
+#define MICROPY_HW_CAN2_NAME                "FDCAN2"
+#define MICROPY_HW_CAN2_TX                  (pin_B13)
+#define MICROPY_HW_CAN2_RX                  (pin_B12)
+
 // UART config
 #define MICROPY_HW_UART1_TX                 (pin_B6) // SB14: Arduino Connector CN10-Pin14 (D1)
 #define MICROPY_HW_UART1_RX                 (pin_B7) // SB63: Arduino Connector CN10-Pin16 (D0)

--- a/ports/stm32/can.h
+++ b/ports/stm32/can.h
@@ -59,7 +59,7 @@
 #define CAN_MODE_SILENT_LOOPBACK    FDCAN_MODE_INTERNAL_LOOPBACK
 
 // FDCAN peripheral has independent indexes for standard id vs extended id filters
-#if defined(STM32G4)
+#if defined(STM32G4) || defined(STM32H5)
 #define CAN_HW_MAX_STD_FILTER 28
 #define CAN_HW_MAX_EXT_FILTER 8
 #elif defined(STM32H7) || defined(STM32N6)
@@ -126,7 +126,7 @@ typedef struct {
 #if defined(STM32H7) || defined(STM32N6)
 #define CAN_TX_QUEUE_LEN 16
 #else
-// FDCAN STM32G4, bxCAN
+// FDCAN STM32G4/H5, bxCAN
 #define CAN_TX_QUEUE_LEN 3
 #endif
 

--- a/ports/stm32/fdcan.c
+++ b/ports/stm32/fdcan.c
@@ -365,17 +365,22 @@ void can_enable_rx_interrupts(CAN_HandleTypeDef *can, can_rx_fifo_t fifo, bool e
     HAL_FDCAN_ActivateNotification(can, ints, 0);
 }
 
-// Fixup the DataLength field from a byte count to a valid DLC value index (rounding up)
-static void encode_datalength(CanTxMsgTypeDef *txmsg) {
+// Fixup the DataLength field from a byte count to a valid DLC value index (rounding up).
+//
+// The destination copy routine determines which of two encodings it expects: a bare
+// DLC table index, or that index pre-shifted into the field position the DLC occupies
+// in the message RAM header word (bits 19:16). Which encoding is needed does not
+// depend on the MCU alone: on STM32H5, HAL_FDCAN_AddMessageToTxFifoQ() (used by
+// can_transmit()) shifts internally and wants a bare index, while this port's own
+// AddMessageToTxBuffer()/EnableTxBufferRequest() shim (used by can_transmit_buf_index(),
+// shared verbatim with STM32G4) expects the value already shifted. Callers pass
+// raw_dlc_index to select the encoding their destination routine needs.
+static void encode_datalength(CanTxMsgTypeDef *txmsg, bool raw_dlc_index) {
     // Roundup DataLength to next DLC size and encode to DLC.
     size_t len_bytes = txmsg->DataLength;
     for (mp_uint_t i = 0; i < MP_ARRAY_SIZE(DLCtoBytes); i++) {
         if (len_bytes <= DLCtoBytes[i]) {
-            #if defined(STM32N6)
-            txmsg->DataLength = i;
-            #else
-            txmsg->DataLength = (i << 16);
-            #endif
+            txmsg->DataLength = raw_dlc_index ? i : (i << 16);
             return;
         }
     }
@@ -398,7 +403,15 @@ HAL_StatusTypeDef can_transmit(CAN_HandleTypeDef *can, CanTxMsgTypeDef *txmsg, u
     }
     // Note: this function doesn't set up TX interrupts, because it's only used by pyb.CAN which
     // doesn't care about this - machine.CAN calls can_transmit_buf_index()
-    encode_datalength(txmsg);
+    //
+    // HAL_FDCAN_AddMessageToTxFifoQ() below is the real HAL implementation on every supported
+    // MCU. It expects a bare DLC index on STM32N6 and STM32H5, and that index pre-shifted into
+    // the header word on STM32G4 and STM32H7.
+    #if defined(STM32N6) || defined(STM32H5)
+    encode_datalength(txmsg, true);
+    #else
+    encode_datalength(txmsg, false);
+    #endif
 
     return HAL_FDCAN_AddMessageToTxFifoQ(can, txmsg, data);
 }
@@ -406,7 +419,15 @@ HAL_StatusTypeDef can_transmit(CAN_HandleTypeDef *can, CanTxMsgTypeDef *txmsg, u
 HAL_StatusTypeDef can_transmit_buf_index(CAN_HandleTypeDef *hcan, int index, CanTxMsgTypeDef *txmsg, const uint8_t *data) {
     uint32_t tx_loc = 1U << index;
 
-    encode_datalength(txmsg);
+    // HAL_FDCAN_AddMessageToTxBuffer() below is this port's own shim on STM32G4 and STM32H5
+    // (see the definition further down this file), which expects the DLC index pre-shifted
+    // into the header word. On STM32H7 and STM32N6 it resolves to the real HAL implementation,
+    // which expects a bare index on STM32N6 and that index pre-shifted on STM32H7.
+    #if defined(STM32N6)
+    encode_datalength(txmsg, true);
+    #else
+    encode_datalength(txmsg, false);
+    #endif
 
     HAL_StatusTypeDef err = HAL_FDCAN_ActivateNotification(hcan, FDCAN_IT_TX_COMPLETE | FDCAN_IT_TX_ABORT_COMPLETE, tx_loc);
     if (err == HAL_OK) {

--- a/ports/stm32/fdcan.c
+++ b/ports/stm32/fdcan.c
@@ -70,11 +70,11 @@
 #define FDCAN_MESSAGE_RAM_SIZE  (2560 - 1)
 #endif // STM32H7 || STM32N6
 
-#if defined(STM32G4)
-// These HAL APIs are not implemented for STM32G4, so we implement them here...
+#if defined(STM32G4) || defined(STM32H5)
+// These HAL APIs are not implemented for STM32G4/H5, so we implement them here...
 static HAL_StatusTypeDef HAL_FDCAN_AddMessageToTxBuffer(FDCAN_HandleTypeDef *hfdcan, FDCAN_TxHeaderTypeDef *pTxHeader, uint8_t *pTxData, uint32_t BufferIndex);
 static HAL_StatusTypeDef HAL_FDCAN_EnableTxBufferRequest(FDCAN_HandleTypeDef *hfdcan, uint32_t BufferIndex);
-#endif // STM32G4
+#endif // STM32G4 || STM32H5
 
 // also defined in <PROC>_hal_fdcan.c, but not able to declare extern and reach the variable
 static const uint8_t DLCtoBytes[16] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48, 64};
@@ -149,7 +149,7 @@ bool can_init(CAN_HandleTypeDef *can, int can_id, can_tx_mode_t tx_mode, uint32_
     init->StdFiltersNbr = CAN_HW_MAX_STD_FILTER;
     init->ExtFiltersNbr = CAN_HW_MAX_EXT_FILTER;
 
-    #if defined(STM32G4)
+    #if defined(STM32G4) || defined(STM32H5)
     init->ClockDivider = FDCAN_CLOCK_DIV1;
     init->TxFifoQueueMode = fifo_queue_mode;
     #elif defined(STM32H7) || defined(STM32N6)
@@ -342,8 +342,8 @@ uint32_t can_get_source_freq(void) {
         default:
             abort(); // Should be unreachable, macro should return one of the above
     }
-    #elif defined(STM32G4)
-    // STM32G4 CAN clock from reset is HSE, unchanged by MicroPython
+    #elif defined(STM32G4) || defined(STM32H5)
+    // STM32G4/H5 CAN clock from reset is HSE, unchanged by MicroPython
     return HSE_VALUE;
     #else // G0, and assume other MCUs too.
     // CAN1/CAN2/CAN3 on APB1 use GetPCLK1Freq, alternatively use the following:
@@ -477,14 +477,16 @@ int can_receive(FDCAN_HandleTypeDef *can, can_rx_fifo_t fifo, FDCAN_RxHeaderType
     uint32_t index, *address;
     if (fifo == CAN_RX_FIFO0) {
         index = (*rxf & FDCAN_RXF0S_F0GI) >> FDCAN_RXF0S_F0GI_Pos;
-        #if defined(STM32G4)
+        // G0's FDCAN_InitTypeDef has no RxFifo0ElmtSize field either, the
+        // same fixed 18-word element the comment already names for G4/H5.
+        #if defined(STM32G4) || defined(STM32H5) || defined(STM32G0)
         address = (uint32_t *)(can->msgRam.RxFIFO0SA + (index * (18U * 4U)));  // SRAMCAN_RF0_SIZE bytes, size not configurable
         #else
         address = (uint32_t *)(can->msgRam.RxFIFO0SA + (index * can->Init.RxFifo0ElmtSize * 4));
         #endif
     } else {
         index = (*rxf & FDCAN_RXF1S_F1GI) >> FDCAN_RXF1S_F1GI_Pos;
-        #if defined(STM32G4)
+        #if defined(STM32G4) || defined(STM32H5) || defined(STM32G0)
         address = (uint32_t *)(can->msgRam.RxFIFO1SA + (index * (18U * 4U)));  // SRAMCAN_RF1_SIZE bytes, size not configurable
         #else
         address = (uint32_t *)(can->msgRam.RxFIFO1SA + (index * can->Init.RxFifo1ElmtSize * 4));
@@ -666,7 +668,7 @@ void FDCAN2_IT1_IRQHandler(void) {
 }
 #endif
 
-#if defined(STM32G4)
+#if defined(STM32G4) || defined(STM32H5)
 // These implementations are copied from stm32h7xx_hal_fdcan.c with modifications for different G4 registers & code formatting
 
 // *FORMAT-OFF*
@@ -807,7 +809,7 @@ static void FDCAN_CopyMessageToRAM(FDCAN_HandleTypeDef *hfdcan, FDCAN_TxHeaderTy
   }
 }
 
-#endif // STM32G4
+#endif // STM32G4 || STM32H5
 
 // *FORMAT-ON*
 #endif // MICROPY_HW_ENABLE_CAN && MICROPY_HW_ENABLE_FDCAN

--- a/ports/stm32/mpconfigboard_common.h
+++ b/ports/stm32/mpconfigboard_common.h
@@ -743,7 +743,7 @@ void mp_usbd_ll_init(void);
 // Enable CAN if there are any peripherals defined
 #if defined(MICROPY_HW_CAN1_TX) || defined(MICROPY_HW_CAN2_TX) || defined(MICROPY_HW_CAN3_TX)
 #define MICROPY_HW_ENABLE_CAN (1)
-#if defined(STM32G0) || defined(STM32G4) || defined(STM32H7) || defined(STM32N6)
+#if defined(STM32G0) || defined(STM32G4) || defined(STM32H5) || defined(STM32H7) || defined(STM32N6)
 #define MICROPY_HW_ENABLE_FDCAN (1) // define for MCUs with FDCAN
 #endif
 #else

--- a/ports/stm32/pin_defs_stm32.h
+++ b/ports/stm32/pin_defs_stm32.h
@@ -127,8 +127,8 @@ enum {
 #define I2S2  SPI2
 #define I2S3  SPI3
 
-#if defined(STM32G4) || defined(STM32H7)
-// Make G4/H7 FDCAN more like CAN
+#if defined(STM32G4) || defined(STM32H5) || defined(STM32H7)
+// Make G4/H5/H7 FDCAN more like CAN
 #define CAN1 FDCAN1
 #define CAN2 FDCAN2
 #define GPIO_AF9_CAN1 GPIO_AF9_FDCAN1

--- a/ports/stm32/pyb_can.c
+++ b/ports/stm32/pyb_can.c
@@ -54,13 +54,23 @@
 #if defined(STM32G4)
 // assuming 24MHz clock
 #define CAN_DEFAULT_PRESCALER       (16)
+#define CAN_DEFAULT_BS1             (8)
+#define CAN_DEFAULT_BS2             (3)
+#elif defined(STM32H5)
+// FDCAN kernel clock is HSE (see can_get_source_freq()). HSE_VALUE is a
+// whole number of MHz on every in-tree H5 board, so a prescaler of
+// HSE_VALUE/1000000 with 8 time quanta divides out to exactly 125Kbps
+// at a 75% sample point regardless of crystal frequency.
+#define CAN_DEFAULT_PRESCALER       (HSE_VALUE / 1000000)
+#define CAN_DEFAULT_BS1             (5)
+#define CAN_DEFAULT_BS2             (2)
 #else
 // assuming 48MHz clock
 #define CAN_DEFAULT_PRESCALER       (32)
-#endif
-#define CAN_DEFAULT_SJW             (1)
 #define CAN_DEFAULT_BS1             (8)
 #define CAN_DEFAULT_BS2             (3)
+#endif
+#define CAN_DEFAULT_SJW             (1)
 
 #define CAN_MAXIMUM_NBRP            (512)
 #define CAN_MAXIMUM_NBS1            (256)

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -39,9 +39,9 @@
 // as well as a fallback to generate MICROPY_GIT_TAG if the git repo or tags
 // are unavailable.
 #define MICROPY_VERSION_MAJOR 1
-#define MICROPY_VERSION_MINOR 29
+#define MICROPY_VERSION_MINOR 30
 #define MICROPY_VERSION_MICRO 0
-#define MICROPY_VERSION_PRERELEASE 0
+#define MICROPY_VERSION_PRERELEASE 1
 
 // Combined version as a 32-bit number for convenience to allow version
 // comparison. Doesn't include prerelease state.

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -123,6 +123,7 @@ function ci_code_size_build {
             OUTFILE=$2
             IGNORE_ERRORS=$3
 
+            git restore ports/esp32/lockfiles/*  # esp32 port may update local lockfile
             git checkout --detach $COMMIT
             git submodule update --init $SUBMODULES
             git show -s


### PR DESCRIPTION

# stm32: Enable FDCAN on STM32H5.

### Summary

The STM32H5 has FDCAN hardware and no bxCAN, but the stm32 port builds neither for it. `MICROPY_HW_ENABLE_FDCAN` is defined only for G0, G4, H7 and N6, so `fdcan.c` compiles out and the port falls back to bxCAN paths the silicon does not have. Separately the Makefile selects the CAN HAL for `f0 f4 f7`, `g0 g4 h7 n6` and `l4` but not `h5`, so no CAN HAL is compiled at all; that one fails at link with nothing in the error naming the cause. The result is that CAN is simply unavailable on every H5 board.

H5 rides the existing G4 code path, so most of this is extending guards rather than new logic: the H5 FDCAN IP matches G4 closely enough that the Init struct field set, the Rx FIFO addressing and the port's own `AddMessageToTxBuffer`/`EnableTxBufferRequest` shims all apply unchanged. `can_get_source_freq()` returns `HSE_VALUE` because `RCC_CCIPR5.FDCANSEL` resets to `00 = hse_ck` and nothing in the tree writes it for H5, and `pyb.CAN`'s legacy default timings get an H5 branch computing the prescaler from `HSE_VALUE` so the documented 125 kbit/s default holds on both in-tree H5 boards rather than only the 8 MHz one.

One thing is genuinely not shared with G4. The H5 HAL takes `FDCAN_TxHeaderTypeDef.DataLength` as a raw DLC index and shifts it internally, matching N6, whereas the port's own TX buffer shim wants it pre-shifted like G4. Since `pyb.CAN` reaches the HAL and `machine.CAN` reaches the shim, the two transmit paths on H5 need opposite conventions, so `encode_datalength()` takes the convention as an argument and each call site passes what its destination expects.

The board profile change is included because without a board defining `MICROPY_HW_CAN*_TX`, `MICROPY_HW_ENABLE_CAN` stays 0 and none of this is reachable or testable upstream.

### Testing

On a NUCLEO-H563ZI, `machine.CAN` on both FDCAN1 and FDCAN2 in loopback at 500 kbit/s and 125 kbit/s, round-tripping frames with 0, 1 and 8 byte payloads. The payload lengths matter here: they are what fails under the wrong DLC convention. Register reads confirm the peripheral is configured as expected, with `CCIPR5 = 0x0` (HSE), `NBTP = 0xa03` and `TXBTO` set after transmit.

No transceiver is fitted, so nothing has been on a real bus, `tests/multi_extmod/machine_can_01..08` has not been run, and no bit timing has been measured on a scope. The `pyb.CAN` path is untested on hardware, which is worth flagging since it is the path the DLC commit changes.

### Trade-offs and Alternatives

Reading the DLC convention from the destination rather than the MCU macro is slightly more indirect than the `#if defined(STM32N6)` split it replaces. The direct alternative, moving H5 onto the N6 branch, fixes `pyb.CAN` and breaks `machine.CAN`, because the split was never really about the MCU: it is about which of the two write paths the frame takes.

Leaving FDCAN2 enabled in the board profile is a judgement call. The pins are unused elsewhere in that board file and are AF9 per `boards/stm32h573_af.csv`, but I have not confirmed the board-level bridge configuration, so the comment says to check the user manual before wiring.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the description above.

### Outstanding before this goes upstream

- DONE 2026-08-28: pushed to https://github.com/andrewleech/micropython/tree/feature/stm32-h5-fdcan. A `fork` remote points at the personal fork and `upstream` at micropython/micropython; the submodule's `origin` and `.gitmodules` now point at the fork so the integration pointer resolves on clone.
- Run tests/multi_extmod/machine_can_01..08 against a second CAN node. Needs two transceivers, which are on order. This is the evidence a maintainer will want and the branch should not be proposed without it.
- Verify bit timing on a scope or logic analyser at 125k, 500k and 1M. The kernel clock is HSE by reset default and can_get_source_freq() now returns HSE_VALUE, but nothing has measured the wire rate.
- Confirm the pyb.CAN path on hardware. Only machine.CAN has been exercised, and the two paths use opposite DLC conventions, so pyb.CAN is the one the DLC commit actually changes.
- Check the NUCLEO-H563ZI user manual for solder bridge and jumper configuration of PB13/PB12 and fold the answer into the board comment. Currently the comment says to check, which is honest but weak.

---
*Draft raised on the fork for review. Base is the fork's own branch, not upstream.*
