### PR TITLE
stm32/mphalport: Don't let UART REPL poll overwrite USB CDC's.

### DIFF
--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -20,7 +20,7 @@ concurrency:
 env:
    # Oldest and newest supported ESP-IDF versions, should match ports/esp32/README.md
    IDF_OLDEST_VER: &oldest "v5.3"
-   IDF_NEWEST_VER: &newest "v5.5.2"
+   IDF_NEWEST_VER: &newest "v5.5.5"
 
 jobs:
   build_idf:

--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -52,8 +52,8 @@ manage the ESP32 microcontroller, as well as a way to manage the required
 build environment and toolchains needed to build the firmware.
 
 The ESP-IDF changes quickly and MicroPython only supports certain versions. The
-current recommended version of ESP-IDF for MicroPython is v5.5.2. MicroPython
-also supports v5.3, v5.4, v5.4.1, v5.4.2, v5.5.1 and v5.5.4.
+current recommended version of ESP-IDF for MicroPython is v5.5.5. MicroPython
+also supports v5.3, v5.4, v5.4.1, v5.4.2, v5.5.1, v5.5.2 and v5.5.4.
 
 <!-- Important: If updating the above, please also update:
      * IDF_OLDEST_VER & IDF_NEWEST_VER in .github/workflows/port_esp32.yml

--- a/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
@@ -13,6 +13,9 @@
 
 #define MICROPY_PY_MACHINE_SDCARD           (1)
 #define MICROPY_HW_SDMMC_LDO_CHAN_ID        (4)
+// This board wires the SD/MMC card to SDMMC slot 0 with a full 4-bit bus.
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (0)
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (4)
 
 #ifndef USB_SERIAL_JTAG_PACKET_SZ_BYTES
 #define USB_SERIAL_JTAG_PACKET_SZ_BYTES (64)

--- a/ports/esp32/lockfiles/dependencies.lock.esp32
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32
@@ -25,7 +25,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/lan867x
 - espressif/mdns

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c2
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c3
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c5
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c5
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c6
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c6
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32h2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32h2
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32p4
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32p4
@@ -81,7 +81,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/esp_hosted
 - espressif/esp_wifi_remote

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s2
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s3
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/ports/esp32/machine_sdcard.h
+++ b/ports/esp32/machine_sdcard.h
@@ -26,6 +26,17 @@
 #ifndef MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
 #define MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
 
+// Default slot and bus width for a native SD/MMC machine.SDCard(). These are
+// conservative defaults (the historically usable slot 1, 1-bit); which slot is
+// wired and how many data lines are routed is board specific, so a board should
+// override these in its mpconfigboard.h to match its layout.
+#ifndef MICROPY_HW_SDMMC_DEFAULT_SLOT
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
+#endif
+#ifndef MICROPY_HW_SDMMC_DEFAULT_WIDTH
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (1)
+#endif
+
 // Default pins for the primary SPI-mode SD card bus (slot 2). SPI mode is
 // available on every ESP32 variant, so a board may override these in its
 // mpconfigboard.h to make machine.SDCard(slot=2) work without explicit pins.

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -150,8 +150,11 @@ soft_reset:
     machine_i2s_init0();
     #endif
 
