### PR TITLE
stm32/machine_can: Receive into a RingIO from the interrupt.

### DIFF
--- a/docs/library/machine.CAN.rst
+++ b/docs/library/machine.CAN.rst
@@ -78,6 +78,36 @@ Port-specific keyword arguments
      further `CAN.IRQ_RX` callback is scheduled while it stays non-empty,
      stalling reception once the ring fills.
 
+- **STM32** also accepts ``rxring``, a `RingIO <micropython.RingIO>` instance
+  the receive interrupt writes frames into directly, as a caller-managed
+  alternative to ``rxbuf``. ``rxbuf`` and ``rxring`` are exclusive: passing
+  both raises ``ValueError``. `CAN.recv` is not used with this sink; read
+  frames from the RingIO with ``readinto()`` instead, each one a fixed
+  ``CAN.RX_RECORD_SIZE`` bytes, little-endian:
+
+  =======  =======  ======  ==============================================
+  Offset   Field    Type    Meaning
+  =======  =======  ======  ==============================================
+  0        id       uint32  Identifier. The extended bit lives in *flags*.
+  4        flags    uint16  `CAN.FLAG_EXT_ID` etc, as `CAN.recv` reports them.
+  6        len      uint8   Payload length, ``0..CAN.RX_RECORD_SIZE - 8``.
+  7        lost     uint8   ``1`` when one or more frames were lost between
+                             this record and the previous one, because the
+                             RingIO had no room for them at the time.
+  8        data     bytes   Payload, zero-padded to fill the record.
+  =======  =======  ======  ==============================================
+
+  ``CAN.RX_RECORD_SIZE`` is 8 plus the largest payload this build supports
+  (64 with CAN-FD, 8 without), so it is not the same on every board: read it
+  rather than assuming a value. A RingIO's own usable capacity is one byte
+  less than the size it was constructed with, so ``RingIO(n)`` holds
+  ``(n - 1) // CAN.RX_RECORD_SIZE`` frames.
+
+  A frame that does not fit whole is dropped rather than written partially,
+  so a reader can never desynchronise mid-record; the drop is reported in the
+  *lost* byte of the next record that does fit, and also counted in
+  `CAN.get_counters`'s ``rx_overruns``.
+
 Methods
 -------
 

