### PR TITLE
shared/tinyusb: Add desc_bos support to runtime USBDevice.

### DIFF
--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -20,7 +20,7 @@ concurrency:
 env:
    # Oldest and newest supported ESP-IDF versions, should match ports/esp32/README.md
    IDF_OLDEST_VER: &oldest "v5.3"
-   IDF_NEWEST_VER: &newest "v5.5.2"
+   IDF_NEWEST_VER: &newest "v5.5.5"
 
 jobs:
   build_idf:

--- a/docs/library/machine.USBDevice.rst
+++ b/docs/library/machine.USBDevice.rst
@@ -69,7 +69,7 @@ Constructors
 Methods
 -------
 
-.. method:: USBDevice.config(desc_dev, desc_cfg, desc_strs=None, open_itf_cb=None, reset_cb=None, control_xfer_cb=None, xfer_cb=None)
+.. method:: USBDevice.config(desc_dev, desc_cfg, desc_strs=None, open_itf_cb=None, reset_cb=None, control_xfer_cb=None, xfer_cb=None, desc_bos=None)
 
     Configures the ``USBDevice`` singleton object with the USB runtime device
     state and callback functions:
@@ -166,6 +166,12 @@ Methods
       .. note:: If a bus reset occurs (see :func:`USBDevice.reset`),
                 ``xfer_cb`` is not called for any transfers that have not
                 already completed.
+
+    - ``desc_bos`` - Optional bytes-like object containing a USB BOS
+      (Binary Device Object Store) descriptor. If not set, the device has no BOS
+      descriptor and the host's request for one is stalled, which is
+      correct for a device that advertises a USB version below 2.1 and
+      therefore does not promise a BOS in the first place.
 
 .. method:: USBDevice.active(self, [value] /)
 

--- a/extmod/machine_usb_device.c
+++ b/extmod/machine_usb_device.c
@@ -57,6 +57,7 @@ static mp_obj_t usb_device_make_new(const mp_obj_type_t *type, size_t n_args, si
         o->base.type = &machine_usb_device_type;
         o->desc_dev = mp_const_none;
         o->desc_cfg = mp_const_none;
+        o->desc_bos = mp_const_none;
         o->desc_strs = mp_const_none;
         o->open_itf_cb = mp_const_none;
         o->reset_cb = mp_const_none;
@@ -196,7 +197,7 @@ static mp_obj_t usb_device_config(size_t n_args, const mp_obj_t *pos_args, mp_ma
     mp_obj_usb_device_t *self = (mp_obj_usb_device_t *)MP_OBJ_TO_PTR(pos_args[0]);
 
     enum { ARG_desc_dev, ARG_desc_cfg, ARG_desc_strs, ARG_open_itf_cb,
-           ARG_reset_cb, ARG_control_xfer_cb, ARG_xfer_cb, ARG_active };
+           ARG_reset_cb, ARG_control_xfer_cb, ARG_xfer_cb, ARG_desc_bos };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_desc_dev, MP_ARG_OBJ | MP_ARG_REQUIRED },
         { MP_QSTR_desc_cfg, MP_ARG_OBJ | MP_ARG_REQUIRED },
