### PR TITLE
stm32/machine_can: Deliver received frames in arrival order.

### DIFF
--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -20,7 +20,7 @@ concurrency:
 env:
    # Oldest and newest supported ESP-IDF versions, should match ports/esp32/README.md
    IDF_OLDEST_VER: &oldest "v5.3"
-   IDF_NEWEST_VER: &newest "v5.5.2"
+   IDF_NEWEST_VER: &newest "v5.5.5"
 
 jobs:
   build_idf:

--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -52,8 +52,8 @@ manage the ESP32 microcontroller, as well as a way to manage the required
 build environment and toolchains needed to build the firmware.
 
 The ESP-IDF changes quickly and MicroPython only supports certain versions. The
-current recommended version of ESP-IDF for MicroPython is v5.5.2. MicroPython
-also supports v5.3, v5.4, v5.4.1, v5.4.2, v5.5.1 and v5.5.4.
+current recommended version of ESP-IDF for MicroPython is v5.5.5. MicroPython
+also supports v5.3, v5.4, v5.4.1, v5.4.2, v5.5.1, v5.5.2 and v5.5.4.
 
 <!-- Important: If updating the above, please also update:
      * IDF_OLDEST_VER & IDF_NEWEST_VER in .github/workflows/port_esp32.yml

--- a/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
@@ -13,6 +13,9 @@
 
 #define MICROPY_PY_MACHINE_SDCARD           (1)
 #define MICROPY_HW_SDMMC_LDO_CHAN_ID        (4)
+// This board wires the SD/MMC card to SDMMC slot 0 with a full 4-bit bus.
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (0)
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (4)
 
 #ifndef USB_SERIAL_JTAG_PACKET_SZ_BYTES
 #define USB_SERIAL_JTAG_PACKET_SZ_BYTES (64)

--- a/ports/esp32/lockfiles/dependencies.lock.esp32
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32
@@ -25,7 +25,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/lan867x
 - espressif/mdns

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c2
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c3
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c5
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c5
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c6
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c6
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32h2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32h2
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32p4
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32p4
@@ -81,7 +81,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/esp_hosted
 - espressif/esp_wifi_remote

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s2
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s3
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/ports/esp32/machine_sdcard.h
+++ b/ports/esp32/machine_sdcard.h
@@ -26,6 +26,17 @@
 #ifndef MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
 #define MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
 
+// Default slot and bus width for a native SD/MMC machine.SDCard(). These are
+// conservative defaults (the historically usable slot 1, 1-bit); which slot is
+// wired and how many data lines are routed is board specific, so a board should
+// override these in its mpconfigboard.h to match its layout.
+#ifndef MICROPY_HW_SDMMC_DEFAULT_SLOT
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
+#endif
+#ifndef MICROPY_HW_SDMMC_DEFAULT_WIDTH
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (1)
+#endif
+
 // Default pins for the primary SPI-mode SD card bus (slot 2). SPI mode is
 // available on every ESP32 variant, so a board may override these in its
 // mpconfigboard.h to make machine.SDCard(slot=2) work without explicit pins.

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -150,8 +150,11 @@ soft_reset:
     machine_i2s_init0();
     #endif
 
