### PR TITLE
mimxrt: Enable machine.USBDevice.

### DIFF
--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -20,7 +20,7 @@ concurrency:
 env:
    # Oldest and newest supported ESP-IDF versions, should match ports/esp32/README.md
    IDF_OLDEST_VER: &oldest "v5.3"
-   IDF_NEWEST_VER: &newest "v5.5.2"
+   IDF_NEWEST_VER: &newest "v5.5.5"
 
 jobs:
   build_idf:

--- a/docs/library/machine.USBDevice.rst
+++ b/docs/library/machine.USBDevice.rst
@@ -4,9 +4,11 @@
 class USBDevice -- USB Device driver
 ====================================
 
-Availability: **ESP32, RP2, SAMD**
+Availability: **ESP32, RP2, SAMD, STM32, MIMXRT**
 
 .. note:: Native USB support is required, and not every board supports native USB.
+   On STM32 this also requires the board to use the TinyUSB stack
+   (``MICROPY_HW_TINYUSB_STACK``).
 
 USBDevice provides a low-level Python API for implementing USB device functions using
 Python code.

--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -52,8 +52,8 @@ manage the ESP32 microcontroller, as well as a way to manage the required
 build environment and toolchains needed to build the firmware.
 
 The ESP-IDF changes quickly and MicroPython only supports certain versions. The
-current recommended version of ESP-IDF for MicroPython is v5.5.2. MicroPython
-also supports v5.3, v5.4, v5.4.1, v5.4.2, v5.5.1 and v5.5.4.
+current recommended version of ESP-IDF for MicroPython is v5.5.5. MicroPython
+also supports v5.3, v5.4, v5.4.1, v5.4.2, v5.5.1, v5.5.2 and v5.5.4.
 
 <!-- Important: If updating the above, please also update:
      * IDF_OLDEST_VER & IDF_NEWEST_VER in .github/workflows/port_esp32.yml

--- a/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
@@ -13,6 +13,9 @@
 
 #define MICROPY_PY_MACHINE_SDCARD           (1)
 #define MICROPY_HW_SDMMC_LDO_CHAN_ID        (4)
+// This board wires the SD/MMC card to SDMMC slot 0 with a full 4-bit bus.
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (0)
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (4)
 
 #ifndef USB_SERIAL_JTAG_PACKET_SZ_BYTES
 #define USB_SERIAL_JTAG_PACKET_SZ_BYTES (64)

--- a/ports/esp32/lockfiles/dependencies.lock.esp32
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32
@@ -25,7 +25,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/lan867x
 - espressif/mdns

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c2
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c3
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c5
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c5
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c6
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c6
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32h2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32h2
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32p4
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32p4
@@ -81,7 +81,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/esp_hosted
 - espressif/esp_wifi_remote

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s2
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s3
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/ports/esp32/machine_sdcard.h
+++ b/ports/esp32/machine_sdcard.h
@@ -26,6 +26,17 @@
 #ifndef MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
 #define MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
 
+// Default slot and bus width for a native SD/MMC machine.SDCard(). These are
+// conservative defaults (the historically usable slot 1, 1-bit); which slot is
+// wired and how many data lines are routed is board specific, so a board should
+// override these in its mpconfigboard.h to match its layout.
+#ifndef MICROPY_HW_SDMMC_DEFAULT_SLOT
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
+#endif
+#ifndef MICROPY_HW_SDMMC_DEFAULT_WIDTH
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (1)
+#endif
+
 // Default pins for the primary SPI-mode SD card bus (slot 2). SPI mode is
 // available on every ESP32 variant, so a board may override these in its
 // mpconfigboard.h to make machine.SDCard(slot=2) work without explicit pins.

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -150,8 +150,11 @@ soft_reset:
     machine_i2s_init0();
     #endif
 
