### PR TITLE
stm32/machine_can: Add software receive ring via CAN.init(rxbuf=N).

### DIFF
--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -20,7 +20,7 @@ concurrency:
 env:
    # Oldest and newest supported ESP-IDF versions, should match ports/esp32/README.md
    IDF_OLDEST_VER: &oldest "v5.3"
-   IDF_NEWEST_VER: &newest "v5.5.2"
+   IDF_NEWEST_VER: &newest "v5.5.5"
 
 jobs:
   build_idf:

--- a/docs/library/machine.CAN.rst
+++ b/docs/library/machine.CAN.rst
@@ -37,9 +37,9 @@ Constructor
    - All other arguments are passed to :func:`CAN.init`. At least one argument (``bitrate``)
      must be provided.
 
-   Future versions of this class may also accept port-specific keyword arguments
-   here which configure the hardware. Currently no such keyword arguments are
-   implemented.
+   Some ports accept additional, port-specific keyword arguments here which
+   configure the hardware. See `can-port-kwargs` for the keyword arguments
+   supported by each port.
 
    Example
    ^^^^^^^
@@ -49,14 +49,42 @@ Constructor
       from machine import CAN
       can = CAN(1, 500_000)
 
-.. Add a table of port-specific keyword arguments here, once they exist
+.. _can-port-kwargs:
+
+Port-specific keyword arguments
+--------------------------------
+
+- **STM32** accepts ``rxbuf``, an integer giving the depth, in frames, of a
+  software receive ring. The default, ``0``, disables the ring: `CAN.recv`
+  reads directly from the hardware receive FIFO, which holds 3 frames per FIFO
+  on parts with a fixed message RAM layout (H5, G0, G4) and on classic bxCAN
+  parts, or 24 frames per FIFO on H7 and N6. A non-zero value has the receive
+  interrupt handler move frames out of the hardware FIFO into the ring as they
+  arrive, which lets the driver keep up with bus frame rates that would
+  otherwise overrun the hardware FIFO between calls to `CAN.recv`.
+
+  A frame that arrives once the ring is full is left in the hardware FIFO,
+  with that FIFO's receive interrupt masked until `CAN.recv` next pops an
+  entry from the ring and makes room. If the hardware FIFO then also fills,
+  the frame is dropped and counted the same way as any other hardware FIFO
+  overflow, via `CAN.get_counters` and the ``errors`` value returned by
+  `CAN.recv`.
+
+  .. note:: A `CAN.irq` handler configured for `CAN.IRQ_RX` is called once
+     when the ring transitions from empty to non-empty, not once per frame
+     added to the ring. The handler must call `CAN.recv` repeatedly until it
+     returns ``None`` to fully drain the ring: a handler that calls
+     `CAN.recv` only once per invocation leaves the ring non-empty, and no
+     further `CAN.IRQ_RX` callback is scheduled while it stays non-empty,
+     stalling reception once the ring fills.
 
 Methods
 -------
 
 .. method:: CAN.init(bitrate, mode=CAN.MODE_NORMAL, sample_point=75, sjw=1, tseg1=None, tseg2=None)
 
-   Initialise the CAN bus with the given parameters:
+   Initialise the CAN bus with the given parameters. Also accepts the
+   port-specific keyword arguments described under `can-port-kwargs`.
 
    - *bitrate* is the desired bus bit rate in bits per second.
    - *mode* is one of the values shown under `can-modes`, indicating the
@@ -379,6 +407,11 @@ Methods
 
   .. note:: The **Alif** port cannot report the exact number of pending RX or TX messages. It
             will report a number > 0, if messages are pending.
+
+  .. note:: On **STM32**, if the ``rxbuf`` keyword argument was used to configure a
+            software receive ring, the pending RX count includes frames already
+            moved into that ring as well as frames still queued in the hardware
+            FIFOs.
 
 .. method:: CAN.get_timings(list=None /)
 

--- a/extmod/machine_can.c
+++ b/extmod/machine_can.c
@@ -222,7 +222,11 @@ static mp_obj_t machine_can_deinit(mp_obj_t self_in) {
 static MP_DEFINE_CONST_FUN_OBJ_1(machine_can_deinit_obj, machine_can_deinit);
 
 static void machine_can_init_helper(machine_can_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_bitrate, ARG_mode, ARG_sample_point, ARG_sjw, ARG_tseg1, ARG_tseg2};
+    enum { ARG_bitrate, ARG_mode, ARG_sample_point, ARG_sjw, ARG_tseg1, ARG_tseg2,
+           #if MICROPY_PY_MACHINE_CAN_RXBUF
+           ARG_rxbuf,
+           #endif
+    };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_bitrate, MP_ARG_INT | MP_ARG_REQUIRED },
         { MP_QSTR_mode, MP_ARG_INT, {.u_int = MP_CAN_MODE_NORMAL} },
