### PR TITLE
stm32/mphalport: Idle on WFE so scheduled work is not slept through.

### DIFF
--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -20,7 +20,7 @@ concurrency:
 env:
    # Oldest and newest supported ESP-IDF versions, should match ports/esp32/README.md
    IDF_OLDEST_VER: &oldest "v5.3"
-   IDF_NEWEST_VER: &newest "v5.5.2"
+   IDF_NEWEST_VER: &newest "v5.5.5"
 
 jobs:
   build_idf:

--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -52,8 +52,8 @@ manage the ESP32 microcontroller, as well as a way to manage the required
 build environment and toolchains needed to build the firmware.
 
 The ESP-IDF changes quickly and MicroPython only supports certain versions. The
-current recommended version of ESP-IDF for MicroPython is v5.5.2. MicroPython
-also supports v5.3, v5.4, v5.4.1, v5.4.2, v5.5.1 and v5.5.4.
+current recommended version of ESP-IDF for MicroPython is v5.5.5. MicroPython
+also supports v5.3, v5.4, v5.4.1, v5.4.2, v5.5.1, v5.5.2 and v5.5.4.
 
 <!-- Important: If updating the above, please also update:
      * IDF_OLDEST_VER & IDF_NEWEST_VER in .github/workflows/port_esp32.yml

--- a/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
@@ -13,6 +13,9 @@
 
 #define MICROPY_PY_MACHINE_SDCARD           (1)
 #define MICROPY_HW_SDMMC_LDO_CHAN_ID        (4)
+// This board wires the SD/MMC card to SDMMC slot 0 with a full 4-bit bus.
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (0)
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (4)
 
 #ifndef USB_SERIAL_JTAG_PACKET_SZ_BYTES
 #define USB_SERIAL_JTAG_PACKET_SZ_BYTES (64)

--- a/ports/esp32/lockfiles/dependencies.lock.esp32
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32
@@ -25,7 +25,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/lan867x
 - espressif/mdns

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c2
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c3
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c5
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c5
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c6
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c6
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32h2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32h2
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32p4
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32p4
@@ -81,7 +81,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/esp_hosted
 - espressif/esp_wifi_remote

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s2
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s3
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/ports/esp32/machine_sdcard.h
+++ b/ports/esp32/machine_sdcard.h
@@ -26,6 +26,17 @@
 #ifndef MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
 #define MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
 
+// Default slot and bus width for a native SD/MMC machine.SDCard(). These are
+// conservative defaults (the historically usable slot 1, 1-bit); which slot is
+// wired and how many data lines are routed is board specific, so a board should
+// override these in its mpconfigboard.h to match its layout.
+#ifndef MICROPY_HW_SDMMC_DEFAULT_SLOT
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
+#endif
+#ifndef MICROPY_HW_SDMMC_DEFAULT_WIDTH
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (1)
+#endif
+
 // Default pins for the primary SPI-mode SD card bus (slot 2). SPI mode is
 // available on every ESP32 variant, so a board may override these in its
 // mpconfigboard.h to make machine.SDCard(slot=2) work without explicit pins.

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -150,8 +150,11 @@ soft_reset:
     machine_i2s_init0();
     #endif
 