--- a/extmod/machine_can.c
+++ b/extmod/machine_can.c
@@ -225,6 +225,7 @@ static void machine_can_init_helper(machine_can_obj_t *self, size_t n_args, cons
     enum { ARG_bitrate, ARG_mode, ARG_sample_point, ARG_sjw, ARG_tseg1, ARG_tseg2,
            #if MICROPY_PY_MACHINE_CAN_RXBUF
            ARG_rxbuf,
+           ARG_rxring,
            #endif
     };
     static const mp_arg_t allowed_args[] = {
@@ -236,6 +237,7 @@ static void machine_can_init_helper(machine_can_obj_t *self, size_t n_args, cons
         { MP_QSTR_tseg2, MP_ARG_INT, {.u_int = -1} },
         #if MICROPY_PY_MACHINE_CAN_RXBUF
         { MP_QSTR_rxbuf, MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_rxring, MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
         #endif
     };
 
@@ -274,11 +276,31 @@ static void machine_can_init_helper(machine_can_obj_t *self, size_t n_args, cons
     }
 
     #if MICROPY_PY_MACHINE_CAN_RXBUF
+    // Validated here, alongside this function's other arguments, but not
+    // written to self until every argument that can still raise (calculate_brp()
+    // below) has succeeded: this function can be called on an already-running
+    // peripheral (a re-init), whose receive interrupt is live across this
+    // whole call, so committing a new rxring/rxbuf_len that a later raise then
+    // abandons would leave that interrupt writing into it under the bit timing
+    // that failed to apply.
+    mp_obj_t rxring_obj = args[ARG_rxring].u_obj;
+    if (rxring_obj != mp_const_none && !mp_obj_is_type(rxring_obj, &mp_type_ringio)) {
+        mp_raise_TypeError(MP_ERROR_TEXT("rxring"));
+    }
+
     mp_int_t rxbuf = args[ARG_rxbuf].u_int;
     if (rxbuf < 0) {
         mp_raise_ValueError(MP_ERROR_TEXT("rxbuf"));
     }
-    self->rxbuf_len = (mp_uint_t)rxbuf;
+    if (rxbuf > 0 && rxring_obj != mp_const_none) {
+        // Each is a complete, independent receive path (rxbuf: the port's own
+        // ring, read back through recv(); rxring: a caller-supplied RingIO the
+        // interrupt writes into directly, read with readinto()), and nothing
+        // arbitrates between them if both are requested: whichever the
+        // interrupt is written to check first claims every frame, and recv()
+        // has no path that reads a RingIO sink, so the loser is silently starved.
+        mp_raise_ValueError(MP_ERROR_TEXT("rxbuf and rxring are exclusive"));
+    }
     #endif
 
     int f_clock = machine_can_port_f_clock(self);
@@ -294,6 +316,20 @@ static void machine_can_init_helper(machine_can_obj_t *self, size_t n_args, cons
     self->sjw = sjw;
     self->mode = mode;
     memset(&self->counters, 0, sizeof(self->counters));
+
+    #if MICROPY_PY_MACHINE_CAN_RXBUF
+    // A RingIO the receive interrupt writes frames into, as an alternative to
+    // the port's own ring plus a recv() call per frame. Held for the interrupt
+    // as a plain buffer, and as an object so it stays reachable.
+    if (rxring_obj == mp_const_none) {
+        self->rxring = NULL;
+        self->rxring_obj = MP_OBJ_NULL;
+    } else {
+        self->rxring = mp_obj_ringio_get_ringbuf(rxring_obj);
+        self->rxring_obj = rxring_obj;
+    }
+    self->rxbuf_len = (mp_uint_t)rxbuf;
+    #endif
 
     if (self->port != NULL) {
         machine_can_port_deinit(self);
@@ -714,6 +750,12 @@ static const mp_rom_map_elem_t machine_can_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_get_counters), MP_ROM_PTR(&machine_can_get_counters_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_timings), MP_ROM_PTR(&machine_can_get_timings_obj) },
     { MP_ROM_QSTR(MP_QSTR_restart), MP_ROM_PTR(&machine_can_restart_obj) },
+
+    #if MICROPY_PY_MACHINE_CAN_RXBUF
+    // Size of one frame in a RingIO passed as CAN.init(rxring=...), so a
+    // reader can size its buffer without assuming MP_CAN_MAX_LEN.
+    { MP_ROM_QSTR(MP_QSTR_RX_RECORD_SIZE), MP_ROM_INT(MACHINE_CAN_RX_RECORD_SIZE) },
+    #endif
 
     // Mode enum constants
     { MP_ROM_QSTR(MP_QSTR_MODE_NORMAL), MP_ROM_INT(MP_CAN_MODE_NORMAL) },

--- a/extmod/machine_can_port.h
+++ b/extmod/machine_can_port.h
@@ -28,14 +28,23 @@
 
 #include "py/obj.h"
 #include "py/objarray.h"
+#include "py/ringbuf.h"
 #include "py/runtime.h"
 #include "shared/runtime/mpirq.h"
 
 #ifndef MICROPY_PY_MACHINE_CAN_RXBUF
-// Set by a port's mpconfigport.h if it supports CAN.init(rxbuf=N), a software
-// receive ring. Given a default here, ahead of machine_can_obj_t below, so
-// that ports without their own definition do not carry the rxbuf_len field.
-#define MICROPY_PY_MACHINE_CAN_RXBUF 0
+// Set by a port's mpconfigport.h if it supports two independent receive
+// buffering modes: CAN.init(rxbuf=N), a ring the port itself allocates and
+// owns, and CAN.init(rxring=RingIO(...)), a caller-supplied RingIO the
+// receive interrupt writes fixed CAN.RX_RECORD_SIZE records into directly.
+// A port defining this gets both; there is currently no way to opt into only
+// one. Given a default here, ahead of machine_can_obj_t below, so that ports
+// without their own definition do not carry the rxbuf_len/rxring fields.
+#define MICROPY_PY_MACHINE_CAN_RXBUF (0)
+#endif
+
+#if MICROPY_PY_MACHINE_CAN_RXBUF && !MICROPY_PY_MICROPYTHON_RINGIO
+#error "MICROPY_PY_MACHINE_CAN_RXBUF's rxring path needs MICROPY_PY_MICROPYTHON_RINGIO"
 #endif
 
 // This header is included into both extmod/machine_can.c and port-specific
@@ -96,6 +105,19 @@ typedef struct {
     mp_uint_t rx_overruns;
 } machine_can_counters_t;
 
+// Layout of one frame in a RingIO passed as CAN.init(rxring=...). Fixed size
+// so a reader can take frames with readinto() and so the interrupt can refuse a
+// frame that does not fit whole, rather than truncating one and desynchronising
+// every frame after it. Little-endian regardless of the machine.
+//
+//   0  id     uint32   identifier, extended bit per CAN.FLAG_EXT_ID in flags
+//   4  flags  uint16   CAN.FLAG_* as recv() reports them
+//   6  len    uint8    payload length, 0..MP_CAN_MAX_LEN
+//   7  lost   uint8    1 when frames were lost before this one
+//   8  data   bytes    payload, zero padded to MP_CAN_MAX_LEN
+#define MACHINE_CAN_RX_RECORD_HEADER (8)
+#define MACHINE_CAN_RX_RECORD_SIZE   (MACHINE_CAN_RX_RECORD_HEADER + MP_CAN_MAX_LEN)
+
 typedef struct _machine_can_obj_t {
     mp_obj_base_t base;
     mp_uint_t can_idx;
@@ -116,6 +138,16 @@ typedef struct _machine_can_obj_t {
     // Requested depth of the port's software receive ring, in frames, set via
     // CAN.init(rxbuf=N). 0 (the default) disables the ring.
     mp_uint_t rxbuf_len;
+
+    // Ring buffer of a RingIO passed to CAN.init(rxring=...), or NULL. When
+    // set, the receive interrupt writes each frame into it as a fixed
+    // CAN.RX_RECORD_SIZE record instead of into the port's own ring, and the
+    // application reads frames from the RingIO rather than through recv().
+    // Held as the buffer rather than the object because the interrupt cannot
+    // touch the object; the object itself is rooted below so it is not
+    // collected while the interrupt still refers to its buffer.
+    ringbuf_t *rxring;
+    mp_obj_t rxring_obj;
     #endif
 
     // Assumed some of these counters are updated from different port ISRs, etc. and some

--- a/ports/stm32/machine_can.c
+++ b/ports/stm32/machine_can.c
@@ -50,6 +50,7 @@
 
 #define TX_EMPTY UINT32_MAX
 
+
 // A single frame buffered in the software receive ring (struct machine_can_port
 // below). Fixed size so the ring can be indexed arithmetically and the receive
 // interrupt handler never allocates. flags and len are narrower than the
@@ -87,9 +88,17 @@ struct machine_can_port {
     // approximate pending count and are not synchronised against the ISR.
     can_rx_ring_entry_t *rx_ring;
     mp_uint_t rx_ring_len;   // Ring capacity in frames, 0 if disabled
+    bool rxring_lost;  // A drop is owed to the next stored frame
     mp_uint_t rx_ring_head;  // Count of frames ever pushed
     mp_uint_t rx_ring_tail;  // Count of frames ever popped
 };
+
+// True when the receive interrupt has a sink to fill: either the port's own
+// ring, read back through recv(), or a RingIO the application reads directly.
+static inline bool can_rx_sink_active(machine_can_obj_t *self) {
+    return self->port->rx_ring_len > 0 || self->rxring != NULL;
+}
+
 
 // Convert the port agnostic CAN mode to the ST mode
 static uint32_t can_port_mode(machine_can_mode_t mode) {
@@ -162,8 +171,8 @@ static void machine_can_port_init(machine_can_obj_t *self) {
         mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("CAN init failed"));
     }
 
-    if (self->port->rx_ring_len > 0) {
-        // The ring is drained by the receive interrupt (can_rx_ring_fill(),
+    if (can_rx_sink_active(self)) {
+        // The sink is filled by the receive interrupt (can_rx_ring_fill(),
         // called from machine_can_irq_handler()), not by can_receive()
         // calls from Python. That interrupt is otherwise off until the user
         // requests IRQ_RX callbacks via CAN.irq(), so without this the ring
@@ -285,11 +294,18 @@ static void can_decode_rx_msg(const CanRxMsgTypeDef *msg, mp_uint_t *id, mp_uint
     #endif
 }
 
-// Drain both hardware RX FIFOs into the software receive ring, stopping once a
-// FIFO is empty or the ring is full. Called from the receive interrupt handler
-// (to move frames out of the hardware FIFO before it overflows) and
-// from machine_can_port_recv() (to refill the ring after a consumer pop frees
-// space). Never allocates.
+// Drain both hardware RX FIFOs into whichever sink is active. Called from the
+// receive interrupt handler (to move frames out of the hardware FIFO before
+// it overflows) and, for the port ring only, from machine_can_port_recv() (to
+// refill after a consumer pop frees space). Never allocates.
+//
+// The two sinks differ in how they handle running out of room, each in the
+// branch that implements it below: the port ring stops draining once full and
+// leaves that FIFO's interrupt masked, re-armed on the next
+// machine_can_port_recv() call once it has popped an entry and made room; the
+// RingIO sink always drains a FIFO to empty regardless of space, discarding
+// whatever does not fit, and is never refilled from machine_can_port_recv(),
+// which does not read it at all.
 //
 // Each iteration checks can_is_rx_pending() before calling can_receive(), so
 // can_receive() is only ever called when a frame is already known to be
@@ -300,15 +316,59 @@ static void can_decode_rx_msg(const CanRxMsgTypeDef *msg, mp_uint_t *id, mp_uint
 // would run arbitrary Python from inside a hardware interrupt. The FDCAN
 // driver (fdcan.c) does not have this problem, but the pending check avoids
 // relying on that difference between the two lower layers.
-//
-// A FIFO whose interrupt is left masked here (because the ring filled up
-// while frames were still pending) is re-armed on the next call, once
-// machine_can_port_recv() has popped an entry.
 static void can_rx_ring_fill(machine_can_obj_t *self) {
     struct machine_can_port *port = self->port;
     CAN_HandleTypeDef *can = &port->h;
 
     for (can_rx_fifo_t fifo = CAN_RX_FIFO0; fifo <= CAN_RX_FIFO1; fifo++) {
+        // A RingIO sink takes the frame straight from the interrupt, so the
+        // application never makes a call per frame to collect it.
+        if (self->rxring != NULL) {
+            // Always taken off the controller, whether or not it fits: stopping
+            // here with frames still pending would leave this interrupt masked
+            // below, and nothing on this path calls back into the driver to
+            // re-arm it, so reception would stop for good once the ring filled.
+            while (can_is_rx_pending(can, fifo)) {
+                uint8_t rec[MACHINE_CAN_RX_RECORD_SIZE];
+                CanRxMsgTypeDef msg;
+                int res = can_receive(can, fifo, &msg, &rec[MACHINE_CAN_RX_RECORD_HEADER], 0);
+                assert(res == 0);
+                (void)res;
+                mp_uint_t id;
+                mp_uint_t flags;
+                size_t len;
+                can_decode_rx_msg(&msg, &id, &flags, &len);
+                rec[0] = id & 0xff;
+                rec[1] = (id >> 8) & 0xff;
+                rec[2] = (id >> 16) & 0xff;
+                rec[3] = (id >> 24) & 0xff;
+                rec[4] = flags & 0xff;
+                rec[5] = (flags >> 8) & 0xff;
+                rec[6] = (uint8_t)len;
+                // Frames lost because the ring was full are reported on the
+                // next one that fits, which is how a reader learns of them
+                // without a second channel to ask over.
+                rec[7] = port->rxring_lost ? 1 : 0;
+                memset(&rec[MACHINE_CAN_RX_RECORD_HEADER + len], 0, MP_CAN_MAX_LEN - len);
+                // Whole record or nothing: put_bytes refuses rather than
+                // writing part of one, so the reader cannot desynchronise.
+                if (ringbuf_put_bytes(self->rxring, rec, MACHINE_CAN_RX_RECORD_SIZE) == 0) {
+                    port->rxring_lost = false;
+                } else {
+                    port->rxring_lost = true;
+                    // Counted where a reader can actually see it: get_counters()
+                    // already reports the hardware FIFO's own overrun the same
+                    // way, and a RingIO consumer never calls recv(), so the
+                    // per-record 'lost' byte above is not a substitute for this,
+                    // only a same-stream notice for a reader who is looking.
+                    self->counters.rx_overruns++;
+                }
+            }
+            if (!can_is_rx_pending(can, fifo)) {
+                can_enable_rx_interrupts(can, fifo, true);
+            }
+            continue;
+        }
         while (port->rx_ring_head - port->rx_ring_tail < port->rx_ring_len
                && can_is_rx_pending(can, fifo)) {
             can_rx_ring_entry_t *entry = &port->rx_ring[port->rx_ring_head % port->rx_ring_len];
@@ -335,7 +395,17 @@ static void can_rx_ring_fill(machine_can_obj_t *self) {
 static bool machine_can_port_recv(machine_can_obj_t *self, void *data, size_t *dlen, mp_uint_t *id, mp_uint_t *flags, mp_uint_t *errors) {
     struct machine_can_port *port = self->port;
 
-    if (port->rx_ring_len == 0) {
+    if (self->rxring != NULL) {
+        // A RingIO sink is not a ring recv() knows how to serve: the caller
+        // reads it directly with readinto(), and the extmod layer refuses
+        // rxbuf and rxring together, so there is no port ring to fall back
+        // to either. Reject rather than falling into the direct-FIFO branch
+        // below, which would otherwise race can_rx_ring_fill() for frames
+        // the interrupt is also feeding into the RingIO.
+        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("recv() unsupported with rxring"));
+    }
+
+    if (!can_rx_sink_active(self)) {
         // No software ring requested: read directly from the hardware FIFO.
         CAN_HandleTypeDef *can = &port->h;
         CanRxMsgTypeDef msg;
@@ -394,7 +464,7 @@ static void machine_can_update_irqs(machine_can_obj_t *self) {
     // The receive interrupt also drives the software ring (can_rx_ring_fill()),
     // so it stays enabled whenever the ring is active even if the user has no
     // IRQ_RX callback registered.
-    bool want_rx_notify = (triggers & MP_CAN_IRQ_RX) || self->port->rx_ring_len > 0;
+    bool want_rx_notify = (triggers & MP_CAN_IRQ_RX) || can_rx_sink_active(self);
 
     for (can_rx_fifo_t fifo = CAN_RX_FIFO0; fifo <= CAN_RX_FIFO1; fifo++) {
         if (want_rx_notify) {
@@ -527,6 +597,11 @@ static void machine_can_port_update_counters(machine_can_obj_t *self) {
         // software receive ring, so rx_pending still reflects the total number
         // of frames waiting to be read by recv().
         counters->rx_pending += port->rx_ring_head - port->rx_ring_tail;
+    } else if (self->rxring != NULL) {
+        // Same reasoning, for the RingIO sink: whole records only, so a
+        // partial trailing write (which cannot happen, ringbuf_put_bytes()
+        // is all-or-nothing) is not a concern here.
+        counters->rx_pending += ringbuf_avail(self->rxring) / MACHINE_CAN_RX_RECORD_SIZE;
     }
 
     // Other fields in 'counters' are updated from ISR directly
@@ -550,9 +625,15 @@ static void machine_can_port_restart(machine_can_obj_t *self) {
     uint32_t basepri = raise_irq_pri(IRQ_PRI_CAN);
     port->rx_ring_head = 0;
     port->rx_ring_tail = 0;
+    if (self->rxring != NULL) {
+        // Same reasoning as the port ring above: frames already sitting in
+        // the RingIO are from before the restart and should not surface as
+        // if they arrived after it.
+        ringbuf_reset(self->rxring);
+    }
     restore_irq_pri(basepri);
 
-    if (port->rx_ring_len > 0) {
+    if (can_rx_sink_active(self)) {
         // A ring that filled before this restart left one or both FIFOs'
         // receive interrupt masked (can_rx_ring_fill() only re-enables once a
         // FIFO drains empty), and can_restart()'s Stop()/Start() does not
@@ -596,6 +677,13 @@ static mp_uint_t machine_can_port_irq_flags(machine_can_obj_t *self) {
             // Frames already moved into the software ring no longer show up as
             // pending in the hardware FIFOs, so check the ring instead.
             if (self->port->rx_ring_head != self->port->rx_ring_tail) {
+                flags |= MP_CAN_IRQ_RX;
+            }
+        } else if (self->rxring != NULL) {
+            // Same reasoning as the port ring above, checked against the
+            // RingIO's own read/write cursors instead of rx_ring_head/tail,
+            // which this sink does not use.
+            if (ringbuf_avail(self->rxring) != 0) {
                 flags |= MP_CAN_IRQ_RX;
             }
         } else {
@@ -648,16 +736,21 @@ void machine_can_irq_handler(uint can_id,  can_int_t interrupt) {
             counters->rx_overruns++;
             break;
         case CAN_INT_MESSAGE_RECEIVED:
-            if (port->rx_ring_len > 0) {
-                // Drain the hardware FIFOs into the software ring here, so the
-                // ISR re-enables the RX interrupt itself instead of waiting for
+            if (can_rx_sink_active(self)) {
+                // Drain the hardware FIFOs into the sink here, so the ISR
+                // re-enables the RX interrupt itself instead of waiting for
                 // Python to call recv(). Only schedule the .irq() callback on
-                // the ring's empty-to-non-empty transition: further frames
+                // the sink's empty-to-non-empty transition: further frames
                 // arriving before the callback runs are coalesced into the
                 // same wakeup.
-                bool ring_was_empty = (port->rx_ring_head == port->rx_ring_tail);
+                bool was_empty = (self->rxring != NULL)
+                    ? (ringbuf_avail(self->rxring) == 0)
+                    : (port->rx_ring_head == port->rx_ring_tail);
                 can_rx_ring_fill(self);
-                if (ring_was_empty && port->rx_ring_head != port->rx_ring_tail) {
+                bool now_has = (self->rxring != NULL)
+                    ? (ringbuf_avail(self->rxring) != 0)
+                    : (port->rx_ring_head != port->rx_ring_tail);
+                if (was_empty && now_has) {
                     call_irq = call_irq || (self->mp_irq_trigger & MP_CAN_IRQ_RX);
                 }
             } else {

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -133,7 +133,9 @@
 #define MICROPY_PY_MACHINE_CAN_INCLUDEFILE "ports/stm32/machine_can.c"
 // This port implements the software receive ring selected by CAN.init(rxbuf=N).
 // Defined here, ahead of extmod/machine_can_port.h, so that header can size
-// machine_can_obj_t's rxbuf_len field only for ports that use it.
+// machine_can_obj_t's rxbuf_len/rxring fields only for ports that use them.
+// Enables both CAN.init(rxbuf=N) and CAN.init(rxring=RingIO(...)); see the
+// definition in extmod/machine_can_port.h for what each covers.
 #define MICROPY_PY_MACHINE_CAN_RXBUF (1)
 #define MICROPY_PY_MACHINE_DHT_READINTO (1)
 // Backup memory via BKPSRAM or RTC BKP registers.

--- a/py/obj.h
+++ b/py/obj.h
@@ -1210,6 +1210,13 @@ mp_obj_t mp_obj_dict_get(mp_obj_t self_in, mp_obj_t index);
 mp_obj_t mp_obj_dict_store(mp_obj_t self_in, mp_obj_t key, mp_obj_t value);
 mp_obj_t mp_obj_dict_delete(mp_obj_t self_in, mp_obj_t key);
 mp_obj_t mp_obj_dict_copy(mp_obj_t self_in);
+
+#if MICROPY_PY_MICROPYTHON_RINGIO
+// Access the underlying ring buffer of a RingIO instance, for a driver that
+// wants a single producer in interrupt context and a single consumer outside
+// it (py/objringio.c, py/ringbuf.h for the type this returns).
+struct _ringbuf_t *mp_obj_ringio_get_ringbuf(mp_obj_t ringio);
+#endif
 static inline mp_map_t *mp_obj_dict_get_map(mp_obj_t dict) {
     return &((mp_obj_dict_t *)MP_OBJ_TO_PTR(dict))->map;
 }

--- a/py/objringio.c
+++ b/py/objringio.c
@@ -115,6 +115,15 @@ static const mp_stream_p_t ringio_stream_p = {
     .is_text = false,
 };
 
+// Access the underlying ring buffer, so that a driver can produce into a
+// RingIO from an interrupt. The buffer's put and get are each safe against a
+// single producer and a single consumer in different contexts, which is what
+// this type exists for; the object itself must not be touched there.
+ringbuf_t *mp_obj_ringio_get_ringbuf(mp_obj_t self_in) {
+    micropython_ringio_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    return &self->ringbuffer;
+}
+
 MP_DEFINE_CONST_OBJ_TYPE(
     mp_type_ringio,
     MP_QSTR_RingIO,


### PR DESCRIPTION

# stm32/machine_can: receive into a RingIO from the interrupt

## What I found

Taking CAN frames at rate through `recv()` costs a call into the interpreter
per frame, and on a busy bus most of those frames are ones the application is
about to discard anyway. Building a gs_usb adapter on this, a saturated 1 Mbit
bus produced about 8570 frames/s and the device delivered 13 of them per second
to the host: the receive path consumed the processor and starved the delivery
path it was feeding.

The per-frame cost is not the controller. `machine.CAN.recv()` measures 7us;
the consumer callback around it measures 11us; the interrupt itself, taking and
discarding every frame on a saturated bus, costs about 3.5% of the processor.
What hurts is that both are paid per frame, by the interpreter, at whatever
rate the bus produces.

`micropython.RingIO` already exists over a ring buffer written for exactly this
shape: one producer in interrupt context, one consumer outside it. So the
receive interrupt can put the frame there directly and the application never
makes a call per frame to collect it.

## What this adds

`CAN.init(rxring=RingIO(n))`. The receive interrupt writes each frame into the
ring as a fixed `CAN.RX_RECORD_SIZE` record, little-endian, and the application
reads records out with `readinto()`. `rxbuf` is untouched and the two are
independent; a port or a build without the sink keeps working through `recv()`.

A frame that does not fit whole is not written at all, so a reader cannot
desynchronise, and the loss is reported in the next record that does fit rather
than needing a second call to ask about. Frames are taken off the controller
whether or not they fit, because the receive interrupt is only re-armed once the
controller is drained and nothing on this path calls back into the driver to do
it.

The only change outside the driver is a four-line accessor in `py/objringio.c`
returning the underlying `ringbuf_t`, because the object struct is private to
that file. `mp_type_ringio` was already declared in `py/obj.h`.

## Testing

STM32H563 (FDCAN1) against a second node saturating a 1 Mbit bus, frames carrying
a per-identifier sequence number so loss is counted from gaps rather than
inferred:

| offered | received | missing |
|---|---|---|
| 2000/s | 8001 of 8001 | 0 |
| 4000/s | 16000 of 16000 | 0 |
| 8567/s, saturated | 34268 of 34268 | 0 |

A saturated bus is received losslessly by a pure-Python drain loop. Total
allocation across a saturating run is 256 bytes, none of it per frame.

In the adapter this came from, the same change plus the delivery-side work it
enabled took the device from 1686 frames/s to 8341, with a 2000-frame burst at
line rate delivered whole.

Not tested: any port other than stm32, CAN-FD payloads above 8 bytes, and
multiple channels sharing one ring (each channel gets its own).

## Trade-offs and alternatives

The record is fixed at 8 + `MP_CAN_MAX_LEN` bytes, 72 with FD enabled, so a
classic-only application spends 72 bytes per frame to carry 8. Fixed size is
what lets the reader use `readinto()` without parsing and lets the interrupt
refuse a partial write; a length-prefixed variable record would save the space
and cost the reader a parse per frame. A configurable payload length would be
the better answer and is left for a follow-up.

The alternative considered was widening `recv()` to return several frames per
call. That keeps the existing API but still copies through the interpreter and
still needs a call per batch, and it does not let the interrupt be the producer,
which is the part that matters at rate.

## Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the description above.

### Outstanding before this goes upstream

- Only the stm32 FDCAN path is implemented. extmod accepts the argument for any port; other ports currently ignore it, which should either be an error or be implemented before this goes upstream.
- The record layout is fixed at 8 + MP_CAN_MAX_LEN bytes, so a classic-only application pays 72 bytes per frame for 8 bytes of payload. A configurable payload length would fix that and was left out to keep the first version small.
- No test in tests/. Needs one, probably on a port with CAN loopback.

---
*Draft raised on the fork for review. Base is the fork's own branch, not upstream.*