-    // run boot-up scripts
-    pyexec_frozen_module("_boot.py", false);
+    // Run optional frozen boot code.
+    #ifdef MICROPY_BOARD_FROZEN_BOOT_FILE
+    pyexec_frozen_module(MICROPY_BOARD_FROZEN_BOOT_FILE, false);
+    #endif
+
     int ret = pyexec_file_if_exists("boot.py");
 
     #if MICROPY_HW_ENABLE_USBDEV

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -326,9 +326,7 @@ static mp_obj_t machine_wake_pins(void) {
 
     // Only a few (~8) pins might cause wakeup.
     // Therefore, we calculate the required space in a first pass.
-    for (index = 0, len = 0; index < 64; index++) {
-        len += (status & (1ULL << index)) ? 1 : 0;
-    }
+    len = mp_popcount(status >> 32) + mp_popcount(status & 0xFFFFFFFF);
     if (len) {
         mp_obj_tuple_t *tuple = MP_OBJ_TO_PTR(mp_obj_new_tuple(len, NULL));
 

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -224,20 +224,6 @@
 #ifndef MICROPY_HW_ENABLE_SDCARD
 #define MICROPY_HW_ENABLE_SDCARD            (1)
 #endif
-#ifndef MICROPY_HW_SDMMC_DEFAULT_SLOT
-#if CONFIG_IDF_TARGET_ESP32P4
-#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (0)
-#else
-#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
-#endif
-#endif
-#ifndef MICROPY_HW_SDMMC_DEFAULT_WIDTH
-#if CONFIG_IDF_TARGET_ESP32P4
-#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (4)
-#else
-#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (1)
-#endif
-#endif
 #define MICROPY_HW_SOFTSPI_MIN_DELAY        (0)
 #define MICROPY_HW_SOFTSPI_MAX_BAUDRATE     (esp_rom_get_cpu_ticks_per_us() * 1000000 / 200) // roughly
 #define MICROPY_PY_SSL                      (MICROPY_PY_NETWORK)

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -425,6 +425,10 @@ typedef long mp_off_t;
 #define MICROPY_BOARD_STARTUP boardctrl_startup
 #endif
 
+#ifndef MICROPY_BOARD_FROZEN_BOOT_FILE
+#define MICROPY_BOARD_FROZEN_BOOT_FILE "_boot.py"
+#endif
+
 void boardctrl_startup(void);
 
 #ifndef MICROPY_PY_NETWORK_LAN

--- a/ports/stm32/fdcan.c
+++ b/ports/stm32/fdcan.c
@@ -192,9 +192,15 @@ bool can_init(CAN_HandleTypeDef *can, int can_id, can_tx_mode_t tx_mode, uint32_
     // The total number of words reserved for the Rx FIFOs per FDCAN instance is 864 words.
     init->RxBuffersNbr = 0;
     init->RxBufferSize = FDCAN_DATA_BYTES_64;
-    init->RxFifo0ElmtsNbr = 24;
+    // Every filter targets FIFO0 (machine_can_port_set_filter(), below), to
+    // keep received frames in arrival order rather than split across two
+    // FIFOs that drain independently. FIFO1 therefore never receives
+    // anything on this MCU family, where the split is a configurable message
+    // RAM partition rather than a hardware-fixed one, so its share is given
+    // to FIFO0 instead of sitting reserved and unreachable.
+    init->RxFifo0ElmtsNbr = 48;
     init->RxFifo0ElmtSize = FDCAN_DATA_BYTES_64;
-    init->RxFifo1ElmtsNbr = 24;
+    init->RxFifo1ElmtsNbr = 0;
     init->RxFifo1ElmtSize = FDCAN_DATA_BYTES_64;
     #endif // STM32H7 || STM32N6
 

--- a/ports/stm32/machine_can.c
+++ b/ports/stm32/machine_can.c
@@ -278,8 +278,10 @@ static void machine_can_port_set_filter(machine_can_obj_t *self, int filter_idx,
         // already accounted for in filter_idx due to CAN_FILTERS_STD_EXT_SEPARATE.
         .FilterIndex = filter_idx,
         .FilterType = FDCAN_FILTER_MASK,
-        // Round-robin between FIFO1 and FIFO0
-        .FilterConfig = (filter_idx & 1) ? FDCAN_FILTER_TO_RXFIFO1 : FDCAN_FILTER_TO_RXFIFO0,
+        // Every filter targets FIFO0. recv() empties FIFO0 before it looks
+        // at FIFO1, so filters spread across both FIFOs would deliver frames
+        // grouped by which FIFO matched rather than in arrival order.
+        .FilterConfig = FDCAN_FILTER_TO_RXFIFO0,
         .FilterID1 = can_id,
         .FilterID2 = mask,
     };
@@ -306,9 +308,11 @@ static void machine_can_port_set_filter(machine_can_obj_t *self, int filter_idx,
         .FilterScale = CAN_FILTERSCALE_32BIT,
         .FilterMode = CAN_FILTERMODE_IDMASK,
         .FilterNumber = filter_idx,
-        // Apply the filters round-robin to each FIFO, as each filter in bxCAN is
-        // associated with only one FIFO.
-        .FilterFIFOAssignment = filter_idx % 2,
+        // Every filter targets FIFO0, matching the FDCAN branch above: bxCAN's
+        // recv() also empties FIFO0 before FIFO1, so filters split across both
+        // would deliver frames grouped by which FIFO matched rather than in
+        // arrival order.
+        .FilterFIFOAssignment = 0,
         .BankNumber = CAN_HW_MAX_FILTER, // Assign same number of filters to CAN2 as CAN1
     };
 

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -39,9 +39,9 @@
 // as well as a fallback to generate MICROPY_GIT_TAG if the git repo or tags
 // are unavailable.
 #define MICROPY_VERSION_MAJOR 1
-#define MICROPY_VERSION_MINOR 29
+#define MICROPY_VERSION_MINOR 30
 #define MICROPY_VERSION_MICRO 0
-#define MICROPY_VERSION_PRERELEASE 0
+#define MICROPY_VERSION_PRERELEASE 1
 
 // Combined version as a 32-bit number for convenience to allow version
 // comparison. Doesn't include prerelease state.

--- a/tests/multi_extmod/machine_can_09_rx_order.py
+++ b/tests/multi_extmod/machine_can_09_rx_order.py
@@ -1,0 +1,68 @@
+from machine import CAN
+import time
+
+# Regression test for arrival-order delivery. Standard and extended id
+# frames are received in hardware through independent FIFOs; a receiver
+# that drains one FIFO to empty before looking at the other reorders
+# frames whenever both id widths are on the bus at once. Filter
+# configuration must route both id widths to the same FIFO for order to
+# hold under load.
+#
+# Sent back to back with no inter-frame delay, unlike
+# machine_can_03_rx_filters.py's 5ms gap: that gap gives each frame time
+# to be drained before the next arrives, which cannot catch this class of
+# bug regardless of filter configuration, since only one frame is ever in
+# flight at a time.
+
+can = CAN(1, 500_000)
+
+# Interleaved std/ext ids, arrival order is exactly this list, and correct
+# reception means the receiver reports them back in this order.
+MESSAGES = [
+    (0x101, 0),
+    (0x1FFFFF01, CAN.FLAG_EXT_ID),
+    (0x102, 0),
+    (0x1FFFFF02, CAN.FLAG_EXT_ID),
+    (0x103, 0),
+    (0x1FFFFF03, CAN.FLAG_EXT_ID),
+    (0x104, 0),
+    (0x105, 0),
+    (0x1FFFFF04, CAN.FLAG_EXT_ID),
+    (0x1FFFFF05, CAN.FLAG_EXT_ID),
+]
+
+
+def instance0():
+    can.set_filters([(0, 0, 0), (0, 0, CAN.FLAG_EXT_ID)])
+    multitest.next()
+    multitest.wait("sent")
+
+    # Drain everything the sender put on the bus and report it in the order
+    # it was received. A correct implementation reproduces MESSAGES exactly;
+    # a FIFO-grouping bug reports every standard id first, then every
+    # extended id, regardless of the order they were sent in.
+    received = []
+    deadline = time.ticks_add(time.ticks_ms(), 1000)
+    while len(received) < len(MESSAGES) and time.ticks_diff(deadline, time.ticks_ms()) > 0:
+        r = can.recv()
+        if r is not None:
+            can_id, _data, flags, _errors = r
+            received.append((can_id, flags & CAN.FLAG_EXT_ID))
+
+    for can_id, is_ext in received:
+        print("recv", hex(can_id), "ext" if is_ext else "std")
+    print("count", len(received))
+    print("in order", received == MESSAGES)
+
+
+def instance1():
+    multitest.next()
+
+    for can_id, flags in MESSAGES:
+        r = can.send(can_id, b"", flags)
+        if r is None:
+            print("Failed to send:", hex(can_id))
+        # Deliberately no sleep: the point of this test is frames still in
+        # flight together, which is what a 5ms-apart send cannot produce.
+
+    multitest.broadcast("sent")

--- a/tests/multi_extmod/machine_can_09_rx_order.py.exp
+++ b/tests/multi_extmod/machine_can_09_rx_order.py.exp
@@ -1,0 +1,14 @@
+--- instance0 ---
+recv 0x101 std
+recv 0x1fffff01 ext
+recv 0x102 std
+recv 0x1fffff02 ext
+recv 0x103 std
+recv 0x1fffff03 ext
+recv 0x104 std
+recv 0x105 std
+recv 0x1fffff04 ext
+recv 0x1fffff05 ext
+count 10
+in order True
+--- instance1 ---

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -123,6 +123,7 @@ function ci_code_size_build {
             OUTFILE=$2
             IGNORE_ERRORS=$3
 
+            git restore ports/esp32/lockfiles/*  # esp32 port may update local lockfile
             git checkout --detach $COMMIT
             git submodule update --init $SUBMODULES
             git show -s


### PR DESCRIPTION

# stm32/machine_can: deliver received frames in arrival order

## What I found

Frames arrive at the consumer grouped by identifier width rather than in the
order they were received. On a real two-node bus, sending

    101(std)  1FFFFF01(ext)  102(std)  1FFFFF02(ext)  103(std)  1FFFFF03(ext)

back to back produced, every time:

    101  102  103  1FFFFF01  1FFFFF02  1FFFFF03

Both standard frames ahead of both extended ones, consistently, regardless of
arrival order.

It is invisible under light traffic. With 50 ms between frames each is drained
before the next arrives and order is preserved, which is why loopback testing
never showed it. It needs two frames in the two FIFOs at once.

## Why it happens

Two things combine. `set_filters(None)` installs the accept-all pair as filter 0
for standard identifiers and filter 1 for extended. The port then assigns
filters to hardware receive FIFOs by the parity of the filter index:

    // Round-robin between FIFO1 and FIFO0
    .FilterConfig = (filter_idx & 1) ? FDCAN_FILTER_TO_RXFIFO1 : FDCAN_FILTER_TO_RXFIFO0,

while `machine_can_port_recv()` empties FIFO0 before it looks at FIFO1:

    for (can_rx_fifo_t fifo = CAN_RX_FIFO0; fifo <= CAN_RX_FIFO1; fifo++) {

So a frame matching an even-indexed filter always overtakes one matching an
odd-indexed filter, whenever both are queued. Because `set_filters(None)` yields
exactly one filter of each width, the **default** configuration reorders any bus
carrying both.

It is not limited to mixed widths: the same parity rule splits any filter set of
three or more across both FIFOs.

## Why it matters

Frame order is load-bearing for anything layered on CAN. ISO-TP and CANopen
segmented SDO transfers both reassemble by arrival order, and reordering
corrupts a reassembled message silently rather than raising an error. That is a
bad failure mode: the transport reports success and the payload is wrong.

## The change

Point every filter at one FIFO. The spreading it replaces offered no ordering
guarantee to trade away, and a consumer needing more depth than one FIFO holds
is better served by a software buffer than by one that reorders.

The alternative, keeping both FIFOs and merging by the receive timestamp the
FDCAN element already carries, preserves the extra hardware depth but adds a
comparison and a second FIFO probe to every receive. That seemed the wrong trade
for a hot path, but I would happily take direction on it.

## Testing

STM32H5 (NUCLEO-H563ZI), FDCAN backend, on a real two-node 500 kbit bus against
a second gs_usb adapter. The interleaved burst above now arrives interleaved
across repeated runs, where before the fix it was grouped by width every time.
Standard-only and extended-only traffic are unaffected, and a 500-frame
single-width run remains lossless.

Not tested on the classic bxCAN backend, which has separate FIFO handling; see
the todo above.

### Outstanding before this goes upstream

- Tested on STM32H5 (FDCAN) only. The classic bxCAN path (ports/stm32/can.c) has its own FIFO handling and was not examined; check whether it has the equivalent problem before claiming the fix is port-wide.

---
*Draft raised on the fork for review. Base is the fork's own branch, not upstream.*