@@ -230,6 +234,9 @@ static void machine_can_init_helper(machine_can_obj_t *self, size_t n_args, cons
         { MP_QSTR_sjw, MP_ARG_INT, {.u_int = CAN_SJW_MIN } },
         { MP_QSTR_tseg1, MP_ARG_INT, {.u_int = -1} },
         { MP_QSTR_tseg2, MP_ARG_INT, {.u_int = -1} },
+        #if MICROPY_PY_MACHINE_CAN_RXBUF
+        { MP_QSTR_rxbuf, MP_ARG_INT, {.u_int = 0} },
+        #endif
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -265,6 +272,14 @@ static void machine_can_init_helper(machine_can_obj_t *self, size_t n_args, cons
         // Probably can make these values more restrictive
         mp_raise_ValueError(MP_ERROR_TEXT("sample_point"));
     }
+
+    #if MICROPY_PY_MACHINE_CAN_RXBUF
+    mp_int_t rxbuf = args[ARG_rxbuf].u_int;
+    if (rxbuf < 0) {
+        mp_raise_ValueError(MP_ERROR_TEXT("rxbuf"));
+    }
+    self->rxbuf_len = (mp_uint_t)rxbuf;
+    #endif
 
     int f_clock = machine_can_port_f_clock(self);
 

--- a/extmod/machine_can_port.h
+++ b/extmod/machine_can_port.h
@@ -31,6 +31,13 @@
 #include "py/runtime.h"
 #include "shared/runtime/mpirq.h"
 
+#ifndef MICROPY_PY_MACHINE_CAN_RXBUF
+// Set by a port's mpconfigport.h if it supports CAN.init(rxbuf=N), a software
+// receive ring. Given a default here, ahead of machine_can_obj_t below, so
+// that ports without their own definition do not carry the rxbuf_len field.
+#define MICROPY_PY_MACHINE_CAN_RXBUF 0
+#endif
+
 // This header is included into both extmod/machine_can.c and port-specific
 // machine_can.c implementations and provides shared (static) function
 // declarations to both.
@@ -104,6 +111,12 @@ typedef struct _machine_can_obj_t {
     mp_irq_obj_t *mp_irq_obj;
     uint16_t mp_irq_trigger;
     mp_uint_t rx_error_flags;
+
+    #if MICROPY_PY_MACHINE_CAN_RXBUF
+    // Requested depth of the port's software receive ring, in frames, set via
+    // CAN.init(rxbuf=N). 0 (the default) disables the ring.
+    mp_uint_t rxbuf_len;
+    #endif
 
     // Assumed some of these counters are updated from different port ISRs, etc. and some
     // are updated by calling machine_can_port_update_counters()

--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -52,8 +52,8 @@ manage the ESP32 microcontroller, as well as a way to manage the required
 build environment and toolchains needed to build the firmware.
 
 The ESP-IDF changes quickly and MicroPython only supports certain versions. The
-current recommended version of ESP-IDF for MicroPython is v5.5.2. MicroPython
-also supports v5.3, v5.4, v5.4.1, v5.4.2, v5.5.1 and v5.5.4.
+current recommended version of ESP-IDF for MicroPython is v5.5.5. MicroPython
+also supports v5.3, v5.4, v5.4.1, v5.4.2, v5.5.1, v5.5.2 and v5.5.4.
 
 <!-- Important: If updating the above, please also update:
      * IDF_OLDEST_VER & IDF_NEWEST_VER in .github/workflows/port_esp32.yml

--- a/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
@@ -13,6 +13,9 @@
 
 #define MICROPY_PY_MACHINE_SDCARD           (1)
 #define MICROPY_HW_SDMMC_LDO_CHAN_ID        (4)
+// This board wires the SD/MMC card to SDMMC slot 0 with a full 4-bit bus.
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (0)
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (4)
 
 #ifndef USB_SERIAL_JTAG_PACKET_SZ_BYTES
 #define USB_SERIAL_JTAG_PACKET_SZ_BYTES (64)

--- a/ports/esp32/lockfiles/dependencies.lock.esp32
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32
@@ -25,7 +25,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/lan867x
 - espressif/mdns

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c2
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c3
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c5
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c5
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c6
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c6
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32h2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32h2
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32p4
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32p4
@@ -81,7 +81,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/esp_hosted
 - espressif/esp_wifi_remote

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s2
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s3
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/ports/esp32/machine_sdcard.h
+++ b/ports/esp32/machine_sdcard.h
@@ -26,6 +26,17 @@
 #ifndef MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
 #define MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
 
+// Default slot and bus width for a native SD/MMC machine.SDCard(). These are
+// conservative defaults (the historically usable slot 1, 1-bit); which slot is
+// wired and how many data lines are routed is board specific, so a board should
+// override these in its mpconfigboard.h to match its layout.
+#ifndef MICROPY_HW_SDMMC_DEFAULT_SLOT
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
+#endif
+#ifndef MICROPY_HW_SDMMC_DEFAULT_WIDTH
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (1)
+#endif
+
 // Default pins for the primary SPI-mode SD card bus (slot 2). SPI mode is
 // available on every ESP32 variant, so a board may override these in its
 // mpconfigboard.h to make machine.SDCard(slot=2) work without explicit pins.

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -150,8 +150,11 @@ soft_reset:
     machine_i2s_init0();
     #endif
 
-    // run boot-up scripts
-    pyexec_frozen_module("_boot.py", false);
+    // Run optional frozen boot code.
+    #ifdef MICROPY_BOARD_FROZEN_BOOT_FILE
+    pyexec_frozen_module(MICROPY_BOARD_FROZEN_BOOT_FILE, false);
+    #endif
+
     int ret = pyexec_file_if_exists("boot.py");
 
     #if MICROPY_HW_ENABLE_USBDEV

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -326,9 +326,7 @@ static mp_obj_t machine_wake_pins(void) {
 
     // Only a few (~8) pins might cause wakeup.
     // Therefore, we calculate the required space in a first pass.
-    for (index = 0, len = 0; index < 64; index++) {
-        len += (status & (1ULL << index)) ? 1 : 0;
-    }
+    len = mp_popcount(status >> 32) + mp_popcount(status & 0xFFFFFFFF);
     if (len) {
         mp_obj_tuple_t *tuple = MP_OBJ_TO_PTR(mp_obj_new_tuple(len, NULL));
 

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -224,20 +224,6 @@
 #ifndef MICROPY_HW_ENABLE_SDCARD
 #define MICROPY_HW_ENABLE_SDCARD            (1)
 #endif
-#ifndef MICROPY_HW_SDMMC_DEFAULT_SLOT
-#if CONFIG_IDF_TARGET_ESP32P4
-#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (0)
-#else
-#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
-#endif
-#endif
-#ifndef MICROPY_HW_SDMMC_DEFAULT_WIDTH
-#if CONFIG_IDF_TARGET_ESP32P4
-#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (4)
-#else
-#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (1)
-#endif
-#endif
 #define MICROPY_HW_SOFTSPI_MIN_DELAY        (0)
 #define MICROPY_HW_SOFTSPI_MAX_BAUDRATE     (esp_rom_get_cpu_ticks_per_us() * 1000000 / 200) // roughly
 #define MICROPY_PY_SSL                      (MICROPY_PY_NETWORK)

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -425,6 +425,10 @@ typedef long mp_off_t;
 #define MICROPY_BOARD_STARTUP boardctrl_startup
 #endif
 
+#ifndef MICROPY_BOARD_FROZEN_BOOT_FILE
+#define MICROPY_BOARD_FROZEN_BOOT_FILE "_boot.py"
+#endif
+
 void boardctrl_startup(void);
 
 #ifndef MICROPY_PY_NETWORK_LAN

--- a/ports/stm32/machine_can.c
+++ b/ports/stm32/machine_can.c
@@ -29,6 +29,7 @@
 #include <stdbool.h>
 #include "extmod/machine_can_port.h"
 #include "can.h"
+#include "irq.h"
 #include "py/runtime.h"
 #include "py/mperrno.h"
 #include "py/mphal.h"
@@ -49,11 +50,45 @@
 
 #define TX_EMPTY UINT32_MAX
 
+// A single frame buffered in the software receive ring (struct machine_can_port
+// below). Fixed size so the ring can be indexed arithmetically and the receive
+// interrupt handler never allocates. flags and len are narrower than the
+// mp_uint_t/size_t types used elsewhere for the same values, since a CAN_MSG_FLAG_*
+// combination fits in a handful of bits and a frame is at most MP_CAN_MAX_LEN
+// bytes: 8 on classic bxCAN, 64 with FDCAN. On an FDCAN build a ring entry is
+// 72 bytes, so a large rxbuf is a correspondingly sized one-off allocation at
+// CAN.init() time (rxbuf=256 is 18 KB); on classic bxCAN it is 16 bytes per
+// entry, 4 KB at the same rxbuf.
+typedef struct _can_rx_ring_entry_t {
+    mp_uint_t id;
+    uint16_t flags;
+    uint8_t len;
+    uint8_t data[MP_CAN_MAX_LEN];
+} can_rx_ring_entry_t;
+
 struct machine_can_port {
     CAN_HandleTypeDef h;
     uint32_t tx[CAN_TX_QUEUE_LEN];  // ID stored in each hardware tx buffer, or TX_EMPTY if empty
     bool irq_state_pending;
     bool error_passive;
+
+    // Software receive ring, allocated once by machine_can_port_init() when
+    // self->rxbuf_len is non-zero, and freed by machine_can_port_deinit().
+    // NULL and zero length when rxbuf is 0 (the default), in which case
+    // recv() reads directly from the hardware FIFO.
+    //
+    // head and tail are each written from more than one context:
+    // machine_can_irq_handler() advances head from the ISR, and
+    // machine_can_port_recv() both advances tail and, via can_rx_ring_fill(),
+    // advances head, from ordinary (non-ISR) context with the CAN interrupt
+    // masked for the duration (see IRQ_PRI_CAN in machine_can_port_recv()
+    // and machine_can_port_restart()). machine_can_port_update_counters() and
+    // machine_can_port_irq_flags() only read the pair to report an
+    // approximate pending count and are not synchronised against the ISR.
+    can_rx_ring_entry_t *rx_ring;
+    mp_uint_t rx_ring_len;   // Ring capacity in frames, 0 if disabled
+    mp_uint_t rx_ring_head;  // Count of frames ever pushed
+    mp_uint_t rx_ring_tail;  // Count of frames ever popped
 };
 
 // Convert the port agnostic CAN mode to the ST mode
@@ -101,6 +136,18 @@ static void machine_can_port_init(machine_can_obj_t *self) {
         self->port->tx[i] = TX_EMPTY;
     }
 
+    if (self->rxbuf_len > 0) {
+        // rxbuf is only range-checked against 0 by the shared extmod layer,
+        // which has no visibility into this port's entry size; a large
+        // enough value overflows the byte-count multiply m_new expands to
+        // and silently under-allocates. Reject rather than wrap.
+        if (self->rxbuf_len > SIZE_MAX / sizeof(can_rx_ring_entry_t)) {
+            mp_raise_ValueError(MP_ERROR_TEXT("rxbuf too large"));
+        }
+        self->port->rx_ring = m_new(can_rx_ring_entry_t, self->rxbuf_len);
+        self->port->rx_ring_len = self->rxbuf_len;
+    }
+
     bool res = can_init(&self->port->h,
         self->can_idx + 1, // Convert 0-based index to 1-based 'can_id' for lower layer
         CAN_TX_QUEUE,
@@ -113,6 +160,17 @@ static void machine_can_port_init(machine_can_obj_t *self) {
 
     if (!res) {
         mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("CAN init failed"));
+    }
+
+    if (self->port->rx_ring_len > 0) {
+        // The ring is drained by the receive interrupt (can_rx_ring_fill(),
+        // called from machine_can_irq_handler()), not by can_receive()
+        // calls from Python. That interrupt is otherwise off until the user
+        // requests IRQ_RX callbacks via CAN.irq(), so without this the ring
+        // never receives anything: enable it unconditionally here.
+        for (can_rx_fifo_t fifo = CAN_RX_FIFO0; fifo <= CAN_RX_FIFO1; fifo++) {
+            can_enable_rx_interrupts(&self->port->h, fifo, true);
+        }
     }
 }
 
@@ -128,6 +186,11 @@ static void machine_can_port_cancel_all_tx(machine_can_obj_t *self) {
 static void machine_can_port_deinit(machine_can_obj_t *self) {
     machine_can_port_cancel_all_tx(self);
     can_deinit(&self->port->h);
+    if (self->port->rx_ring != NULL) {
+        m_del(can_rx_ring_entry_t, self->port->rx_ring, self->port->rx_ring_len);
+        self->port->rx_ring = NULL;
+        self->port->rx_ring_len = 0;
+    }
 }
 
 static mp_int_t machine_can_port_send(machine_can_obj_t *self, mp_uint_t id, const byte *data, size_t data_len, mp_uint_t flags) {
@@ -201,42 +264,140 @@ static bool machine_can_port_cancel_send(machine_can_obj_t *self, mp_uint_t idx)
     return can_cancel_transmit(&self->port->h, idx);
 }
 
-static bool machine_can_port_recv(machine_can_obj_t *self, void *data, size_t *dlen, mp_uint_t *id, mp_uint_t *flags, mp_uint_t *errors) {
-    CAN_HandleTypeDef *can = &self->port->h;
-    CanRxMsgTypeDef msg;
+// Decode a received frame header into the port-agnostic id/flags/len fields.
+// CanRxMsgTypeDef is different for Classic CAN vs FDCAN.
+static void can_decode_rx_msg(const CanRxMsgTypeDef *msg, mp_uint_t *id, mp_uint_t *flags, size_t *dlen) {
+    #if MICROPY_HW_ENABLE_FDCAN
+    *flags = ((msg->IdType == FDCAN_EXTENDED_ID) ? CAN_MSG_FLAG_EXT_ID : 0) |
+        ((msg->RxFrameType == FDCAN_REMOTE_FRAME) ? CAN_MSG_FLAG_RTR : 0);
+    *id = msg->Identifier;
+    *dlen = msg->DataLength; // Lower layer has converted to bytes already
+    #else
+    *flags = (msg->IDE ? CAN_MSG_FLAG_EXT_ID : 0) |
+        (msg->RTR ? CAN_MSG_FLAG_RTR : 0);
+    *id = msg->IDE ? msg->ExtId : msg->StdId;
+    // bxCAN's DLC field is 4 bits and a conforming remote node can send 9..15;
+    // the CAN spec requires those to be read back as 8 data bytes. Every
+    // caller of this function copies *dlen bytes into a fixed MP_CAN_MAX_LEN
+    // (8, without FDCAN) buffer, so an unclamped value here is a buffer
+    // overflow at every one of them.
+    *dlen = msg->DLC > 8 ? 8 : msg->DLC;
+    #endif
+}
+
+// Drain both hardware RX FIFOs into the software receive ring, stopping once a
+// FIFO is empty or the ring is full. Called from the receive interrupt handler
+// (to move frames out of the hardware FIFO before it overflows) and
+// from machine_can_port_recv() (to refill the ring after a consumer pop frees
+// space). Never allocates.
+//
+// Each iteration checks can_is_rx_pending() before calling can_receive(), so
+// can_receive() is only ever called when a frame is already known to be
+// waiting. This is required for correctness, not just an optimisation:
+// can_receive(..., timeout_ms=0) on an empty FIFO enters a wait loop that
+// calls mp_event_wait_ms(), which runs the scheduler, on ports using the
+// classic bxCAN driver (can.c); doing that from this function's ISR caller
+// would run arbitrary Python from inside a hardware interrupt. The FDCAN
+// driver (fdcan.c) does not have this problem, but the pending check avoids
+// relying on that difference between the two lower layers.
+//
+// A FIFO whose interrupt is left masked here (because the ring filled up
+// while frames were still pending) is re-armed on the next call, once
+// machine_can_port_recv() has popped an entry.
+static void can_rx_ring_fill(machine_can_obj_t *self) {
+    struct machine_can_port *port = self->port;
+    CAN_HandleTypeDef *can = &port->h;
 
     for (can_rx_fifo_t fifo = CAN_RX_FIFO0; fifo <= CAN_RX_FIFO1; fifo++) {
-        if (can_receive(can, fifo, &msg, data, 0) == 0) {
-            // CanRxMsgTypeDef is different for Classic vs FD
-            #if MICROPY_HW_ENABLE_FDCAN
-            *flags = ((msg.IdType == FDCAN_EXTENDED_ID) ? CAN_MSG_FLAG_EXT_ID : 0) |
-                ((msg.RxFrameType == FDCAN_REMOTE_FRAME) ? CAN_MSG_FLAG_RTR : 0);
-            *id = msg.Identifier;
-            *dlen = msg.DataLength; // Lower layer has converted to bytes already
-            #else
-            *flags = (msg.IDE ? CAN_MSG_FLAG_EXT_ID : 0) |
-                (msg.RTR ? CAN_MSG_FLAG_RTR : 0);
-            *id = msg.IDE ? msg.ExtId : msg.StdId;
-            *dlen = msg.DLC;
-            #endif
-
-            *errors = self->rx_error_flags;
-            self->rx_error_flags = 0;
-
-            // Re-enable any interrupts that were disabled in RX IRQ handlers
-            can_enable_rx_interrupts(can, fifo, self->mp_irq_trigger & MP_CAN_IRQ_RX);
-
-            return true;
+        while (port->rx_ring_head - port->rx_ring_tail < port->rx_ring_len
+               && can_is_rx_pending(can, fifo)) {
+            can_rx_ring_entry_t *entry = &port->rx_ring[port->rx_ring_head % port->rx_ring_len];
+            CanRxMsgTypeDef msg;
+            int res = can_receive(can, fifo, &msg, entry->data, 0);
+            assert(res == 0); // A frame is known to be pending, so this cannot time out
+            (void)res;
+            mp_uint_t flags;
+            size_t len;
+            can_decode_rx_msg(&msg, &entry->id, &flags, &len);
+            entry->flags = (uint16_t)flags;
+            entry->len = (uint8_t)len;
+            port->rx_ring_head++;
+        }
+        if (!can_is_rx_pending(can, fifo)) {
+            // Re-enable the interrupt this function itself depends on: it is
+            // only ever called with the ring active, so this is unconditional
+            // regardless of whether the user also wants IRQ_RX callbacks.
+            can_enable_rx_interrupts(can, fifo, true);
         }
     }
-    return false;
+}
+
+static bool machine_can_port_recv(machine_can_obj_t *self, void *data, size_t *dlen, mp_uint_t *id, mp_uint_t *flags, mp_uint_t *errors) {
+    struct machine_can_port *port = self->port;
+
+    if (port->rx_ring_len == 0) {
+        // No software ring requested: read directly from the hardware FIFO.
+        CAN_HandleTypeDef *can = &port->h;
+        CanRxMsgTypeDef msg;
+
+        for (can_rx_fifo_t fifo = CAN_RX_FIFO0; fifo <= CAN_RX_FIFO1; fifo++) {
+            if (can_receive(can, fifo, &msg, data, 0) == 0) {
+                can_decode_rx_msg(&msg, id, flags, dlen);
+
+                *errors = self->rx_error_flags;
+                self->rx_error_flags = 0;
+
+                // Re-enable any interrupts that were disabled in RX IRQ handlers
+                can_enable_rx_interrupts(can, fifo, self->mp_irq_trigger & MP_CAN_IRQ_RX);
+
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // machine_can_irq_handler() also advances rx_ring_head, from the CAN
+    // controller's interrupt, and can preempt this function at any point,
+    // because this function runs from ordinary (non-ISR) context. Raising
+    // the IRQ priority ceiling for the pop and the refill excludes that
+    // interrupt for the duration, so head, tail and the popped entry are
+    // each touched by one context at a time.
+    uint32_t basepri = raise_irq_pri(IRQ_PRI_CAN);
+
+    if (port->rx_ring_head == port->rx_ring_tail) {
+        restore_irq_pri(basepri);
+        return false; // Ring empty
+    }
+
+    can_rx_ring_entry_t *entry = &port->rx_ring[port->rx_ring_tail % port->rx_ring_len];
+    *id = entry->id;
+    *flags = entry->flags;
+    *dlen = entry->len;
+    memcpy(data, entry->data, entry->len);
+    port->rx_ring_tail++;
+
+    // Popping an entry frees ring space: refill from the hardware FIFOs and
+    // re-enable any receive interrupts that were masked because the ring was full.
+    can_rx_ring_fill(self);
+
+    restore_irq_pri(basepri);
+
+    *errors = self->rx_error_flags;
+    self->rx_error_flags = 0;
+
+    return true;
 }
 
 static void machine_can_update_irqs(machine_can_obj_t *self) {
     uint16_t triggers = self->mp_irq_trigger;
 
+    // The receive interrupt also drives the software ring (can_rx_ring_fill()),
+    // so it stays enabled whenever the ring is active even if the user has no
+    // IRQ_RX callback registered.
+    bool want_rx_notify = (triggers & MP_CAN_IRQ_RX) || self->port->rx_ring_len > 0;
+
     for (can_rx_fifo_t fifo = CAN_RX_FIFO0; fifo <= CAN_RX_FIFO1; fifo++) {
-        if (triggers & MP_CAN_IRQ_RX) {
+        if (want_rx_notify) {
             can_enable_rx_interrupts(&self->port->h, fifo, true);
         } else {
             can_disable_rx_interrupts(&self->port->h, fifo);
@@ -361,6 +522,12 @@ static void machine_can_port_update_counters(machine_can_obj_t *self) {
     counters->rec = hw_counters.rec;
     counters->tx_pending = hw_counters.tx_pending;
     counters->rx_pending = hw_counters.rx_fifo0_pending + hw_counters.rx_fifo1_pending;
+    if (port->rx_ring_len > 0) {
+        // Include frames already moved out of the hardware FIFOs and into the
+        // software receive ring, so rx_pending still reflects the total number
+        // of frames waiting to be read by recv().
+        counters->rx_pending += port->rx_ring_head - port->rx_ring_tail;
+    }
 
     // Other fields in 'counters' are updated from ISR directly
 }
@@ -375,6 +542,33 @@ static void machine_can_port_restart(machine_can_obj_t *self) {
     machine_can_port_cancel_all_tx(self);
     can_restart(&port->h);
     port->irq_state_pending = false;
+
+    // Masked against machine_can_irq_handler(), which also writes rx_ring_head
+    // via can_rx_ring_fill(): otherwise a frame delivered by the controller
+    // between these two writes could be counted as pending against a ring
+    // that this function is resetting to empty.
+    uint32_t basepri = raise_irq_pri(IRQ_PRI_CAN);
+    port->rx_ring_head = 0;
+    port->rx_ring_tail = 0;
+    restore_irq_pri(basepri);
+
+    if (port->rx_ring_len > 0) {
+        // A ring that filled before this restart left one or both FIFOs'
+        // receive interrupt masked (can_rx_ring_fill() only re-enables once a
+        // FIFO drains empty), and can_restart()'s Stop()/Start() does not
+        // touch IE. Emptying the ring above does not on its own re-arm
+        // anything: the next place that would have done it,
+        // can_rx_ring_fill() being called again, only runs from an interrupt
+        // or from machine_can_port_recv(), and recv() returns immediately on
+        // head == tail without reaching it. Left unarmed here, reception
+        // would stay dead until something else happens to touch IE.
+        //
+        // Unconditional true, matching can_rx_ring_fill()'s own re-arm: the
+        // ring's refill mechanism depends on this interrupt regardless of
+        // whether the user has asked for IRQ_RX callbacks.
+        can_enable_rx_interrupts(&port->h, CAN_RX_FIFO0, true);
+        can_enable_rx_interrupts(&port->h, CAN_RX_FIFO1, true);
+    }
 }
 
 static bool clear_complete_transfer(machine_can_obj_t *self, int *index, bool *is_success) {
@@ -398,9 +592,17 @@ static mp_uint_t machine_can_port_irq_flags(machine_can_obj_t *self) {
 
     // Check for RX
     if (self->mp_irq_trigger & MP_CAN_IRQ_RX) {
-        for (can_rx_fifo_t fifo = CAN_RX_FIFO0; fifo <= CAN_RX_FIFO1; fifo++) {
-            if (can_is_rx_pending(can, fifo)) {
+        if (self->port->rx_ring_len > 0) {
+            // Frames already moved into the software ring no longer show up as
+            // pending in the hardware FIFOs, so check the ring instead.
+            if (self->port->rx_ring_head != self->port->rx_ring_tail) {
                 flags |= MP_CAN_IRQ_RX;
+            }
+        } else {
+            for (can_rx_fifo_t fifo = CAN_RX_FIFO0; fifo <= CAN_RX_FIFO1; fifo++) {
+                if (can_is_rx_pending(can, fifo)) {
+                    flags |= MP_CAN_IRQ_RX;
+                }
             }
         }
     }
@@ -423,8 +625,13 @@ static mp_uint_t machine_can_port_irq_flags(machine_can_obj_t *self) {
 void machine_can_irq_handler(uint can_id,  can_int_t interrupt) {
     assert(can_id > 0);
     machine_can_obj_t *self = MP_STATE_PORT(machine_can_objs)[can_id - 1];
-    if (self == NULL) {
-        return; // Should only hit this code path if pyb.CAN has enabled interrupt
+    if (self == NULL || self->port == NULL) {
+        // Either pyb.CAN has enabled the interrupt with no machine.CAN ever
+        // constructed on this peripheral, or a machine.CAN that was
+        // constructed has since been deinitialised. Either way, self->port
+        // (dereferenced below for every case except CAN_INT_FIFO_FULL and
+        // CAN_INT_FIFO_OVERFLOW) is not available.
+        return;
     }
     struct machine_can_port *port = self->port;
     machine_can_counters_t *counters = &self->counters;
@@ -441,7 +648,21 @@ void machine_can_irq_handler(uint can_id,  can_int_t interrupt) {
             counters->rx_overruns++;
             break;
         case CAN_INT_MESSAGE_RECEIVED:
-            call_irq = call_irq || (self->mp_irq_trigger & MP_CAN_IRQ_RX);
+            if (port->rx_ring_len > 0) {
+                // Drain the hardware FIFOs into the software ring here, so the
+                // ISR re-enables the RX interrupt itself instead of waiting for
+                // Python to call recv(). Only schedule the .irq() callback on
+                // the ring's empty-to-non-empty transition: further frames
+                // arriving before the callback runs are coalesced into the
+                // same wakeup.
+                bool ring_was_empty = (port->rx_ring_head == port->rx_ring_tail);
+                can_rx_ring_fill(self);
+                if (ring_was_empty && port->rx_ring_head != port->rx_ring_tail) {
+                    call_irq = call_irq || (self->mp_irq_trigger & MP_CAN_IRQ_RX);
+                }
+            } else {
+                call_irq = call_irq || (self->mp_irq_trigger & MP_CAN_IRQ_RX);
+            }
             break;
 
         // Error states

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -131,6 +131,10 @@
 #endif
 #endif
 #define MICROPY_PY_MACHINE_CAN_INCLUDEFILE "ports/stm32/machine_can.c"
+// This port implements the software receive ring selected by CAN.init(rxbuf=N).
+// Defined here, ahead of extmod/machine_can_port.h, so that header can size
+// machine_can_obj_t's rxbuf_len field only for ports that use it.
+#define MICROPY_PY_MACHINE_CAN_RXBUF (1)
 #define MICROPY_PY_MACHINE_DHT_READINTO (1)
 // Backup memory via BKPSRAM or RTC BKP registers.
 #if MICROPY_HW_ENABLE_RTC

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -39,9 +39,9 @@
 // as well as a fallback to generate MICROPY_GIT_TAG if the git repo or tags
 // are unavailable.
 #define MICROPY_VERSION_MAJOR 1
-#define MICROPY_VERSION_MINOR 29
+#define MICROPY_VERSION_MINOR 30
 #define MICROPY_VERSION_MICRO 0
-#define MICROPY_VERSION_PRERELEASE 0
+#define MICROPY_VERSION_PRERELEASE 1
 
 // Combined version as a 32-bit number for convenience to allow version
 // comparison. Doesn't include prerelease state.

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -123,6 +123,7 @@ function ci_code_size_build {
             OUTFILE=$2
             IGNORE_ERRORS=$3
 
+            git restore ports/esp32/lockfiles/*  # esp32 port may update local lockfile
             git checkout --detach $COMMIT
             git submodule update --init $SUBMODULES
             git show -s


### PR DESCRIPTION

# stm32/machine_can: software receive ring

## Why

`machine.CAN` retains only what its hardware receive FIFO holds whenever the
consumer is not draining continuously. On the STM32H5 that FIFO is three
elements, fixed in silicon.

That is enough only while nothing else runs. At 1 Mbit a frame arrives every
54 us (zero-byte) to 124 us (8-byte), so three elements is **162 to 372 us** of
tolerance. Measured on the same board: a `gc.collect()` with frames pending takes
**253 us**, and a single blocking log line on a 115200 console takes about
**5 ms**. Neither is exotic, and neither involves the networking or protocol
stacks an application is likely to add.

The interrupt also masks itself and waits for the consumer to call `recv()`
before re-enabling, so the gap is not merely a scheduling delay; receive
interrupts are off for its duration.

## What

An optional `rxbuf` argument, counted in frames, mirroring `machine.UART`'s
existing `rxbuf`. When set, the receive interrupt drains the hardware FIFO into a
ring allocated once at init and re-enables the FIFO interrupt itself, rather than
waiting for Python. The `.irq()` callback is scheduled only on the ring's
empty-to-non-empty transition, which coalesces: while a drain is pending, further
interrupts add to the ring and schedule nothing.

`rxbuf=0` is the default and leaves every code path exactly as it was.

## Measured

Consumer alive but busy elsewhere, 1 Mbit loopback, sends paced so each is
accepted by the controller:

| | sent | recovered |
|---|---|---|
| `rxbuf=0`, callback registered | 12 | **3** |
| `rxbuf=64`, callback registered | 12 | **12** |
| `rxbuf=64`, no callback, polled `recv()` | 12 | **12** |
| `rxbuf=0`, no callback, polled `recv()` | 12 | **3** |

**Steady-state throughput is unchanged**, and that is worth stating plainly: with
a consumer that does keep up, the stock driver already reaches 8077 frames/s at
8 bytes and 18515 at zero bytes on this board, losing nothing. This change buys
tolerance to a stalled consumer, not rate.

`rx_overruns` counts overrun interrupts rather than frames lost, so it fires once
for many dropped frames. That is pre-existing behaviour, unchanged here, and
noted so the counter is not over-read.

## Testing

STM32H5 (NUCLEO-H563ZI), FDCAN backend, on hardware: the table above, plus
polled `recv()` with and without a registered callback, and a 64-check
`machine.CAN` API sweep passing identically with the ring off.

Not exercised: the classic bxCAN backend, since no such board was available, and
the ports that do not enable the feature. Those paths are reasoned about, not
run.

### Outstanding before this goes upstream

- Decide one PR or two, given the ring already lives partly in extmod. See machine-can-rxbuf.md: a reviewer may reasonably ask why mimxrt and alif do not adopt it, and the answer is that they should.
- Findings 2 and 3 from review (classic bxCAN ISR path, NULL port dereference) are resolved by inspection only. No classic-bxCAN board is available here and the NULL sequence could not be provoked. Say so in the PR rather than implying they were exercised.

---
*Draft raised on the fork for review. Base is the fork's own branch, not upstream.*
