### PR TITLE
shared/tinyusb: Queue transfers per endpoint in runtime USBDevice.

### DIFF
--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -20,7 +20,7 @@ concurrency:
 env:
    # Oldest and newest supported ESP-IDF versions, should match ports/esp32/README.md
    IDF_OLDEST_VER: &oldest "v5.3"
-   IDF_NEWEST_VER: &newest "v5.5.2"
+   IDF_NEWEST_VER: &newest "v5.5.5"
 
 jobs:
   build_idf:

--- a/docs/library/machine.USBDevice.rst
+++ b/docs/library/machine.USBDevice.rst
@@ -234,9 +234,16 @@ Methods
                transfers are built up through successive executions of
                ``control_xfer_cb``, see above.
 
-            Returns ``True`` if successful, ``False`` if the transfer could not
-            be queued (as USB device is not configured by host, or because
-            another transfer is queued on this endpoint.)
+            Returns ``True`` if the transfer was queued, or ``False`` if it was
+            refused because the USB device is not configured by the host.
+
+            An endpoint holds a small queue of outstanding transfers rather
+            than one at a time. Raises ``OSError`` with reason ``MP_EBUSY`` if
+            the endpoint's queue is already full; call again once an earlier
+            transfer on the same endpoint has completed. Completions are
+            delivered to ``xfer_cb`` in the order the transfers were
+            submitted, which is what lets a caller match a completion to the
+            buffer it submitted.
 
             When the USB host completes the transfer, the ``xfer_cb`` callback
             is called (see above).