-    // run boot-up scripts
-    pyexec_frozen_module("_boot.py", false);
+    // Run optional frozen boot code.
+    #ifdef MICROPY_BOARD_FROZEN_BOOT_FILE
+    pyexec_frozen_module(MICROPY_BOARD_FROZEN_BOOT_FILE, false);
+    #endif
+
     int ret = pyexec_file_if_exists("boot.py");
 
     #if MICROPY_HW_ENABLE_USBDEV

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -326,9 +326,7 @@ static mp_obj_t machine_wake_pins(void) {
 
     // Only a few (~8) pins might cause wakeup.
     // Therefore, we calculate the required space in a first pass.
-    for (index = 0, len = 0; index < 64; index++) {
-        len += (status & (1ULL << index)) ? 1 : 0;
-    }
+    len = mp_popcount(status >> 32) + mp_popcount(status & 0xFFFFFFFF);
     if (len) {
         mp_obj_tuple_t *tuple = MP_OBJ_TO_PTR(mp_obj_new_tuple(len, NULL));
 

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -224,20 +224,6 @@
 #ifndef MICROPY_HW_ENABLE_SDCARD
 #define MICROPY_HW_ENABLE_SDCARD            (1)
 #endif
-#ifndef MICROPY_HW_SDMMC_DEFAULT_SLOT
-#if CONFIG_IDF_TARGET_ESP32P4
-#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (0)
-#else
-#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
-#endif
-#endif
-#ifndef MICROPY_HW_SDMMC_DEFAULT_WIDTH
-#if CONFIG_IDF_TARGET_ESP32P4
-#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (4)
-#else
-#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (1)
-#endif
-#endif
 #define MICROPY_HW_SOFTSPI_MIN_DELAY        (0)
 #define MICROPY_HW_SOFTSPI_MAX_BAUDRATE     (esp_rom_get_cpu_ticks_per_us() * 1000000 / 200) // roughly
 #define MICROPY_PY_SSL                      (MICROPY_PY_NETWORK)

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -425,6 +425,10 @@ typedef long mp_off_t;
 #define MICROPY_BOARD_STARTUP boardctrl_startup
 #endif
 
+#ifndef MICROPY_BOARD_FROZEN_BOOT_FILE
+#define MICROPY_BOARD_FROZEN_BOOT_FILE "_boot.py"
+#endif
+
 void boardctrl_startup(void);
 
 #ifndef MICROPY_PY_NETWORK_LAN

--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -299,6 +299,7 @@ SHARED_SRC_C += \
 	shared/tinyusb/mp_usbd.c \
 	shared/tinyusb/mp_usbd_cdc.c \
 	shared/tinyusb/mp_usbd_descriptor.c \
+	shared/tinyusb/mp_usbd_runtime.c \
 
 # Set flash driver name, base address and internal flash flag, based on the flash type.
 ifeq ($(MICROPY_HW_FLASH_TYPE),$(filter $(MICROPY_HW_FLASH_TYPE),qspi_nor_flash))

--- a/ports/mimxrt/main.c
+++ b/ports/mimxrt/main.c
@@ -206,6 +206,9 @@ int main(void) {
         #if MICROPY_PY_MACHINE_QECNT
         machine_encoder_deinit_all();
         #endif
+        #if MICROPY_HW_ENABLE_USB_RUNTIME_DEVICE
+        mp_usbd_deinit();
+        #endif
         gc_sweep_all();
         mp_deinit();
     }

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -183,6 +183,9 @@ uint32_t trng_random_u32(void);
 #endif
 
 #define MICROPY_HW_ENABLE_USBDEV            (1)
+#ifndef MICROPY_HW_ENABLE_USB_RUNTIME_DEVICE
+#define MICROPY_HW_ENABLE_USB_RUNTIME_DEVICE    (1) // Support machine.USBDevice
+#endif
 // Enable USB-CDC serial port
 #ifndef MICROPY_HW_USB_CDC
 #define MICROPY_HW_USB_CDC                  (1)

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -39,9 +39,9 @@
 // as well as a fallback to generate MICROPY_GIT_TAG if the git repo or tags
 // are unavailable.
 #define MICROPY_VERSION_MAJOR 1
-#define MICROPY_VERSION_MINOR 29
+#define MICROPY_VERSION_MINOR 30
 #define MICROPY_VERSION_MICRO 0
-#define MICROPY_VERSION_PRERELEASE 0
+#define MICROPY_VERSION_PRERELEASE 1
 
 // Combined version as a 32-bit number for convenience to allow version
 // comparison. Doesn't include prerelease state.

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -123,6 +123,7 @@ function ci_code_size_build {
             OUTFILE=$2
             IGNORE_ERRORS=$3
 
+            git restore ports/esp32/lockfiles/*  # esp32 port may update local lockfile
             git checkout --detach $COMMIT
             git submodule update --init $SUBMODULES
             git show -s


### PR DESCRIPTION
## What I found

`shared/tinyusb/mp_usbd_runtime.c` (the runtime `machine.USBDevice` support) is already portable across the TinyUSB device stack: esp32, rp2 and samd all build it, and stm32 does too once `MICROPY_HW_TINYUSB_STACK` is selected. mimxrt already builds on TinyUSB via the ChipIdea high-speed controller (`dcd_ci_hs.c`) but never compiled this file in, so `machine.USBDevice` simply didn't exist on the port.

## What this changes

Adds `shared/tinyusb/mp_usbd_runtime.c` to the mimxrt build, defines `MICROPY_HW_ENABLE_USB_RUNTIME_DEVICE` the same way esp32/rp2/samd/stm32 do, and calls `mp_usbd_deinit()` on soft reset alongside the port's other peripheral teardown, matching the other TinyUSB ports. Also updates the `machine.USBDevice` availability doc, which was missing both mimxrt and stm32 (the latter already supported it).

## Testing

Builds clean for `SEEED_ARCH_MIX`. Not yet exercised against a Python-defined USB configuration on real mimxrt hardware.

## Trade-offs and alternatives

None specific to this change: it's a config switch onto code four other ports already carry, not new logic.

## Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the description above.