-    // run boot-up scripts
-    pyexec_frozen_module("_boot.py", false);
+    // Run optional frozen boot code.
+    #ifdef MICROPY_BOARD_FROZEN_BOOT_FILE
+    pyexec_frozen_module(MICROPY_BOARD_FROZEN_BOOT_FILE, false);
+    #endif
+
     int ret = pyexec_file_if_exists("boot.py");
 
     #if MICROPY_HW_ENABLE_USBDEV

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -326,9 +326,7 @@ static mp_obj_t machine_wake_pins(void) {
 
     // Only a few (~8) pins might cause wakeup.
     // Therefore, we calculate the required space in a first pass.
-    for (index = 0, len = 0; index < 64; index++) {
-        len += (status & (1ULL << index)) ? 1 : 0;
-    }
+    len = mp_popcount(status >> 32) + mp_popcount(status & 0xFFFFFFFF);
     if (len) {
         mp_obj_tuple_t *tuple = MP_OBJ_TO_PTR(mp_obj_new_tuple(len, NULL));
 

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -224,20 +224,6 @@
 #ifndef MICROPY_HW_ENABLE_SDCARD
 #define MICROPY_HW_ENABLE_SDCARD            (1)
 #endif
-#ifndef MICROPY_HW_SDMMC_DEFAULT_SLOT
-#if CONFIG_IDF_TARGET_ESP32P4
-#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (0)
-#else
-#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
-#endif
-#endif
-#ifndef MICROPY_HW_SDMMC_DEFAULT_WIDTH
-#if CONFIG_IDF_TARGET_ESP32P4
-#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (4)
-#else
-#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (1)
-#endif
-#endif
 #define MICROPY_HW_SOFTSPI_MIN_DELAY        (0)
 #define MICROPY_HW_SOFTSPI_MAX_BAUDRATE     (esp_rom_get_cpu_ticks_per_us() * 1000000 / 200) // roughly
 #define MICROPY_PY_SSL                      (MICROPY_PY_NETWORK)

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -425,6 +425,10 @@ typedef long mp_off_t;
 #define MICROPY_BOARD_STARTUP boardctrl_startup
 #endif
 
+#ifndef MICROPY_BOARD_FROZEN_BOOT_FILE
+#define MICROPY_BOARD_FROZEN_BOOT_FILE "_boot.py"
+#endif
+
 void boardctrl_startup(void);
 
 #ifndef MICROPY_PY_NETWORK_LAN

--- a/ports/stm32/mphalport.c
+++ b/ports/stm32/mphalport.c
@@ -45,7 +45,7 @@ MP_WEAK uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
         mp_obj_t pyb_stdio_uart = MP_OBJ_FROM_PTR(MP_STATE_PORT(pyb_stdio_uart));
         int errcode;
         const mp_stream_p_t *stream_p = mp_get_stream(pyb_stdio_uart);
-        ret = stream_p->ioctl(pyb_stdio_uart, MP_STREAM_POLL, poll_flags, &errcode);
+        ret |= stream_p->ioctl(pyb_stdio_uart, MP_STREAM_POLL, poll_flags, &errcode);
     }
     return ret | mp_os_dupterm_poll(poll_flags);
 }

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -39,9 +39,9 @@
 // as well as a fallback to generate MICROPY_GIT_TAG if the git repo or tags
 // are unavailable.
 #define MICROPY_VERSION_MAJOR 1
-#define MICROPY_VERSION_MINOR 29
+#define MICROPY_VERSION_MINOR 30
 #define MICROPY_VERSION_MICRO 0
-#define MICROPY_VERSION_PRERELEASE 0
+#define MICROPY_VERSION_PRERELEASE 1
 
 // Combined version as a 32-bit number for convenience to allow version
 // comparison. Doesn't include prerelease state.

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -123,6 +123,7 @@ function ci_code_size_build {
             OUTFILE=$2
             IGNORE_ERRORS=$3
 
+            git restore ports/esp32/lockfiles/*  # esp32 port may update local lockfile
             git checkout --detach $COMMIT
             git submodule update --init $SUBMODULES
             git show -s


### PR DESCRIPTION
mp_hal_stdio_poll() assigned rather than OR'd the UART branch's ioctl result, so on any board with both MICROPY_HW_UART_REPL and USB CDC configured, an idle UART silently discarded whatever readiness the CDC poll had just set.

mp_hal_stdin_rx_chr()'s own blocking loop checks UART, dupterm and the CDC ringbuf as separate sources and was unaffected, which is why this stayed latent: nothing exercised select.poll()-driven stdin (an asyncio REPL reading sys.stdin) on such a board until now.