--- a/extmod/machine_usb_device.c
+++ b/extmod/machine_usb_device.c
@@ -63,8 +63,13 @@ static mp_obj_t usb_device_make_new(const mp_obj_type_t *type, size_t n_args, si
         o->control_xfer_cb = mp_const_none;
         o->xfer_cb = mp_const_none;
         for (int i = 0; i < CFG_TUD_ENDPPOINT_MAX; i++) {
-            o->xfer_data[i][0] = mp_const_none;
-            o->xfer_data[i][1] = mp_const_none;
+            for (int dir = 0; dir < 2; dir++) {
+                for (int slot = 0; slot < MICROPY_HW_USB_XFER_QUEUE_DEPTH; slot++) {
+                    o->xfer_data[i][dir][slot] = mp_const_none;
+                }
+                o->xfer_head[i][dir] = 0;
+                o->xfer_num[i][dir] = 0;
+            }
         }
         o->builtin_driver = MP_OBJ_FROM_PTR(&mp_type_usb_device_builtin_none);
         o->active = false; // Builtin USB may be active already, but runtime is inactive
@@ -93,7 +98,6 @@ static mp_obj_t usb_device_submit_xfer(mp_obj_t self, mp_obj_t ep, mp_obj_t buff
     mp_obj_usb_device_t *usbd = (mp_obj_usb_device_t *)MP_OBJ_TO_PTR(self);
     int ep_addr;
     mp_buffer_info_t buf_info = { 0 };
-    bool result;
 
     usb_device_check_active(usbd);
 
@@ -113,23 +117,31 @@ static mp_obj_t usb_device_submit_xfer(mp_obj_t self, mp_obj_t ep, mp_obj_t buff
         mp_raise_ValueError(MP_ERROR_TEXT("ep"));
     }
 
-    if (!usbd_edpt_claim(RHPORT, ep_addr)) {
+    uint8_t queued = usbd->xfer_num[ep_num][ep_dir];
+
+    if (queued >= MICROPY_HW_USB_XFER_QUEUE_DEPTH) {
+        // As many transfers are outstanding on this endpoint as it can hold.
         mp_raise_OSError(MP_EBUSY);
     }
 
-    #if TUSB_VERSION_NUMBER >= 2001
-    // This submit path runs from the MicroPython scheduler, never an ISR.
-    result = usbd_edpt_xfer(RHPORT, ep_addr, buf_info.buf, buf_info.len, false);
-    #else
-    result = usbd_edpt_xfer(RHPORT, ep_addr, buf_info.buf, buf_info.len);
-    #endif
+    // Store the buffer object until the transfer completes, keeping it alive
+    // and recording the order completions will arrive in.
+    usbd->xfer_data[ep_num][ep_dir][(usbd->xfer_head[ep_num][ep_dir] + queued)
+                                    % MICROPY_HW_USB_XFER_QUEUE_DEPTH] = buffer;
+    usbd->xfer_num[ep_num][ep_dir] = queued + 1;
 
-    if (result) {
-        // Store the buffer object until the transfer completes
-        usbd->xfer_data[ep_num][ep_dir] = buffer;
+    if (queued == 0) {
+        // Nothing in progress, so this transfer starts now. A transfer that is
+        // already running will start this one from its completion callback
+        // instead, which is the point of the queue.
+        if (!mp_usbd_xfer_start_head(usbd, ep_addr)) {
+            usbd->xfer_data[ep_num][ep_dir][usbd->xfer_head[ep_num][ep_dir]] = mp_const_none;
+            usbd->xfer_num[ep_num][ep_dir] = 0;
+            return mp_const_false;
+        }
     }
 
-    return mp_obj_new_bool(result);
+    return mp_const_true;
 }
 static MP_DEFINE_CONST_FUN_OBJ_3(usb_device_submit_xfer_obj, usb_device_submit_xfer);
 

--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -52,8 +52,8 @@ manage the ESP32 microcontroller, as well as a way to manage the required
 build environment and toolchains needed to build the firmware.
 
 The ESP-IDF changes quickly and MicroPython only supports certain versions. The
-current recommended version of ESP-IDF for MicroPython is v5.5.2. MicroPython
-also supports v5.3, v5.4, v5.4.1, v5.4.2, v5.5.1 and v5.5.4.
+current recommended version of ESP-IDF for MicroPython is v5.5.5. MicroPython
+also supports v5.3, v5.4, v5.4.1, v5.4.2, v5.5.1, v5.5.2 and v5.5.4.
 
 <!-- Important: If updating the above, please also update:
      * IDF_OLDEST_VER & IDF_NEWEST_VER in .github/workflows/port_esp32.yml

--- a/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
@@ -13,6 +13,9 @@
 
 #define MICROPY_PY_MACHINE_SDCARD           (1)
 #define MICROPY_HW_SDMMC_LDO_CHAN_ID        (4)
+// This board wires the SD/MMC card to SDMMC slot 0 with a full 4-bit bus.
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (0)
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (4)
 
 #ifndef USB_SERIAL_JTAG_PACKET_SZ_BYTES
 #define USB_SERIAL_JTAG_PACKET_SZ_BYTES (64)

--- a/ports/esp32/lockfiles/dependencies.lock.esp32
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32
@@ -25,7 +25,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/lan867x
 - espressif/mdns

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c2
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c3
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c5
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c5
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c6
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c6
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32h2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32h2
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32p4
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32p4
@@ -81,7 +81,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/esp_hosted
 - espressif/esp_wifi_remote

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s2
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s3
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/ports/esp32/machine_sdcard.h
+++ b/ports/esp32/machine_sdcard.h
@@ -26,6 +26,17 @@
 #ifndef MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
 #define MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
 
+// Default slot and bus width for a native SD/MMC machine.SDCard(). These are
+// conservative defaults (the historically usable slot 1, 1-bit); which slot is
+// wired and how many data lines are routed is board specific, so a board should
+// override these in its mpconfigboard.h to match its layout.
+#ifndef MICROPY_HW_SDMMC_DEFAULT_SLOT
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
+#endif
+#ifndef MICROPY_HW_SDMMC_DEFAULT_WIDTH
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (1)
+#endif
+
 // Default pins for the primary SPI-mode SD card bus (slot 2). SPI mode is
 // available on every ESP32 variant, so a board may override these in its
 // mpconfigboard.h to make machine.SDCard(slot=2) work without explicit pins.

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -150,8 +150,11 @@ soft_reset:
     machine_i2s_init0();
     #endif
 
-    // run boot-up scripts
-    pyexec_frozen_module("_boot.py", false);
+    // Run optional frozen boot code.
+    #ifdef MICROPY_BOARD_FROZEN_BOOT_FILE
+    pyexec_frozen_module(MICROPY_BOARD_FROZEN_BOOT_FILE, false);
+    #endif
+
     int ret = pyexec_file_if_exists("boot.py");
 
     #if MICROPY_HW_ENABLE_USBDEV

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -326,9 +326,7 @@ static mp_obj_t machine_wake_pins(void) {
 
     // Only a few (~8) pins might cause wakeup.
     // Therefore, we calculate the required space in a first pass.
-    for (index = 0, len = 0; index < 64; index++) {
-        len += (status & (1ULL << index)) ? 1 : 0;
-    }
+    len = mp_popcount(status >> 32) + mp_popcount(status & 0xFFFFFFFF);
     if (len) {
         mp_obj_tuple_t *tuple = MP_OBJ_TO_PTR(mp_obj_new_tuple(len, NULL));
 

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -224,20 +224,6 @@
 #ifndef MICROPY_HW_ENABLE_SDCARD
 #define MICROPY_HW_ENABLE_SDCARD            (1)
 #endif
-#ifndef MICROPY_HW_SDMMC_DEFAULT_SLOT
-#if CONFIG_IDF_TARGET_ESP32P4
-#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (0)
-#else
-#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
-#endif
-#endif
-#ifndef MICROPY_HW_SDMMC_DEFAULT_WIDTH
-#if CONFIG_IDF_TARGET_ESP32P4
-#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (4)
-#else
-#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (1)
-#endif
-#endif
 #define MICROPY_HW_SOFTSPI_MIN_DELAY        (0)
 #define MICROPY_HW_SOFTSPI_MAX_BAUDRATE     (esp_rom_get_cpu_ticks_per_us() * 1000000 / 200) // roughly
 #define MICROPY_PY_SSL                      (MICROPY_PY_NETWORK)

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -425,6 +425,10 @@ typedef long mp_off_t;
 #define MICROPY_BOARD_STARTUP boardctrl_startup
 #endif
 
+#ifndef MICROPY_BOARD_FROZEN_BOOT_FILE
+#define MICROPY_BOARD_FROZEN_BOOT_FILE "_boot.py"
+#endif
+
 void boardctrl_startup(void);
 
 #ifndef MICROPY_PY_NETWORK_LAN

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -39,9 +39,9 @@
 // as well as a fallback to generate MICROPY_GIT_TAG if the git repo or tags
 // are unavailable.
 #define MICROPY_VERSION_MAJOR 1
-#define MICROPY_VERSION_MINOR 29
+#define MICROPY_VERSION_MINOR 30
 #define MICROPY_VERSION_MICRO 0
-#define MICROPY_VERSION_PRERELEASE 0
+#define MICROPY_VERSION_PRERELEASE 1
 
 // Combined version as a 32-bit number for convenience to allow version
 // comparison. Doesn't include prerelease state.

--- a/shared/tinyusb/mp_usbd.h
+++ b/shared/tinyusb/mp_usbd.h
@@ -120,6 +120,23 @@ const char *mp_usbd_runtime_string_cb(uint8_t index);
 // Maximum number of pending exceptions per single TinyUSB task execution
 #define MP_USBD_MAX_PEND_EXCS 2
 
+// How many transfers can be outstanding on one endpoint and direction.
+//
+// TinyUSB hands a single transfer at a time to the hardware, so a deeper
+// queue does not put more on the wire. What it does is let the completion
+// callback start the next transfer immediately, in C, instead of leaving the
+// endpoint idle until Python runs and submits one. Two entries is enough to
+// keep an endpoint busy when the application can produce a buffer per
+// transfer; raise it for producers that run in bursts.
+//
+// Costs one pointer per entry per endpoint and direction, plus two bytes of
+// bookkeeping per endpoint and direction.
+#ifndef MICROPY_HW_USB_XFER_QUEUE_DEPTH
+#define MICROPY_HW_USB_XFER_QUEUE_DEPTH (2)
+#endif
+// xfer_head/xfer_num below are uint8_t.
+MP_STATIC_ASSERT(MICROPY_HW_USB_XFER_QUEUE_DEPTH <= 255);
+
 typedef struct {
     mp_obj_base_t base;
 
@@ -138,9 +155,20 @@ typedef struct {
     bool active; // Has the user set the USB device active?
     bool trigger; // Has the user requested the active state change (or re-activate)?
 
-    // Temporary pointers for xfer data in progress on each endpoint
-    // Ensuring they aren't garbage collected until the xfer completes
-    mp_obj_t xfer_data[CFG_TUD_ENDPPOINT_MAX][2];
+    // Buffers for transfers submitted on each endpoint and direction, held
+    // so they are not garbage collected while the hardware still owns them.
+    //
+    // Each endpoint and direction is a FIFO: `xfer_head` indexes the entry
+    // holding the transfer currently in progress, and `xfer_num` counts the
+    // entries queued behind it, that one included. Completions arrive in
+    // submission order, which is what lets a caller match a completion to the
+    // buffer it submitted.
+    //
+    // Endpoint 0 is not reachable from submit_xfer() and uses only the first
+    // entry, to hold control transfer data.
+    mp_obj_t xfer_data[CFG_TUD_ENDPPOINT_MAX][2][MICROPY_HW_USB_XFER_QUEUE_DEPTH];
+    uint8_t xfer_head[CFG_TUD_ENDPPOINT_MAX][2];
+    uint8_t xfer_num[CFG_TUD_ENDPPOINT_MAX][2];
 
     // Pointer to a memoryview that is reused to refer to various pieces of
     // control transfer data that are pushed to USB control transfer
@@ -153,6 +181,12 @@ typedef struct {
     mp_uint_t num_pend_excs;
     mp_obj_t pend_excs[MP_USBD_MAX_PEND_EXCS];
 } mp_obj_usb_device_t;
+
+// Hand the buffer at the head of an endpoint's queue to TinyUSB.
+//
+// Returns false if the queue is empty, the endpoint could not be claimed, or
+// the transfer was refused. The entry stays queued in the latter two cases.
+bool mp_usbd_xfer_start_head(mp_obj_usb_device_t *usbd, uint8_t ep_addr);
 
 // Built-in constant objects, possible values of builtin_driver
 //

--- a/shared/tinyusb/mp_usbd_runtime.c
+++ b/shared/tinyusb/mp_usbd_runtime.c
@@ -175,7 +175,11 @@ static void runtime_dev_reset(uint8_t rhport) {
 
     for (int epnum = 0; epnum < CFG_TUD_ENDPPOINT_MAX; epnum++) {
         for (int dir = 0; dir < 2; dir++) {
-            usbd->xfer_data[epnum][dir] = mp_const_none;
+            for (int slot = 0; slot < MICROPY_HW_USB_XFER_QUEUE_DEPTH; slot++) {
+                usbd->xfer_data[epnum][dir][slot] = mp_const_none;
+            }
+            usbd->xfer_head[epnum][dir] = 0;
+            usbd->xfer_num[epnum][dir] = 0;
         }
     }
 
@@ -337,7 +341,7 @@ static bool runtime_dev_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_cont
 
         if (result) {
             // Keep buffer object alive until the transfer completes
-            usbd->xfer_data[0][dir] = cb_res;
+            usbd->xfer_data[0][dir][0] = cb_res;
         }
     } else {
         // Expect True or False to stall or continue
@@ -349,10 +353,40 @@ static bool runtime_dev_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_cont
             tud_control_status(rhport, request);
         } else if (stage == CONTROL_STAGE_ACK) {
             // Allow data to be GCed once it's no longer in use
-            usbd->xfer_data[0][dir] = mp_const_none;
+            usbd->xfer_data[0][dir][0] = mp_const_none;
         }
     }
 
+    return result;
+}
+
+bool mp_usbd_xfer_start_head(mp_obj_usb_device_t *usbd, uint8_t ep_addr) {
+    uint8_t epnum = tu_edpt_number(ep_addr);
+    uint8_t dir = tu_edpt_dir(ep_addr);
+
+    if (usbd->xfer_num[epnum][dir] == 0) {
+        return false;
+    }
+
+    mp_buffer_info_t buf_info;
+    mp_obj_t buffer = usbd->xfer_data[epnum][dir][usbd->xfer_head[epnum][dir]];
+    if (!mp_get_buffer(buffer, &buf_info, dir == TUSB_DIR_IN ? MP_BUFFER_READ : MP_BUFFER_RW)) {
+        return false;
+    }
+
+    if (!usbd_edpt_claim(RHPORT, ep_addr)) {
+        return false;
+    }
+
+    #if TUSB_VERSION_NUMBER >= 2001
+    bool result = usbd_edpt_xfer(RHPORT, ep_addr, buf_info.buf, buf_info.len, false);
+    #else
+    bool result = usbd_edpt_xfer(RHPORT, ep_addr, buf_info.buf, buf_info.len);
+    #endif
+
+    if (!result) {
+        usbd_edpt_release(RHPORT, ep_addr);
+    }
     return result;
 }
 
@@ -364,6 +398,22 @@ static bool runtime_dev_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t r
         return false;
     }
 
+    uint8_t epnum = tu_edpt_number(ep_addr);
+    uint8_t dir = tu_edpt_dir(ep_addr);
+
+    // Retire the completed transfer and start whatever was queued behind it
+    // before running the Python callback, so the endpoint is not left idle for
+    // however long that callback takes. Clearing the buffer reference here is
+    // what lets the callback submit: a buffer it queues must outlive this
+    // function.
+    if (usbd->xfer_num[epnum][dir] > 0) {
+        usbd->xfer_data[epnum][dir][usbd->xfer_head[epnum][dir]] = mp_const_none;
+        usbd->xfer_head[epnum][dir] =
+            (usbd->xfer_head[epnum][dir] + 1) % MICROPY_HW_USB_XFER_QUEUE_DEPTH;
+        usbd->xfer_num[epnum][dir]--;
+        mp_usbd_xfer_start_head(usbd, ep_addr);
+    }
+
     if (mp_obj_is_callable(usbd->xfer_cb)) {
         mp_obj_t args[] = {
             ep,
@@ -372,9 +422,6 @@ static bool runtime_dev_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t r
         };
         cb_res = usbd_callback_function_n(usbd->xfer_cb, MP_ARRAY_SIZE(args), args);
     }
-
-    // Clear any xfer_data for this endpoint
-    usbd->xfer_data[tu_edpt_number(ep_addr)][tu_edpt_dir(ep_addr)] = mp_const_none;
 
     return cb_res != MP_OBJ_NULL && mp_obj_is_true(cb_res);
 }
@@ -475,9 +522,13 @@ static void mp_usbd_disconnect(mp_obj_usb_device_t *usbd) {
         // TODO: figure out if we really need this
         for (int epnum = 0; epnum < CFG_TUD_ENDPPOINT_MAX; epnum++) {
             for (int dir = 0; dir < 2; dir++) {
-                if (usbd->xfer_data[epnum][dir] != mp_const_none) {
+                if (usbd->xfer_num[epnum][dir] > 0) {
                     usbd_edpt_stall(RHPORT, tu_edpt_addr(epnum, dir));
-                    usbd->xfer_data[epnum][dir] = mp_const_none;
+                    for (int slot = 0; slot < MICROPY_HW_USB_XFER_QUEUE_DEPTH; slot++) {
+                        usbd->xfer_data[epnum][dir][slot] = mp_const_none;
+                    }
+                    usbd->xfer_head[epnum][dir] = 0;
+                    usbd->xfer_num[epnum][dir] = 0;
                 }
             }
         }

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -123,6 +123,7 @@ function ci_code_size_build {
             OUTFILE=$2
             IGNORE_ERRORS=$3
 
+            git restore ports/esp32/lockfiles/*  # esp32 port may update local lockfile
             git checkout --detach $COMMIT
             git submodule update --init $SUBMODULES
             git show -s


### PR DESCRIPTION
**Branch:** `feature/usbd-xfer-queue`
**Base:** `micropython/micropython:master`

### Summary

I was chasing dropped CAN frames on a `machine.USBDevice` based gs_usb adapter and found the ceiling was not the bus. `submit_xfer()` holds exactly one buffer per endpoint and direction and refuses anything further with `EBUSY`, so an endpoint has nothing to start when a transfer completes until Python has run and submitted the next one.

TinyUSB takes one transfer at a time per endpoint, so this cannot put more on the wire and does not try to. It lets the completion callback start the next queued transfer in C, before entering Python, so an endpoint that has work queued never waits for Python to arm it.

Its value depends entirely on a driver submitting more than one transfer. A companion micropython-lib change does that for CDC, and against that the difference is worth having: host to device throughput on an STM32H563 goes from 107 kB/s to 126 kB/s, about 18%.

That library change stands on its own. Where this queue is absent the second submission reports EBUSY, the driver carries on with one transfer at a time, and nothing misbehaves. So the two can land in either order.

With a driver that submits one at a time regardless, this change does nothing, by construction.

```mermaid
sequenceDiagram
    participant HW as Endpoint
    participant C as runtime_dev_xfer_cb
    participant PY as Python xfer_cb
    Note over HW,PY: before
    HW->>C: A completes
    C->>PY: callback
    PY->>HW: submit B
    Note over HW,PY: endpoint idle for the whole callback
    Note over HW,PY: after
    HW->>C: A completes
    C->>HW: start B from the queue
    C->>PY: callback
    PY->>C: submit C, queued
```

`xfer_data` gains a third dimension and two counters, forming a FIFO per endpoint and direction. Depth is `MICROPY_HW_USBD_XFER_QUEUE_DEPTH`, default 2, which is the smallest depth that keeps an endpoint busy when the application can produce one buffer per transfer. Completions arrive in submission order so a caller can match one to the buffer it submitted. Endpoint 0 keeps a single entry for control transfer data.

The change also closes a way for a submitted buffer to lose its only reference. The completed entry used to be cleared *after* the Python callback returned, which discarded whatever that callback had just submitted; it is now retired before the callback runs. Callers who resubmit from the callback, the pattern the docs suggest, were relying on holding their own reference.

### Testing

Built for `NUCLEO_H563ZI` with `MICROPY_HW_TINYUSB_STACK`.

CDC data OUT, driven by a host writing as fast as it is allowed to, four runs per build:

| | kB/s |
|---|---|
| upstream library, upstream lower layer | 96 |
| queueing library, upstream lower layer | 107 |
| queueing library, this change | 126 |

The middle row is the one that matters for review order: the library change is safe without this.

A bulk loopback with nothing else in the path, 20 byte transfers, three or four runs per point:

| host transfers outstanding | depth 1 | depth 2 |
|---|---|---|
| 1 (synchronous read loop) | 3261/s | 3562/s |
| 8 (libusb async) | 3474/s | 3546/s |

Run to run spread there is under 1%. Depth 2 reaches the same rate whichever host it talks to, while a single entry costs about 6% against a host that does not pipeline. It does not raise the ceiling: at around 3550 transfers/s the device is out of CPU rather than out of endpoint availability, and no depth changes that. I had expected the queue to hide per-transfer Python work behind the transfer and it does not, because the completion callback runs in the same dispatch that re-arms the endpoint.

A gs_usb device driven by the mainline kernel driver was unaffected, as expected: its data plane submits one buffer at a time.

Not tested on a port other than stm32.

### Trade-offs and Alternatives

Costs one pointer per queue entry per endpoint and direction, plus two bytes of bookkeeping, on a structure allocated once. At the default depth on a part with nine endpoints that is under 130 bytes of heap, and depth 1 restores the previous footprint exactly.

The alternative is queuing inside TinyUSB so several transfers are genuinely outstanding on the wire. That needs changes to the device stack and to every DCD, and it is not what limits this path: at 20 bytes per transfer the wire is nowhere near busy. Removing Python from between transfers is where the time is.

Raising the default beyond 2 was tempting but only helps producers that run in bursts, and it costs everyone memory. It is left to boards.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the description above.

---
*Draft raised on the fork for review. Base is the fork's own branch, not upstream.*