@@ -205,6 +206,7 @@ static mp_obj_t usb_device_config(size_t n_args, const mp_obj_t *pos_args, mp_ma
         { MP_QSTR_reset_cb, MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_control_xfer_cb, MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_xfer_cb, MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_desc_bos, MP_ARG_OBJ, {.u_obj = mp_const_none} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -213,6 +215,7 @@ static mp_obj_t usb_device_config(size_t n_args, const mp_obj_t *pos_args, mp_ma
     mp_obj_t desc_dev = args[ARG_desc_dev].u_obj;
     mp_obj_t desc_cfg = args[ARG_desc_cfg].u_obj;
     mp_obj_t desc_strs = args[ARG_desc_strs].u_obj;
+    mp_obj_t desc_bos = args[ARG_desc_bos].u_obj;
     if (!MP_OBJ_TYPE_HAS_SLOT(mp_obj_get_type(desc_dev), buffer)) {
         mp_raise_ValueError(MP_ERROR_TEXT("desc_dev"));
     }
@@ -223,10 +226,15 @@ static mp_obj_t usb_device_config(size_t n_args, const mp_obj_t *pos_args, mp_ma
         && !MP_OBJ_TYPE_HAS_SLOT(mp_obj_get_type(desc_strs), subscr)) {
         mp_raise_ValueError(MP_ERROR_TEXT("desc_strs"));
     }
+    if (desc_bos != mp_const_none
+        && !MP_OBJ_TYPE_HAS_SLOT(mp_obj_get_type(desc_bos), buffer)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("desc_bos"));
+    }
 
     self->desc_dev = desc_dev;
     self->desc_cfg = desc_cfg;
     self->desc_strs = desc_strs;
+    self->desc_bos = desc_bos;
     self->open_itf_cb = args[ARG_open_itf_cb].u_obj;
     self->reset_cb = args[ARG_reset_cb].u_obj;
     self->control_xfer_cb = args[ARG_control_xfer_cb].u_obj;

--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -52,8 +52,8 @@ manage the ESP32 microcontroller, as well as a way to manage the required
 build environment and toolchains needed to build the firmware.
 
 The ESP-IDF changes quickly and MicroPython only supports certain versions. The
-current recommended version of ESP-IDF for MicroPython is v5.5.2. MicroPython
-also supports v5.3, v5.4, v5.4.1, v5.4.2, v5.5.1 and v5.5.4.
+current recommended version of ESP-IDF for MicroPython is v5.5.5. MicroPython
+also supports v5.3, v5.4, v5.4.1, v5.4.2, v5.5.1, v5.5.2 and v5.5.4.
 
 <!-- Important: If updating the above, please also update:
      * IDF_OLDEST_VER & IDF_NEWEST_VER in .github/workflows/port_esp32.yml

--- a/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
@@ -13,6 +13,9 @@
 
 #define MICROPY_PY_MACHINE_SDCARD           (1)
 #define MICROPY_HW_SDMMC_LDO_CHAN_ID        (4)
+// This board wires the SD/MMC card to SDMMC slot 0 with a full 4-bit bus.
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (0)
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (4)
 
 #ifndef USB_SERIAL_JTAG_PACKET_SZ_BYTES
 #define USB_SERIAL_JTAG_PACKET_SZ_BYTES (64)

--- a/ports/esp32/lockfiles/dependencies.lock.esp32
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32
@@ -25,7 +25,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/lan867x
 - espressif/mdns

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c2
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c3
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c5
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c5
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c6
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c6
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32h2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32h2
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32p4
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32p4
@@ -81,7 +81,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/esp_hosted
 - espressif/esp_wifi_remote

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s2
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s3
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/ports/esp32/machine_sdcard.h
+++ b/ports/esp32/machine_sdcard.h
@@ -26,6 +26,17 @@
 #ifndef MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
 #define MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
 
+// Default slot and bus width for a native SD/MMC machine.SDCard(). These are
+// conservative defaults (the historically usable slot 1, 1-bit); which slot is
+// wired and how many data lines are routed is board specific, so a board should
+// override these in its mpconfigboard.h to match its layout.
+#ifndef MICROPY_HW_SDMMC_DEFAULT_SLOT
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
+#endif
+#ifndef MICROPY_HW_SDMMC_DEFAULT_WIDTH
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (1)
+#endif
+
 // Default pins for the primary SPI-mode SD card bus (slot 2). SPI mode is
 // available on every ESP32 variant, so a board may override these in its
 // mpconfigboard.h to make machine.SDCard(slot=2) work without explicit pins.

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -150,8 +150,11 @@ soft_reset:
     machine_i2s_init0();
     #endif
 
-    // run boot-up scripts
-    pyexec_frozen_module("_boot.py", false);
+    // Run optional frozen boot code.
+    #ifdef MICROPY_BOARD_FROZEN_BOOT_FILE
+    pyexec_frozen_module(MICROPY_BOARD_FROZEN_BOOT_FILE, false);
+    #endif
+
     int ret = pyexec_file_if_exists("boot.py");
 
     #if MICROPY_HW_ENABLE_USBDEV

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -326,9 +326,7 @@ static mp_obj_t machine_wake_pins(void) {
 
     // Only a few (~8) pins might cause wakeup.
     // Therefore, we calculate the required space in a first pass.
-    for (index = 0, len = 0; index < 64; index++) {
-        len += (status & (1ULL << index)) ? 1 : 0;
-    }
+    len = mp_popcount(status >> 32) + mp_popcount(status & 0xFFFFFFFF);
     if (len) {
         mp_obj_tuple_t *tuple = MP_OBJ_TO_PTR(mp_obj_new_tuple(len, NULL));
 

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -224,20 +224,6 @@
 #ifndef MICROPY_HW_ENABLE_SDCARD
 #define MICROPY_HW_ENABLE_SDCARD            (1)
 #endif
-#ifndef MICROPY_HW_SDMMC_DEFAULT_SLOT
-#if CONFIG_IDF_TARGET_ESP32P4
-#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (0)
-#else
-#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
-#endif
-#endif
-#ifndef MICROPY_HW_SDMMC_DEFAULT_WIDTH
-#if CONFIG_IDF_TARGET_ESP32P4
-#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (4)
-#else
-#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (1)
-#endif
-#endif
 #define MICROPY_HW_SOFTSPI_MIN_DELAY        (0)
 #define MICROPY_HW_SOFTSPI_MAX_BAUDRATE     (esp_rom_get_cpu_ticks_per_us() * 1000000 / 200) // roughly
 #define MICROPY_PY_SSL                      (MICROPY_PY_NETWORK)

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -425,6 +425,10 @@ typedef long mp_off_t;
 #define MICROPY_BOARD_STARTUP boardctrl_startup
 #endif
 
+#ifndef MICROPY_BOARD_FROZEN_BOOT_FILE
+#define MICROPY_BOARD_FROZEN_BOOT_FILE "_boot.py"
+#endif
+
 void boardctrl_startup(void);
 
 #ifndef MICROPY_PY_NETWORK_LAN

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -39,9 +39,9 @@
 // as well as a fallback to generate MICROPY_GIT_TAG if the git repo or tags
 // are unavailable.
 #define MICROPY_VERSION_MAJOR 1
-#define MICROPY_VERSION_MINOR 29
+#define MICROPY_VERSION_MINOR 30
 #define MICROPY_VERSION_MICRO 0
-#define MICROPY_VERSION_PRERELEASE 0
+#define MICROPY_VERSION_PRERELEASE 1
 
 // Combined version as a 32-bit number for convenience to allow version
 // comparison. Doesn't include prerelease state.

--- a/shared/tinyusb/mp_usbd.h
+++ b/shared/tinyusb/mp_usbd.h
@@ -125,6 +125,7 @@ typedef struct {
 
     mp_obj_t desc_dev; // Device descriptor bytes
     mp_obj_t desc_cfg; // Configuration descriptor bytes
+    mp_obj_t desc_bos; // BOS descriptor bytes, or None if not provided
     mp_obj_t desc_strs; // List/dict/similar to look up string descriptors by index
 
     // Runtime device driver callback functions

--- a/shared/tinyusb/mp_usbd_runtime.c
+++ b/shared/tinyusb/mp_usbd_runtime.c
@@ -126,6 +126,14 @@ const uint8_t *tud_descriptor_configuration_cb(uint8_t index) {
     return result ? result : &mp_usbd_builtin_desc_cfg;
 }
 
+const uint8_t *tud_descriptor_bos_cb(void) {
+    mp_obj_usb_device_t *usbd = MP_OBJ_TO_PTR(MP_STATE_VM(usbd));
+    if (!usbd) {
+        return NULL;
+    }
+    return usbd_get_buffer_in_cb(usbd->desc_bos, MP_BUFFER_READ);
+}
+
 #if (CFG_TUD_MAX_SPEED == OPT_MODE_HIGH_SPEED)
 uint8_t const *tud_descriptor_device_qualifier_cb(void) {
     return (const uint8_t *)&mp_usbd_builtin_desc_qual;

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -123,6 +123,7 @@ function ci_code_size_build {
             OUTFILE=$2
             IGNORE_ERRORS=$3
 
+            git restore ports/esp32/lockfiles/*  # esp32 port may update local lockfile
             git checkout --detach $COMMIT
             git submodule update --init $SUBMODULES
             git show -s


### PR DESCRIPTION

# shared/tinyusb: Add desc_bos support to runtime USBDevice.

## Why

`tud_descriptor_bos_cb()` is unimplemented anywhere in `shared/tinyusb`, so a
runtime USB device declaring `bcdUSB` 0x0210 or higher promises a BOS descriptor
and can then only stall the request. That blocks any Python device needing MS OS
2.0 descriptors for driverless Windows binding, which is carried in a BOS
platform capability.

## What

An optional `desc_bos` keyword on `USBDevice.config()`, stored and exposed the
same way `desc_dev` and `desc_cfg` already are. `tud_descriptor_bos_cb()`
returns it, and returns NULL when no runtime device is active or none was
configured, so the request stalls exactly as before. Unlike `desc_dev` and
`desc_cfg` there is no built-in descriptor to fall back to.

Buffer lifetime follows the same rule as its neighbours: the reference is a
field of `mp_obj_usb_device_t`, which the GC scans as part of that block.

Also drops `ARG_active` from the local arg enum in `usb_device_config()`, which
had no corresponding `allowed_args` entry and was unused; appending after it
would have indexed past the parsed args array.

## Testing

Build-verified on stm32 (NUCLEO-H563ZI under `MICROPY_HW_TINYUSB_STACK`) and the
symbol is present in the linked firmware. **Not exercised**: no host has fetched
a BOS descriptor from it.

### Outstanding before this goes upstream

- Exercise it on the bench. GET_DESCRIPTOR(BOS) has never been served by this code; it compiles, links, and `nm` shows the symbol, and that is all that is known.
- Confirm Linux's usbcore actually fetches the BOS at bcdUSB 0x0210 on this device, and that the two-stage fetch (5-byte header, then wTotalLength) is answered consistently.
- Decide whether a unit test is feasible. There is no existing test infrastructure for machine.USBDevice callbacks in the submodule, which is the same gap the vendor-control branch has.

---
*Draft raised on the fork for review. Base is the fork's own branch, not upstream.*