-    // run boot-up scripts
-    pyexec_frozen_module("_boot.py", false);
+    // Run optional frozen boot code.
+    #ifdef MICROPY_BOARD_FROZEN_BOOT_FILE
+    pyexec_frozen_module(MICROPY_BOARD_FROZEN_BOOT_FILE, false);
+    #endif
+
     int ret = pyexec_file_if_exists("boot.py");
 
     #if MICROPY_HW_ENABLE_USBDEV

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -326,9 +326,7 @@ static mp_obj_t machine_wake_pins(void) {
 
     // Only a few (~8) pins might cause wakeup.
     // Therefore, we calculate the required space in a first pass.
-    for (index = 0, len = 0; index < 64; index++) {
-        len += (status & (1ULL << index)) ? 1 : 0;
-    }
+    len = mp_popcount(status >> 32) + mp_popcount(status & 0xFFFFFFFF);
     if (len) {
         mp_obj_tuple_t *tuple = MP_OBJ_TO_PTR(mp_obj_new_tuple(len, NULL));
 

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -224,20 +224,6 @@
 #ifndef MICROPY_HW_ENABLE_SDCARD
 #define MICROPY_HW_ENABLE_SDCARD            (1)
 #endif
-#ifndef MICROPY_HW_SDMMC_DEFAULT_SLOT
-#if CONFIG_IDF_TARGET_ESP32P4
-#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (0)
-#else
-#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
-#endif
-#endif
-#ifndef MICROPY_HW_SDMMC_DEFAULT_WIDTH
-#if CONFIG_IDF_TARGET_ESP32P4
-#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (4)
-#else
-#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (1)
-#endif
-#endif
 #define MICROPY_HW_SOFTSPI_MIN_DELAY        (0)
 #define MICROPY_HW_SOFTSPI_MAX_BAUDRATE     (esp_rom_get_cpu_ticks_per_us() * 1000000 / 200) // roughly
 #define MICROPY_PY_SSL                      (MICROPY_PY_NETWORK)

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -425,6 +425,10 @@ typedef long mp_off_t;
 #define MICROPY_BOARD_STARTUP boardctrl_startup
 #endif
 
+#ifndef MICROPY_BOARD_FROZEN_BOOT_FILE
+#define MICROPY_BOARD_FROZEN_BOOT_FILE "_boot.py"
+#endif
+
 void boardctrl_startup(void);
 
 #ifndef MICROPY_PY_NETWORK_LAN

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -79,6 +79,14 @@
 #define MICROPY_TIME_SUPPORT_Y1969_AND_BEFORE (1)
 #define MICROPY_USE_INTERNAL_ERRNO  (1)
 #define MICROPY_SCHEDULER_STATIC_NODES (1)
+// Wake the processor out of the __WFE() in MICROPY_INTERNAL_WFE(). The event
+// register is sticky, so this also covers work queued just before the sleep.
+//
+// mp_sched_exception() has no equivalent hook, but every caller on this port
+// (UART and USB CDC RX, both delivering Ctrl-C) runs from the ISR whose own
+// entry already woke the core, so the WFE it needs to clear has already
+// cleared by the time execution returns to the sleeping mainline code.
+#define MICROPY_SCHED_HOOK_SCHEDULED __SEV()
 #define MICROPY_SCHEDULER_DEPTH     (8)
 #define MICROPY_VFS                 (1)
 #define MICROPY_VFS_BLOCKDEV_NATIVE (1)

--- a/ports/stm32/mphalport.h
+++ b/ports/stm32/mphalport.h
@@ -70,6 +70,14 @@ void mp_hal_set_interrupt_char(int c); // -1 to disable
 // Port level Wait-for-Event macro.
 // Do not use this macro directly, include py/runtime.h and
 // call mp_event_wait_indefinite() or mp_event_wait_ms(timeout).
+//
+// __WFE() rather than __WFI() so that work scheduled from an interrupt is not
+// slept through. The callers handle pending events and then sleep without
+// re-testing, so an interrupt landing in that window leaves work queued with
+// nothing pending in the NVIC to wake the processor, and it sleeps until the
+// next SysTick. MICROPY_SCHED_HOOK_SCHEDULED issues __SEV() when that work is
+// queued, and the event register is sticky, so the sleep is skipped whether
+// the interrupt arrived before it or during it.
 #if MICROPY_PY_THREAD
 #define MICROPY_INTERNAL_WFE(TIMEOUT_MS) \
     do { \
@@ -78,12 +86,12 @@ void mp_hal_set_interrupt_char(int c); // -1 to disable
             pyb_thread_yield(); \
             MP_THREAD_GIL_ENTER(); \
         } else { \
-            __WFI(); \
+            __WFE(); \
         } \
     } while (0)
 #define MICROPY_THREAD_YIELD() pyb_thread_yield()
 #else
-#define MICROPY_INTERNAL_WFE(TIMEOUT_MS) __WFI()
+#define MICROPY_INTERNAL_WFE(TIMEOUT_MS) __WFE()
 #define MICROPY_THREAD_YIELD()
 #endif
 

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -39,9 +39,9 @@
 // as well as a fallback to generate MICROPY_GIT_TAG if the git repo or tags
 // are unavailable.
 #define MICROPY_VERSION_MAJOR 1
-#define MICROPY_VERSION_MINOR 29
+#define MICROPY_VERSION_MINOR 30
 #define MICROPY_VERSION_MICRO 0
-#define MICROPY_VERSION_PRERELEASE 0
+#define MICROPY_VERSION_PRERELEASE 1
 
 // Combined version as a 32-bit number for convenience to allow version
 // comparison. Doesn't include prerelease state.

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -123,6 +123,7 @@ function ci_code_size_build {
             OUTFILE=$2
             IGNORE_ERRORS=$3
 
+            git restore ports/esp32/lockfiles/*  # esp32 port may update local lockfile
             git checkout --detach $COMMIT
             git submodule update --init $SUBMODULES
             git show -s


### PR DESCRIPTION

# stm32/mphalport: idle on WFE so scheduled work is not slept through

## What I found

`mp_event_wait_ms()` and `mp_event_wait_indefinite()` handle pending events and
then sleep without re-testing whether more arrived (`py/scheduler.c:284-291`).
Separately, a node scheduled while `mp_sched_run_pending()` is running is
deliberately deferred to the next pass (`py/scheduler.c:106`).

Together those leave a window. Work scheduled from an interrupt during that pass
is queued but not run, and `__WFI()` has no sticky state, so with nothing left
pending in the NVIC the processor sleeps anyway. The work then waits for the
next SysTick, up to a millisecond.

stm32 is the only bare-metal port still idling on `__WFI()`. rp2, mimxrt, samd
and alif all use `__WFE()`, whose event register is sticky and is the standard
idiom for "sleep unless something happened".

## What this changes

Idle on `__WFE()`, and define `MICROPY_SCHED_HOOK_SCHEDULED` to issue `__SEV()`
when work is queued. Because the event register is sticky, the sleep is skipped
whether the work was queued before the sleep was entered or during it, which
closes the window rather than narrowing it. `MICROPY_SCHED_HOOK_SCHEDULED`
already exists for this and was previously defined only by zephyr.

## Testing

STM32H563 streaming a single USB bulk IN endpoint, where every transfer
completion schedules the TinyUSB task, hard reset between points:

| queue depth | `__WFI()` | `__WFE()` plus `__SEV()` |
|---|---|---|
| 1 | 5341 transfers/s | 5373 |
| 2 | 5936 | 6822 |

15% at depth 2 and nothing at depth 1, which is the shape the window predicts:
at depth 2 the next transfer is armed before the Python callback runs, so its
completion can land inside the window, while at depth 1 the arm happens at the
end of the callback and there is almost no window left.

In the application this came from the effect is about 1%, because that workload
is driven by CAN interrupts and is rarely idle. The change is worth having for
correctness rather than for throughput: it removes an up-to-1ms deferral of
scheduled work that applies to every interrupt-driven consumer on the port, not
only USB.

Not tested: other stm32 families, and power draw.

## Trade-offs and alternatives

`__WFE()` can be woken by events unrelated to the scheduler, so there will be
occasional spurious wakes and an extra loop iteration. That is bounded and is
the same behaviour the four ports above already accept.

The more general fix is in `py/scheduler.c`: test for pending work atomically
with entering the sleep, which would fix every port at once. That changes the
`MICROPY_INTERNAL_WFE` contract and needs every port re-validated, so this is
the port-local instance of it and the general case is worth raising separately.
Raising the SysTick rate would also mask it, at a permanent power cost, and
leaves a 100us tail instead of a 1ms one.

## Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the description above.

### Outstanding before this goes upstream

- Only measured on STM32H5. Worth a check on an F4 or F7 that the change is neutral there.
- The general fix belongs in py/scheduler.c, where mp_event_wait_ms() sleeps without re-testing. This is the stm32 instance of it; raise the general case as an issue.

---
*Draft raised on the fork for review. Base is the fork's own branch, not upstream.*
