### PR TITLE
extmod/asyncio: Add a native asyncio REPL

### DIFF
--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -20,7 +20,7 @@ concurrency:
 env:
    # Oldest and newest supported ESP-IDF versions, should match ports/esp32/README.md
    IDF_OLDEST_VER: &oldest "v5.3"
-   IDF_NEWEST_VER: &newest "v5.5.2"
+   IDF_NEWEST_VER: &newest "v5.5.5"
 
 jobs:
   build_idf:

--- a/docs/library/asyncio.rst
+++ b/docs/library/asyncio.rst
@@ -361,3 +361,65 @@ Event Loop
 
     Call the current exception handler.  The argument *context* is passed through and
     is a dictionary containing keys: ``'message'``, ``'exception'``, ``'future'``.
+
+
+Interactive REPL
+----------------
+
+.. module:: asyncio.arepl
+    :synopsis: asyncio-based interactive REPL
+
+``asyncio.arepl`` provides an interactive REPL that runs as an asyncio task, so
+the event loop and any other tasks keep running while it waits for input.  The
+REPL can therefore share a single thread with networking, USB and other
+background work.  Line editing, paste mode, raw and raw-paste mode, and
+synchronous statement execution are handled by the underlying C REPL; only
+complete lines containing ``await`` are run on the event loop.
+
+On ports that enable ``MICROPY_REPL_ASYNCIO`` (the default at the
+``EXTRA_FEATURES`` ROM level) and freeze ``asyncio.arepl``, this is the REPL the
+board boots into.
+
+.. note::
+
+    Import the module as ``import asyncio.arepl``.  ``from asyncio import arepl``
+    does not work, because :mod:`asyncio` resolves attribute access through
+    ``__getattr__`` before falling back to importing a submodule.
+
+.. function:: task(stop_loop_on_exit=True, persistent=False)
+
+    Run the REPL.  This is a coroutine: ``await`` it, or schedule it with
+    `asyncio.create_task`.  Executed code runs in the main global namespace.
+
+    *stop_loop_on_exit* controls what Ctrl-D does.  When ``True`` (the default)
+    Ctrl-D stops the event loop, which lets a boot REPL perform a soft reset.
+    Set it to ``False`` to run the REPL as one task among others, so that Ctrl-D
+    ends only the REPL task and leaves the loop and the other tasks running.
+
+    *persistent*, when ``True``, makes Ctrl-D re-prompt instead of exiting, so
+    the console stays available for the lifetime of the program.  The task still
+    returns if ``sys.stdin`` is closed.
+
+    For example, to run the REPL as a long-lived console alongside other tasks:
+
+    .. code-block:: python3
+
+        import asyncio
+        import asyncio.arepl
+
+        async def main():
+            asyncio.create_task(background_work())
+            await asyncio.arepl.task(stop_loop_on_exit=False, persistent=True)
+
+        asyncio.run(main())
+
+.. function:: breakpoint()
+
+    Drop into a blocking interactive REPL from async code, as an awaitable
+    breakpoint::
+
+        await asyncio.arepl.breakpoint()
+
+    It returns when Ctrl-D is pressed, resuming the awaiting code.  Internally it
+    uses :func:`micropython.repl`, which saves and restores REPL state so it
+    nests safely inside a running `task`.

--- a/docs/library/micropython.rst
+++ b/docs/library/micropython.rst
@@ -266,7 +266,7 @@ Functions
    This backs :func:`asyncio.arepl.breakpoint`, providing a synchronous
    breakpoint-style REPL from within async code.
 
-   Availability: Requires ``MICROPY_REPL_ASYNCIO``.
+   Availability: Requires ``MICROPY_REPL_ASYNCIO_BREAKPOINT``.
 
 .. function:: repl_event_init()
 

--- a/docs/library/micropython.rst
+++ b/docs/library/micropython.rst
@@ -245,6 +245,60 @@ Functions
    as the first argument (and ``None`` as the second argument), and that will
    schedule a `KeyboardInterrupt` to be raised "very soon" in the main thread.
 
+.. function:: stdio_mode_raw(enabled)
+
+   Switch the terminal (stdin/stdout) between raw and original mode.  When
+   *enabled* is ``True`` the terminal is placed in raw mode (no echo, no line
+   editing, characters available immediately).  When *enabled* is ``False`` the
+   terminal settings are restored to their original state.
+
+   This is useful for code that needs to take over terminal I/O, for example
+   an alternative REPL such as ``asyncio.arepl``.
+
+   Availability: Unix port.  Requires ``MICROPY_PY_MICROPYTHON_STDIO_RAW``.
+
+.. function:: repl()
+
+   Enter a blocking interactive REPL.  Ctrl-D returns to the caller.  The
+   terminal's raw mode is set on entry and restored on return, even if an
+   exception is raised.
+
+   This backs :func:`asyncio.arepl.breakpoint`, providing a synchronous
+   breakpoint-style REPL from within async code.
+
+   Availability: Requires ``MICROPY_REPL_ASYNCIO``.
+
+.. function:: repl_event_init()
+
+   Start the event-driven REPL used to build an asyncio REPL: print the banner
+   and the first prompt, then accept input one character at a time via
+   :func:`repl_event`.  Most code should use :mod:`asyncio.arepl` instead of
+   driving the REPL directly.
+
+   Availability: Requires ``MICROPY_REPL_ASYNCIO``.
+
+.. function:: repl_event(c)
+
+   Feed the single character *c* (an integer) to the event-driven REPL, which
+   echoes, edits and, on a complete line, executes it.  Returns either:
+
+   - a coroutine: a complete line containing a top-level ``await``, compiled to a
+     coroutine that the caller should run on the event loop, then call
+     :func:`repl_event_resume`; or
+   - an integer status, with bit ``0x100`` set on Ctrl-D (exit / soft reset) and
+     bit ``0x400`` set while the REPL is in raw mode (the caller should keep
+     feeding input without yielding so other output cannot corrupt the transfer).
+
+   Availability: Requires ``MICROPY_REPL_ASYNCIO``.
+
+.. function:: repl_event_resume()
+
+   Reset the input line and print a fresh prompt, after the caller has run the
+   deferred coroutine returned by :func:`repl_event`.
+
+   Availability: Requires ``MICROPY_REPL_ASYNCIO``.
+
+
 Classes
 -------
 

--- a/extmod/asyncio/arepl.py
+++ b/extmod/asyncio/arepl.py
@@ -90,7 +90,13 @@ async def _async_exec(coro, s, pending):
 # raw REPL, raw-paste and synchronous execution happen in C; only complete lines
 # containing top-level `await` are compiled to a coroutine and handed back here
 # to run on the event loop.
-async def task():
+#
+# stop_loop_on_exit: on Ctrl-D stop the event loop (default), so a boot REPL
+#   soft-resets; set False to just end this task and leave the loop and any
+#   other tasks running.
+# persistent: if True, Ctrl-D re-prompts instead of exiting, keeping the console
+#   up for the life of the program (it still ends if stdin closes).
+async def task(stop_loop_on_exit=True, persistent=False):
     # Deliver Ctrl-C as a byte to the REPL rather than raising KeyboardInterrupt.
     micropython.kbd_intr(-1)
     _stdio_raw(True)
@@ -159,8 +165,14 @@ async def task():
                 await _async_exec(r, s, pending)
                 micropython.repl_event_resume()
             elif r & _PYEXEC_FORCED_EXIT:
-                # Ctrl-D: end the REPL and let the boot loop soft-reset.
-                asyncio.get_event_loop().stop()
+                # Ctrl-D.
+                if persistent:
+                    # Keep the console alive: re-prompt instead of exiting.
+                    micropython.repl_event_resume()
+                    continue
+                if stop_loop_on_exit:
+                    # Boot REPL: stop the loop so the caller soft-resets.
+                    asyncio.get_event_loop().stop()
                 return
             if pending:
                 # More bytes already buffered: yield once per character, same

--- a/extmod/asyncio/arepl.py
+++ b/extmod/asyncio/arepl.py
@@ -1,0 +1,187 @@
+# This file is part of the MicroPython project, http://micropython.org/
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2022 Jim Mussared
+# Copyright (c) 2026 Andrew Leech
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import micropython
+from micropython import const
+import sys
+import asyncio
+import select
+
+
+_CHAR_CTRL_C = const(3)
+_PYEXEC_FORCED_EXIT = const(0x100)
+_PYEXEC_RAW_ACTIVE = const(0x400)
+
+# Cap on how many already-buffered bytes task() will drain ahead in one go
+# (see `pending` below), so a sustained burst can't shut out other tasks
+# indefinitely.
+_MAX_READAHEAD = const(256)
+
+# Raw terminal mode: no echo/line-buffering, escape sequences delivered raw.
+# Absent on ports without MICROPY_PY_MICROPYTHON_STDIO_RAW (e.g. non-unix).
+_stdio_raw = getattr(micropython, "stdio_mode_raw", lambda _: None)
+
+
+async def _async_exec(coro, s, pending):
+    """Run a coroutine compiled from a top-level-await REPL line on the loop.
+
+    The C REPL compiles a line containing top-level await into a coroutine (it
+    runs every other line itself) and hands it here to run on the event loop.
+    Print the repr of a non-None result, and cancel on Ctrl-C from the stream.
+    Bytes read while watching for Ctrl-C are type-ahead for the next line; they
+    are collected in `pending` for the caller to replay, rather than dropped.
+    """
+    try:
+        exec_task = asyncio.create_task(coro)
+
+        async def kbd_intr_task(exec_task, s, pending):
+            while True:
+                b = await s.read(1)
+                if not b:
+                    return
+                if ord(b[0]) == _CHAR_CTRL_C:
+                    exec_task.cancel()
+                    return
+                pending.append(ord(b[0]))
+
+        intr_task = asyncio.create_task(kbd_intr_task(exec_task, s, pending))
+        try:
+            try:
+                result = await exec_task
+                if result is not None:
+                    sys.stdout.write(repr(result))
+                    sys.stdout.write("\r\n")
+            except asyncio.CancelledError:
+                pass
+        finally:
+            intr_task.cancel()
+            try:
+                await intr_task
+            except asyncio.CancelledError:
+                pass
+
+    except Exception as err:
+        sys.print_exception(err, sys.stdout)
+
+
+# REPL task. Drives the native C event-driven REPL: all line editing, paste,
+# raw REPL, raw-paste and synchronous execution happen in C; only complete lines
+# containing top-level `await` are compiled to a coroutine and handed back here
+# to run on the event loop.
+async def task():
+    # Deliver Ctrl-C as a byte to the REPL rather than raising KeyboardInterrupt.
+    micropython.kbd_intr(-1)
+    _stdio_raw(True)
+    s = asyncio.StreamReader(sys.stdin)
+    # Registered once for the task's life. asyncio.StreamReader.read() re-arms
+    # its own poll registration on every single-byte read, which is fine for
+    # interactive typing but costly for a pasted block (one register/poll/
+    # unregister cycle per byte); this poller instead lets the drain below
+    # check readiness directly, so a burst only pays that cost once.
+    poller = select.poll()
+    poller.register(sys.stdin, select.POLLIN)
+    # Bytes queued ahead of the next repl_event() call: either read-ahead
+    # drained below, or type-ahead collected by _async_exec while a coroutine
+    # ran. Both are appended in arrival order and popped from the front, so
+    # the two sources interleave correctly without needing to be told apart.
+    pending = []
+    try:
+        micropython.repl_event_init()
+        while True:
+            if pending:
+                c = pending.pop(0)
+            else:
+                try:
+                    b = await s.read(1)
+                except UnicodeError:
+                    continue  # garbage byte on stdin (e.g. USB CDC reconnect)
+                if not b:
+                    return
+                pending.append(ord(b[0]))
+                # Drain whatever else is already available in one go, instead
+                # of paying the register/poll/unregister cycle again for
+                # every remaining byte of the same burst.
+                while len(pending) < _MAX_READAHEAD and next(poller.ipoll(0), None) is not None:
+                    try:
+                        ch = sys.stdin.read(1)
+                    except UnicodeError:
+                        continue
+                    if not ch:
+                        break
+                    pending.append(ord(ch[0]))
+                c = pending.pop(0)
+            r = micropython.repl_event(c)
+            # In raw mode feed input synchronously (no await/yield) so a
+            # concurrent task's stdout can't corrupt a raw/raw-paste transfer.
+            # Bytes already read ahead into `pending` (e.g. the rest of a
+            # raw-paste burst that arrived together with the byte that
+            # triggered raw mode) must be drained first, in order, before
+            # reading fresh ones from stdin.
+            while isinstance(r, int) and r & _PYEXEC_RAW_ACTIVE and not r & _PYEXEC_FORCED_EXIT:
+                if pending:
+                    c = pending.pop(0)
+                else:
+                    try:
+                        ch = sys.stdin.read(1)
+                    except UnicodeError:
+                        continue
+                    if not ch:
+                        return
+                    c = ord(ch[0])
+                r = micropython.repl_event(c)
+            if not isinstance(r, int):
+                # C deferred a top-level-await line as a coroutine; run it here.
+                # Anything still in pending (read ahead but not yet dispatched)
+                # stays at the front, ahead of type-ahead _async_exec collects
+                # while the coroutine runs.
+                await _async_exec(r, s, pending)
+                micropython.repl_event_resume()
+            elif r & _PYEXEC_FORCED_EXIT:
+                # Ctrl-D: end the REPL and let the boot loop soft-reset.
+                asyncio.get_event_loop().stop()
+                return
+            if pending:
+                # More bytes already buffered: yield once per character, same
+                # as if each had come from its own await, so other tasks stay
+                # interleaved at the same granularity during a fast paste.
+                await asyncio.sleep_ms(0)
+    finally:
+        poller.unregister(sys.stdin)
+        _stdio_raw(False)
+        micropython.kbd_intr(3)
+
+
+async def breakpoint():
+    """Drop into a blocking interactive REPL from async code; Ctrl-D resumes.
+
+    Uses the native breakpoint REPL (micropython.repl()), which saves and
+    restores readline state so it nests safely inside a running arepl session.
+    """
+    try:
+        micropython.repl()
+    finally:
+        # micropython.repl() restores original terminal mode on exit; the
+        # surrounding asyncio REPL needs raw mode again.
+        _stdio_raw(True)

--- a/extmod/asyncio/manifest.py
+++ b/extmod/asyncio/manifest.py
@@ -14,5 +14,9 @@ package(
     opt=3,
 )
 
+options.defaults(repl_asyncio=False)
+if options.repl_asyncio:
+    module("asyncio/arepl.py", base_path="..", opt=3)
+
 # Backwards-compatible uasyncio module.
 module("uasyncio.py", opt=3)

--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -1651,6 +1651,11 @@ static mp_uint_t lwip_socket_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_
             // return EOF, write - error. Without this poll will hang on a
             // socket which was closed by peer.
             ret |= flags & (MP_STREAM_POLL_RD | MP_STREAM_POLL_WR);
+            if (socket->incoming.tcp.pbuf == NULL) {
+                // Pure EOF (no buffered data): flag HUP so an aggregating poller
+                // (eg dupterm stdin) can tell this slot won't yield a byte.
+                ret |= MP_STREAM_POLL_HUP;
+            }
         } else if (socket->state == ERR_RST) {
             // Socket was reset by peer, a write will return an error
             ret |= flags & MP_STREAM_POLL_WR;

--- a/extmod/os_dupterm.c
+++ b/extmod/os_dupterm.c
@@ -86,6 +86,14 @@ uintptr_t mp_os_dupterm_poll(uintptr_t poll_flags) {
         }
 
         if (ret != MP_STREAM_ERROR) {
+            if (ret & (MP_STREAM_POLL_HUP | MP_STREAM_POLL_ERR | MP_STREAM_POLL_NVAL)) {
+                // A closed or errored slot won't recover: drop it so it can't wake a
+                // poll-driven reader (like asyncio.arepl) into a stranding read, and so
+                // os.dupterm() reports it gone.  Not closed here, to keep poll cheap;
+                // the dropped reference lets the stream's finaliser close it.
+                MP_STATE_VM(dupterm_objs[idx]) = MP_OBJ_NULL;
+                continue;
+            }
             poll_flags_out |= ret;
             if (poll_flags_out == poll_flags) {
                 // Finish early if all requested flags are set

--- a/ports/alif/boards/manifest.py
+++ b/ports/alif/boards/manifest.py
@@ -1,5 +1,5 @@
 freeze("$(PORT_DIR)/modules/$(MCU_CORE)")
-include("$(MPY_DIR)/extmod/asyncio")
+include("$(MPY_DIR)/extmod/asyncio", repl_asyncio=True)
 require("dht")
 require("neopixel")
 require("onewire")

--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -52,8 +52,8 @@ manage the ESP32 microcontroller, as well as a way to manage the required
 build environment and toolchains needed to build the firmware.
 
 The ESP-IDF changes quickly and MicroPython only supports certain versions. The
-current recommended version of ESP-IDF for MicroPython is v5.5.2. MicroPython
-also supports v5.3, v5.4, v5.4.1, v5.4.2, v5.5.1 and v5.5.4.
+current recommended version of ESP-IDF for MicroPython is v5.5.5. MicroPython
+also supports v5.3, v5.4, v5.4.1, v5.4.2, v5.5.1, v5.5.2 and v5.5.4.
 
 <!-- Important: If updating the above, please also update:
      * IDF_OLDEST_VER & IDF_NEWEST_VER in .github/workflows/port_esp32.yml

--- a/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
@@ -13,6 +13,9 @@
 
 #define MICROPY_PY_MACHINE_SDCARD           (1)
 #define MICROPY_HW_SDMMC_LDO_CHAN_ID        (4)
+// This board wires the SD/MMC card to SDMMC slot 0 with a full 4-bit bus.
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (0)
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (4)
 
 #ifndef USB_SERIAL_JTAG_PACKET_SZ_BYTES
 #define USB_SERIAL_JTAG_PACKET_SZ_BYTES (64)

--- a/ports/esp32/boards/manifest.py
+++ b/ports/esp32/boards/manifest.py
@@ -1,5 +1,5 @@
 freeze("$(PORT_DIR)/modules")
-include("$(MPY_DIR)/extmod/asyncio")
+include("$(MPY_DIR)/extmod/asyncio", repl_asyncio=True)
 
 # Useful networking-related packages.
 require("bundle-networking")

--- a/ports/esp32/lockfiles/dependencies.lock.esp32
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32
@@ -25,7 +25,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/lan867x
 - espressif/mdns

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c2
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c3
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c5
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c5
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c6
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c6
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32h2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32h2
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32p4
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32p4
@@ -81,7 +81,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/esp_hosted
 - espressif/esp_wifi_remote

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s2
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s3
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/ports/esp32/machine_sdcard.h
+++ b/ports/esp32/machine_sdcard.h
@@ -26,6 +26,17 @@
 #ifndef MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
 #define MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
 
+// Default slot and bus width for a native SD/MMC machine.SDCard(). These are
+// conservative defaults (the historically usable slot 1, 1-bit); which slot is
+// wired and how many data lines are routed is board specific, so a board should
+// override these in its mpconfigboard.h to match its layout.
+#ifndef MICROPY_HW_SDMMC_DEFAULT_SLOT
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
+#endif
+#ifndef MICROPY_HW_SDMMC_DEFAULT_WIDTH
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (1)
+#endif
+
 // Default pins for the primary SPI-mode SD card bus (slot 2). SPI mode is
 // available on every ESP32 variant, so a board may override these in its
 // mpconfigboard.h to make machine.SDCard(slot=2) work without explicit pins.

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -150,8 +150,11 @@ soft_reset:
     machine_i2s_init0();
     #endif
 
-    // run boot-up scripts
-    pyexec_frozen_module("_boot.py", false);
+    // Run optional frozen boot code.
+    #ifdef MICROPY_BOARD_FROZEN_BOOT_FILE
+    pyexec_frozen_module(MICROPY_BOARD_FROZEN_BOOT_FILE, false);
+    #endif
+
     int ret = pyexec_file_if_exists("boot.py");
 
     #if MICROPY_HW_ENABLE_USBDEV

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -326,9 +326,7 @@ static mp_obj_t machine_wake_pins(void) {
 
     // Only a few (~8) pins might cause wakeup.
     // Therefore, we calculate the required space in a first pass.
-    for (index = 0, len = 0; index < 64; index++) {
-        len += (status & (1ULL << index)) ? 1 : 0;
-    }
+    len = mp_popcount(status >> 32) + mp_popcount(status & 0xFFFFFFFF);
     if (len) {
         mp_obj_tuple_t *tuple = MP_OBJ_TO_PTR(mp_obj_new_tuple(len, NULL));
 

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -224,20 +224,6 @@
 #ifndef MICROPY_HW_ENABLE_SDCARD
 #define MICROPY_HW_ENABLE_SDCARD            (1)
 #endif
-#ifndef MICROPY_HW_SDMMC_DEFAULT_SLOT
-#if CONFIG_IDF_TARGET_ESP32P4
-#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (0)
-#else
-#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
-#endif
-#endif
-#ifndef MICROPY_HW_SDMMC_DEFAULT_WIDTH
-#if CONFIG_IDF_TARGET_ESP32P4
-#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (4)
-#else
-#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (1)
-#endif
-#endif
 #define MICROPY_HW_SOFTSPI_MIN_DELAY        (0)
 #define MICROPY_HW_SOFTSPI_MAX_BAUDRATE     (esp_rom_get_cpu_ticks_per_us() * 1000000 / 200) // roughly
 #define MICROPY_PY_SSL                      (MICROPY_PY_NETWORK)

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -425,6 +425,10 @@ typedef long mp_off_t;
 #define MICROPY_BOARD_STARTUP boardctrl_startup
 #endif
 
+#ifndef MICROPY_BOARD_FROZEN_BOOT_FILE
+#define MICROPY_BOARD_FROZEN_BOOT_FILE "_boot.py"
+#endif
+
 void boardctrl_startup(void);
 
 #ifndef MICROPY_PY_NETWORK_LAN

--- a/ports/esp8266/boards/ESP8266_GENERIC/manifest_2MiB.py
+++ b/ports/esp8266/boards/ESP8266_GENERIC/manifest_2MiB.py
@@ -2,7 +2,7 @@
 include("$(PORT_DIR)/boards/manifest.py")
 
 # asyncio
-include("$(MPY_DIR)/extmod/asyncio")
+include("$(MPY_DIR)/extmod/asyncio", repl_asyncio=True)
 
 # drivers
 require("ssd1306")

--- a/ports/esp8266/boards/ESP8266_GENERIC/mpconfigboard.h
+++ b/ports/esp8266/boards/ESP8266_GENERIC/mpconfigboard.h
@@ -26,6 +26,9 @@
 #define MICROPY_READER_VFS              (MICROPY_VFS)
 #define MICROPY_VFS                     (1)
 
+// No room to freeze asyncio.arepl, so keep the blocking REPL.
+#define MICROPY_REPL_ASYNCIO            (0)
+
 #elif defined(MICROPY_ESP8266_512K)
 
 #define MICROPY_HW_BOARD_NAME "ESP module (512K)"
@@ -39,6 +42,7 @@
 #define MICROPY_PY_REVERSE_SPECIAL_METHODS (0)
 #define MICROPY_PY_SYS_STDIO_BUFFER     (0)
 #define MICROPY_PY_ASYNCIO              (0)
+#define MICROPY_REPL_ASYNCIO            (0)
 #define MICROPY_PY_RE_SUB               (0)
 #define MICROPY_PY_CRYPTOLIB            (0)
 #define MICROPY_PY_FRAMEBUF             (0)

--- a/ports/mimxrt/boards/manifest.py
+++ b/ports/mimxrt/boards/manifest.py
@@ -1,5 +1,5 @@
 freeze("$(PORT_DIR)/modules")
-include("$(MPY_DIR)/extmod/asyncio")
+include("$(MPY_DIR)/extmod/asyncio", repl_asyncio=True)
 require("onewire")
 require("ds18x20")
 require("dht")

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -57,6 +57,11 @@
 #define CORE_FEAT (MICROPY_CONFIG_ROM_LEVEL >= MICROPY_CONFIG_ROM_LEVEL_CORE_FEATURES)
 #define EXTRA_FEAT (MICROPY_CONFIG_ROM_LEVEL >= MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES)
 
+// nrf does not freeze asyncio.arepl, so keep the blocking REPL on the
+// EXTRA-level parts (NRF52840/NRF9160) rather than boot-looping on a missing
+// frozen module.
+#define MICROPY_REPL_ASYNCIO (0)
+
 // options to control how MicroPython is built
 
 // Due to the use of LTO and the unknown distance between nlr.o and nlrthumb.o code,

--- a/ports/qemu/mpconfigport.h
+++ b/ports/qemu/mpconfigport.h
@@ -30,6 +30,10 @@
 
 #define MICROPY_CONFIG_ROM_LEVEL    (MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES)
 
+// The asyncio REPL needs pollable stdin, which the semihosting console does
+// not provide; use the blocking REPL.
+#define MICROPY_REPL_ASYNCIO        (0)
+
 #if defined(__ARM_ARCH_ISA_ARM)
 #define MICROPY_EMIT_ARM            (1)
 #define MICROPY_EMIT_INLINE_THUMB   (1)

--- a/ports/renesas-ra/boards/manifest.py
+++ b/ports/renesas-ra/boards/manifest.py
@@ -1,3 +1,3 @@
-include("$(MPY_DIR)/extmod/asyncio")
+include("$(MPY_DIR)/extmod/asyncio", repl_asyncio=True)
 require("dht")
 require("onewire")

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -192,6 +192,7 @@ set(MICROPY_SOURCE_PORT
 set(MICROPY_SOURCE_QSTR
     ${MICROPY_SOURCE_PY}
     ${MICROPY_DIR}/shared/readline/readline.c
+    ${MICROPY_DIR}/shared/runtime/pyexec.c
     ${MICROPY_DIR}/shared/runtime/mpirq.c
     ${MICROPY_DIR}/shared/runtime/sys_stdio_mphal.c
     ${MICROPY_DIR}/shared/tinyusb/mp_usbd_runtime.c

--- a/ports/rp2/boards/manifest.py
+++ b/ports/rp2/boards/manifest.py
@@ -1,5 +1,5 @@
 freeze("$(PORT_DIR)/modules")
-include("$(MPY_DIR)/extmod/asyncio")
+include("$(MPY_DIR)/extmod/asyncio", repl_asyncio=True)
 require("onewire")
 require("ds18x20")
 require("dht")

--- a/ports/rp2/mphalport.c
+++ b/ports/rp2/mphalport.c
@@ -75,6 +75,13 @@ uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
     #if MICROPY_PY_OS_DUPTERM
     ret |= mp_os_dupterm_poll(poll_flags);
     #endif
+    #if MICROPY_HW_ENABLE_UART_REPL || MICROPY_HW_USB_CDC || MICROPY_PY_OS_DUPTERM_NOTIFY
+    // The UART REPL, USB CDC and dupterm-notify sources all feed stdin_ringbuf;
+    // report readable so a poll-driven REPL (asyncio reading sys.stdin) wakes.
+    if ((poll_flags & MP_STREAM_POLL_RD) && ringbuf_avail(&stdin_ringbuf) > 0) {
+        ret |= MP_STREAM_POLL_RD;
+    }
+    #endif
     return ret;
 }
 

--- a/ports/samd/mcu/samd51/manifest.py
+++ b/ports/samd/mcu/samd51/manifest.py
@@ -1,2 +1,2 @@
 include("$(PORT_DIR)/boards/manifest.py")
-include("$(MPY_DIR)/extmod/asyncio")
+include("$(MPY_DIR)/extmod/asyncio", repl_asyncio=True)

--- a/ports/stm32/boards/PYBD_SF2/manifest.py
+++ b/ports/stm32/boards/PYBD_SF2/manifest.py
@@ -1,3 +1,5 @@
-include("$(PORT_DIR)/boards/manifest.py")
+# Insufficient internal flash to also carry the asyncio REPL (see
+# MICROPY_REPL_ASYNCIO=0 in mpconfigboard.h), so don't freeze arepl.py.
+include("$(PORT_DIR)/boards/manifest.py", repl_asyncio=False)
 include("$(PORT_DIR)/boards/manifest_pyboard.py")
 require("bundle-networking")

--- a/ports/stm32/boards/PYBD_SF2/mpconfigboard.h
+++ b/ports/stm32/boards/PYBD_SF2/mpconfigboard.h
@@ -31,6 +31,9 @@
 
 #define MICROPY_PY_PYB_LEGACY       (1)
 #define MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE (0)
+
+// Insufficient internal flash (FLASH_APP) to also carry the asyncio REPL.
+#define MICROPY_REPL_ASYNCIO        (0)
 #define MICROPY_HW_HAS_SWITCH       (1)
 #define MICROPY_HW_HAS_FLASH        (1)
 #define MICROPY_HW_ENABLE_RNG       (1)

--- a/ports/stm32/boards/PYBD_SF6/manifest.py
+++ b/ports/stm32/boards/PYBD_SF6/manifest.py
@@ -1,0 +1,3 @@
+include("$(PORT_DIR)/boards/manifest.py")
+include("$(PORT_DIR)/boards/manifest_pyboard.py")
+require("bundle-networking")

--- a/ports/stm32/boards/PYBD_SF6/mpconfigboard.h
+++ b/ports/stm32/boards/PYBD_SF6/mpconfigboard.h
@@ -38,6 +38,11 @@
 #define MICROPY_HW_BOARD_NAME       "PYBD-SF6W"
 #define MICROPY_HW_MCU_NAME         "STM32F767IIK"
 
+// The SF2 base config disables the asyncio REPL for the flash-tight 512 KiB
+// SF2/SF3; SF6 has 2 MiB of internal flash, so re-enable it here.
+#undef MICROPY_REPL_ASYNCIO
+#define MICROPY_REPL_ASYNCIO        (1)
+
 // HSE is 25MHz, run SYS at 144MHz
 #define MICROPY_HW_CLK_PLLM         (25)
 #define MICROPY_HW_CLK_PLLN         (288)

--- a/ports/stm32/boards/PYBD_SF6/mpconfigboard.mk
+++ b/ports/stm32/boards/PYBD_SF6/mpconfigboard.mk
@@ -17,4 +17,4 @@ MICROPY_SSL_MBEDTLS = 1
 MICROPY_VFS_LFS2 = 1
 
 # PYBD-specific frozen modules
-FROZEN_MANIFEST ?= boards/PYBD_SF2/manifest.py
+FROZEN_MANIFEST ?= boards/PYBD_SF6/manifest.py

--- a/ports/stm32/boards/manifest.py
+++ b/ports/stm32/boards/manifest.py
@@ -1,4 +1,7 @@
-include("$(MPY_DIR)/extmod/asyncio")
+# Freeze the asyncio REPL by default; flash-tight boards can opt out by
+# including this manifest with repl_asyncio=False (and MICROPY_REPL_ASYNCIO=0).
+options.defaults(repl_asyncio=True)
+include("$(MPY_DIR)/extmod/asyncio", repl_asyncio=options.repl_asyncio)
 
 require("dht")
 require("onewire")

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -235,6 +235,8 @@ static inline unsigned long mp_random_seed_init(void) {
 #include <sched.h>
 #define MICROPY_UNIX_MACHINE_IDLE sched_yield();
 
+#define MICROPY_PY_MICROPYTHON_STDIO_RAW (1)
+
 #ifndef MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
 #define MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE (1)
 #endif

--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -107,6 +107,7 @@ void mp_hal_stdio_mode_raw(void) {
     static struct termios termios;
     termios = orig_termios;
     termios.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
+    termios.c_oflag &= ~OPOST;  // raw output: don't translate \n to \r\n
     termios.c_cflag = (termios.c_cflag & ~(CSIZE | PARENB)) | CS8;
     termios.c_lflag = 0;
     termios.c_cc[VMIN] = 1;

--- a/ports/unix/variants/standard/manifest.py
+++ b/ports/unix/variants/standard/manifest.py
@@ -1,3 +1,3 @@
 include("$(PORT_DIR)/variants/manifest.py")
 
-include("$(MPY_DIR)/extmod/asyncio")
+include("$(MPY_DIR)/extmod/asyncio", repl_asyncio=True)

--- a/ports/unix/variants/standard/mpconfigvariant.h
+++ b/ports/unix/variants/standard/mpconfigvariant.h
@@ -29,3 +29,7 @@
 
 // Enable extra Unix features.
 #include "../mpconfigvariant_common.h"
+
+// Keep test coverage of the asyncio REPL breakpoint() debugger, which
+// defaults off below MICROPY_CONFIG_ROM_LEVEL_EVERYTHING.
+#define MICROPY_REPL_ASYNCIO_BREAKPOINT (1)

--- a/ports/zephyr/mpconfigport.h
+++ b/ports/zephyr/mpconfigport.h
@@ -47,6 +47,10 @@
 #error "Undefined Feature Level"
 #endif
 
+// The asyncio REPL needs pollable stdin, which the Zephyr console does not
+// provide; use the blocking REPL.
+#define MICROPY_REPL_ASYNCIO (0)
+
 // Usually passed from Makefile
 #ifndef MICROPY_HEAP_SIZE
 #define MICROPY_HEAP_SIZE (16 * 1024)

--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -31,6 +31,9 @@
 #include "py/runtime.h"
 #include "py/gc.h"
 #include "py/mphal.h"
+#if MICROPY_REPL_ASYNCIO
+#include "shared/runtime/pyexec.h"
+#endif
 
 #if MICROPY_PY_MICROPYTHON
 
@@ -188,6 +191,82 @@ static MP_DEFINE_CONST_FUN_OBJ_2(mp_micropython_schedule_obj, mp_micropython_sch
 
 #endif
 
+#if MICROPY_PY_MICROPYTHON_STDIO_RAW
+static mp_obj_t mp_micropython_stdio_mode_raw(mp_obj_t enabled) {
+    if (mp_obj_is_true(enabled)) {
+        mp_hal_stdio_mode_raw();
+    } else {
+        mp_hal_stdio_mode_orig();
+    }
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(mp_micropython_stdio_mode_raw_obj, mp_micropython_stdio_mode_raw);
+#endif
+
+#if MICROPY_REPL_ASYNCIO
+// Drive the C event-driven REPL from an asyncio task.  All line editing, paste
+// mode, raw REPL, raw-paste and synchronous execution run in C; only complete
+// lines containing "await" are handed back here to run on the event loop.
+
+// micropython.repl_event_init(): start a REPL session (banner + first prompt).
+static mp_obj_t mp_micropython_repl_event_init(void) {
+    pyexec_event_repl_async = true;
+    pyexec_event_repl_init();
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_repl_event_init_obj, mp_micropython_repl_event_init);
+
+// micropython.repl_event(c): feed one input character to the REPL.  Returns an
+// int status (0 to continue, PYEXEC_FORCED_EXIT to soft-reset), or a coroutine
+// when a top-level-await line is deferred to run on the event loop.
+static mp_obj_t mp_micropython_repl_event(mp_obj_t c_in) {
+    if (MP_STATE_VM(repl_line) == NULL) {
+        // repl_event_init() must run first, else the REPL state is NULL.
+        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("repl not active"));
+    }
+    int ret = pyexec_event_repl_process_char(mp_obj_get_int(c_in));
+    if (ret == PYEXEC_ASYNC_PENDING) {
+        return MP_STATE_VM(repl_pending_coro);
+    }
+    if (pyexec_mode_kind == PYEXEC_MODE_RAW_REPL) {
+        // Signal the driver to keep feeding synchronously (no yield) while raw.
+        ret |= PYEXEC_RAW_ACTIVE;
+    }
+    return MP_OBJ_NEW_SMALL_INT(ret);
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(mp_micropython_repl_event_obj, mp_micropython_repl_event);
+
+// micropython.repl_event_resume(): re-prompt after the driver has executed a
+// deferred "await" line on the event loop.
+static mp_obj_t mp_micropython_repl_event_resume(void) {
+    if (MP_STATE_VM(repl_line) == NULL) {
+        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("repl not active"));
+    }
+    pyexec_event_repl_resume();
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_repl_event_resume_obj, mp_micropython_repl_event_resume);
+
+// micropython.repl(): blocking interactive breakpoint REPL, Ctrl-D returns to
+// the caller.
+static mp_obj_t mp_micropython_repl(void) {
+    mp_hal_stdio_mode_raw();
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
+        pyexec_repl_breakpoint();
+        nlr_pop();
+        mp_hal_stdio_mode_orig();
+    } else {
+        // Restore terminal mode and re-raise; pyexec_repl_breakpoint has
+        // already unwound its own readline state.
+        mp_hal_stdio_mode_orig();
+        nlr_jump(nlr.ret_val);
+    }
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_repl_obj, mp_micropython_repl);
+#endif
+
 static const mp_rom_map_elem_t mp_module_micropython_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_micropython) },
     { MP_ROM_QSTR(MP_QSTR_const), MP_ROM_PTR(&mp_identity_obj) },
@@ -227,6 +306,15 @@ static const mp_rom_map_elem_t mp_module_micropython_globals_table[] = {
     #endif
     #if MICROPY_ENABLE_SCHEDULER
     { MP_ROM_QSTR(MP_QSTR_schedule), MP_ROM_PTR(&mp_micropython_schedule_obj) },
+    #endif
+    #if MICROPY_PY_MICROPYTHON_STDIO_RAW
+    { MP_ROM_QSTR(MP_QSTR_stdio_mode_raw), MP_ROM_PTR(&mp_micropython_stdio_mode_raw_obj) },
+    #endif
+    #if MICROPY_REPL_ASYNCIO
+    { MP_ROM_QSTR(MP_QSTR_repl_event_init), MP_ROM_PTR(&mp_micropython_repl_event_init_obj) },
+    { MP_ROM_QSTR(MP_QSTR_repl_event), MP_ROM_PTR(&mp_micropython_repl_event_obj) },
+    { MP_ROM_QSTR(MP_QSTR_repl_event_resume), MP_ROM_PTR(&mp_micropython_repl_event_resume_obj) },
+    { MP_ROM_QSTR(MP_QSTR_repl), MP_ROM_PTR(&mp_micropython_repl_obj) },
     #endif
 };
 

--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -210,8 +210,8 @@ static MP_DEFINE_CONST_FUN_OBJ_1(mp_micropython_stdio_mode_raw_obj, mp_micropyth
 
 // micropython.repl_event_init(): start a REPL session (banner + first prompt).
 static mp_obj_t mp_micropython_repl_event_init(void) {
-    pyexec_event_repl_async = true;
     pyexec_event_repl_init();
+    pyexec_event_repl_async = true;
     return mp_const_none;
 }
 static MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_repl_event_init_obj, mp_micropython_repl_event_init);
@@ -246,7 +246,9 @@ static mp_obj_t mp_micropython_repl_event_resume(void) {
     return mp_const_none;
 }
 static MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_repl_event_resume_obj, mp_micropython_repl_event_resume);
+#endif
 
+#if MICROPY_REPL_ASYNCIO_BREAKPOINT
 // micropython.repl(): blocking interactive breakpoint REPL, Ctrl-D returns to
 // the caller.
 static mp_obj_t mp_micropython_repl(void) {
@@ -314,6 +316,8 @@ static const mp_rom_map_elem_t mp_module_micropython_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_repl_event_init), MP_ROM_PTR(&mp_micropython_repl_event_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_repl_event), MP_ROM_PTR(&mp_micropython_repl_event_obj) },
     { MP_ROM_QSTR(MP_QSTR_repl_event_resume), MP_ROM_PTR(&mp_micropython_repl_event_resume_obj) },
+    #endif
+    #if MICROPY_REPL_ASYNCIO_BREAKPOINT
     { MP_ROM_QSTR(MP_QSTR_repl), MP_ROM_PTR(&mp_micropython_repl_obj) },
     #endif
 };

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -39,9 +39,9 @@
 // as well as a fallback to generate MICROPY_GIT_TAG if the git repo or tags
 // are unavailable.
 #define MICROPY_VERSION_MAJOR 1
-#define MICROPY_VERSION_MINOR 29
+#define MICROPY_VERSION_MINOR 30
 #define MICROPY_VERSION_MICRO 0
-#define MICROPY_VERSION_PRERELEASE 0
+#define MICROPY_VERSION_PRERELEASE 1
 
 // Combined version as a 32-bit number for convenience to allow version
 // comparison. Doesn't include prerelease state.

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -893,6 +893,14 @@ typedef uint64_t mp_uint_t;
 #endif
 #endif
 
+// Whether asyncio.arepl provides breakpoint(), a blocking micropython.repl()
+// debugger REPL that nests inside a running asyncio REPL session. Separate
+// from MICROPY_REPL_ASYNCIO because it is an optional convenience with its
+// own flash cost, not needed for the asyncio REPL itself.
+#ifndef MICROPY_REPL_ASYNCIO_BREAKPOINT
+#define MICROPY_REPL_ASYNCIO_BREAKPOINT (MICROPY_REPL_ASYNCIO && MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EVERYTHING)
+#endif
+
 // Whether the compiler allows compiling top-level await expressions.  The
 // asyncio REPL needs this to compile REPL input containing await into a
 // coroutine that runs on the event loop.

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -888,6 +888,12 @@ typedef uint64_t mp_uint_t;
 #define MICROPY_REPL_EVENT_DRIVEN (0)
 #endif
 
+// Whether to boot into an asyncio-based REPL (asyncio.arepl) instead of the
+// blocking friendly REPL. Requires asyncio.arepl in the frozen manifest.
+#ifndef MICROPY_REPL_ASYNCIO
+#define MICROPY_REPL_ASYNCIO (0)
+#endif
+
 // The number of items to keep in the readline history.
 #ifndef MICROPY_READLINE_HISTORY_SIZE
 #define MICROPY_READLINE_HISTORY_SIZE (8)
@@ -1612,6 +1618,11 @@ typedef time_t mp_timestamp_t;
 // Support for micropython.RingIO()
 #ifndef MICROPY_PY_MICROPYTHON_RINGIO
 #define MICROPY_PY_MICROPYTHON_RINGIO (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
+#endif
+
+// Whether to provide "micropython.stdio_mode_raw" function
+#ifndef MICROPY_PY_MICROPYTHON_STDIO_RAW
+#define MICROPY_PY_MICROPYTHON_STDIO_RAW (0)
 #endif
 
 // Whether to provide "array" module. Note that large chunk of the

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -567,11 +567,6 @@ typedef uint64_t mp_uint_t;
 #define MICROPY_DYNAMIC_COMPILER (0)
 #endif
 
-// Whether the compiler allows compiling top-level await expressions
-#ifndef MICROPY_COMP_ALLOW_TOP_LEVEL_AWAIT
-#define MICROPY_COMP_ALLOW_TOP_LEVEL_AWAIT (0)
-#endif
-
 // Whether to enable constant folding; eg 1+2 rewritten as 3
 #ifndef MICROPY_COMP_CONST_FOLDING
 #define MICROPY_COMP_CONST_FOLDING (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_CORE_FEATURES)
@@ -891,7 +886,18 @@ typedef uint64_t mp_uint_t;
 // Whether to boot into an asyncio-based REPL (asyncio.arepl) instead of the
 // blocking friendly REPL. Requires asyncio.arepl in the frozen manifest.
 #ifndef MICROPY_REPL_ASYNCIO
+#if MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES
+#define MICROPY_REPL_ASYNCIO (1)
+#else
 #define MICROPY_REPL_ASYNCIO (0)
+#endif
+#endif
+
+// Whether the compiler allows compiling top-level await expressions.  The
+// asyncio REPL needs this to compile REPL input containing await into a
+// coroutine that runs on the event loop.
+#ifndef MICROPY_COMP_ALLOW_TOP_LEVEL_AWAIT
+#define MICROPY_COMP_ALLOW_TOP_LEVEL_AWAIT (MICROPY_REPL_ASYNCIO)
 #endif
 
 // The number of items to keep in the readline history.

--- a/py/mphal.h
+++ b/py/mphal.h
@@ -99,6 +99,16 @@ uint64_t mp_hal_time_ns(void);
 #include "extmod/virtpin.h"
 #endif
 
+// If the port doesn't provide stdio mode switching, define trivial no-ops.
+// Ports like unix that switch between raw/cooked terminal modes should define
+// MICROPY_HAL_HAS_STDIO_MODE_SWITCH and provide their own implementations.
+#if !MICROPY_HAL_HAS_STDIO_MODE_SWITCH
+static inline void mp_hal_stdio_mode_raw(void) {
+}
+static inline void mp_hal_stdio_mode_orig(void) {
+}
+#endif
+
 // Event handling and wait-for-event functions.
 
 #ifndef MICROPY_INTERNAL_WFE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ exclude = [  # Ruff finds Python SyntaxError in these files
   "tests/basics/string_tstring_operations.py",
   "tests/basics/string_tstring_parser1.py",
   "tests/cmdline/cmd_compile_only_error.py",
+  "tests/cmdline/repl_asyncio_intr.py",
   "tests/cmdline/repl_autocomplete.py",
   "tests/cmdline/repl_autocomplete_underscore.py",
   "tests/cmdline/repl_autoindent.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ ACKNOWLEDGEMENTS,\
 """
 
 [tool.ruff]
+# Apply exclude/extend-exclude even when files are passed explicitly on the
+# command line, as tools/pre-push-check.sh does with the changed-file list.
+force-exclude = true
 # Exclude third-party code from linting and formatting
 extend-exclude = [
   "lib",

--- a/shared/readline/readline.c
+++ b/shared/readline/readline.c
@@ -51,13 +51,17 @@ enum { ESEQ_NONE, ESEQ_ESC, ESEQ_ESC_BRACKET, ESEQ_ESC_BRACKET_DIGIT, ESEQ_ESC_O
 #pragma warning(disable : 4090)
 #endif
 
+#if MICROPY_REPL_ASYNCIO_BREAKPOINT
 // Guards the single-level readline save slot (rl_saved) used by
 // readline_push/readline_pop; reset in readline_init0.
 static bool rl_saved_valid = false;
+#endif
 
 void readline_init0(void) {
     memset(MP_STATE_PORT(readline_hist), 0, MICROPY_READLINE_HISTORY_SIZE * sizeof(const char*));
+    #if MICROPY_REPL_ASYNCIO_BREAKPOINT
     rl_saved_valid = false;
+    #endif
 }
 
 static char *str_dup_maybe(const char *str) {
@@ -598,6 +602,7 @@ void readline_push_history(const char *line) {
     }
 }
 
+#if MICROPY_REPL_ASYNCIO_BREAKPOINT
 // Save/restore readline state for reentrant use (e.g. sync REPL breakpoint
 // from within an async REPL session). Single-level stack since only one
 // level of nesting is needed.
@@ -624,5 +629,6 @@ void readline_pop(void) {
         rl_saved_valid = false;
     }
 }
+#endif // MICROPY_REPL_ASYNCIO_BREAKPOINT
 
 MP_REGISTER_ROOT_POINTER(const char *readline_hist[MICROPY_READLINE_HISTORY_SIZE]);

--- a/shared/readline/readline.c
+++ b/shared/readline/readline.c
@@ -51,8 +51,13 @@ enum { ESEQ_NONE, ESEQ_ESC, ESEQ_ESC_BRACKET, ESEQ_ESC_BRACKET_DIGIT, ESEQ_ESC_O
 #pragma warning(disable : 4090)
 #endif
 
+// Guards the single-level readline save slot (rl_saved) used by
+// readline_push/readline_pop; reset in readline_init0.
+static bool rl_saved_valid = false;
+
 void readline_init0(void) {
     memset(MP_STATE_PORT(readline_hist), 0, MICROPY_READLINE_HISTORY_SIZE * sizeof(const char*));
+    rl_saved_valid = false;
 }
 
 static char *str_dup_maybe(const char *str) {
@@ -590,6 +595,33 @@ void readline_push_history(const char *line) {
             }
             MP_STATE_PORT(readline_hist)[0] = most_recent_hist;
         }
+    }
+}
+
+// Save/restore readline state for reentrant use (e.g. sync REPL breakpoint
+// from within an async REPL session). Single-level stack since only one
+// level of nesting is needed.
+// Note: not thread-safe. The REPL is inherently single-threaded (one stdin),
+// so this is fine for current use. If multi-core REPL support is ever needed,
+// these would need to move to mp_state_thread_t.
+static readline_t rl_saved;
+
+// Caller is responsible for GC-rooting any vstr referenced by the
+// saved readline_t, e.g. via MP_REGISTER_ROOT_POINTER. Direct C
+// callers of readline_push without rooting will create a GC hazard.
+bool readline_push(void) {
+    if (rl_saved_valid) {
+        return false;
+    }
+    rl_saved = rl;
+    rl_saved_valid = true;
+    return true;
+}
+
+void readline_pop(void) {
+    if (rl_saved_valid) {
+        rl = rl_saved;
+        rl_saved_valid = false;
     }
 }
 

--- a/shared/readline/readline.h
+++ b/shared/readline/readline.h
@@ -46,4 +46,7 @@ void readline_init(vstr_t *line, const char *prompt);
 void readline_note_newline(const char *prompt);
 int readline_process_char(int c);
 
+bool readline_push(void);
+void readline_pop(void);
+
 #endif // MICROPY_INCLUDED_LIB_MP_READLINE_READLINE_H

--- a/shared/readline/readline.h
+++ b/shared/readline/readline.h
@@ -46,7 +46,9 @@ void readline_init(vstr_t *line, const char *prompt);
 void readline_note_newline(const char *prompt);
 int readline_process_char(int c);
 
+#if MICROPY_REPL_ASYNCIO_BREAKPOINT
 bool readline_push(void);
 void readline_pop(void);
+#endif
 
 #endif // MICROPY_INCLUDED_LIB_MP_READLINE_READLINE_H

--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -54,6 +54,11 @@ static bool repl_display_debugging_info = 0;
 #define EXEC_FLAG_SOURCE_IS_FILENAME    (1 << 5)
 #define EXEC_FLAG_SOURCE_IS_READER      (1 << 6)
 #define EXEC_FLAG_NO_INTERRUPT          (1 << 7)
+#define EXEC_FLAG_ASYNC_REPL            (1 << 8)
+
+#if MICROPY_REPL_ASYNCIO && !MICROPY_COMP_ALLOW_TOP_LEVEL_AWAIT
+#error "MICROPY_REPL_ASYNCIO requires MICROPY_COMP_ALLOW_TOP_LEVEL_AWAIT"
+#endif
 
 // parses, compiles and executes the code in the lexer
 // frees the lexer before returning
@@ -122,6 +127,17 @@ static int parse_compile_execute(const void *source, mp_parse_input_kind_t input
             mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("script compilation not supported"));
             #endif
         }
+
+        #if MICROPY_REPL_ASYNCIO
+        if ((exec_flags & EXEC_FLAG_ASYNC_REPL) && mp_obj_get_type(module_fun) == &mp_type_gen_wrap) {
+            // REPL input with top-level await compiled to a coroutine: create it
+            // and hand it to the asyncio driver to run on the event loop, rather
+            // than running it to completion here.
+            MP_STATE_VM(repl_pending_coro) = mp_call_function_0(module_fun);
+            nlr_pop();
+            return PYEXEC_ASYNC_PENDING;
+        }
+        #endif
 
         // execute code
         if (!(exec_flags & EXEC_FLAG_NO_INTERRUPT)) {
@@ -324,7 +340,7 @@ static int do_reader_stdin(int c) {
     return parse_compile_execute(&reader, MP_PARSE_FILE_INPUT, exec_flags);
 }
 
-#if MICROPY_REPL_EVENT_DRIVEN
+#if MICROPY_REPL_EVENT_DRIVEN || MICROPY_REPL_ASYNCIO
 
 typedef struct _repl_t {
     // This structure originally also held current REPL line,
@@ -345,12 +361,25 @@ void pyexec_event_repl_init(void) {
     MP_STATE_VM(repl_line) = vstr_new(32);
     repl.cont_line = false;
     repl.paste_mode = false;
-    // no prompt before printing friendly REPL banner or entering raw REPL
-    readline_init(MP_STATE_VM(repl_line), "");
+    #if MICROPY_REPL_ASYNCIO
+    // A fresh session always starts synchronous; the asyncio driver sets this
+    // once it starts deferring top-level-await lines to the event loop.
+    pyexec_event_repl_async = false;
+    #endif
     if (pyexec_mode_kind == PYEXEC_MODE_RAW_REPL) {
+        // no prompt before entering raw REPL
+        readline_init(MP_STATE_VM(repl_line), "");
         pyexec_raw_repl_process_char(CHAR_CTRL_A);
     } else {
-        pyexec_friendly_repl_process_char(CHAR_CTRL_B);
+        // Print the friendly REPL banner (no leading newline, matching the
+        // blocking REPL) followed by the first prompt.
+        mp_hal_stdout_tx_str(MICROPY_BANNER_NAME_AND_VERSION);
+        mp_hal_stdout_tx_str("; " MICROPY_BANNER_MACHINE);
+        mp_hal_stdout_tx_str("\r\n");
+        #if MICROPY_PY_BUILTINS_HELP
+        mp_hal_stdout_tx_str("Type \"help()\" for more information.\r\n");
+        #endif
+        readline_init(MP_STATE_VM(repl_line), mp_repl_get_ps1());
     }
 }
 
@@ -396,7 +425,10 @@ static int pyexec_raw_repl_process_char(int c) {
         return PYEXEC_FORCED_EXIT;
     }
 
+    // Switch to original terminal mode to execute code, eg to support keyboard interrupt (SIGINT).
+    mp_hal_stdio_mode_orig();
     int ret = parse_compile_execute(MP_STATE_VM(repl_line), MP_PARSE_FILE_INPUT, EXEC_FLAG_PRINT_EOF | EXEC_FLAG_SOURCE_IS_VSTR);
+    mp_hal_stdio_mode_raw();
     if (ret & PYEXEC_FORCED_EXIT) {
         return ret;
     }
@@ -408,6 +440,25 @@ reset:
     return 0;
 }
 
+#if MICROPY_REPL_ASYNCIO
+// Compile and run one complete friendly-REPL line under the asyncio driver.
+// A line whose top-level await compiled to a coroutine is deferred to the driver
+// (PYEXEC_ASYNC_PENDING); anything else runs synchronously in cooked terminal
+// mode so Ctrl-C raises KeyboardInterrupt.
+static int repl_exec_line(mp_parse_input_kind_t input_kind) {
+    mp_uint_t exec_flags = EXEC_FLAG_ALLOW_DEBUGGING | EXEC_FLAG_IS_REPL | EXEC_FLAG_SOURCE_IS_VSTR;
+    if (!pyexec_event_repl_async) {
+        return parse_compile_execute(MP_STATE_VM(repl_line), input_kind, exec_flags);
+    }
+    mp_compile_allow_top_level_await = true;
+    mp_hal_stdio_mode_orig();
+    int ret = parse_compile_execute(MP_STATE_VM(repl_line), input_kind, exec_flags | EXEC_FLAG_ASYNC_REPL);
+    mp_hal_stdio_mode_raw();
+    mp_compile_allow_top_level_await = false;
+    return ret;
+}
+#endif
+
 static int pyexec_friendly_repl_process_char(int c) {
     if (repl.paste_mode) {
         if (c == CHAR_CTRL_C) {
@@ -417,7 +468,14 @@ static int pyexec_friendly_repl_process_char(int c) {
         } else if (c == CHAR_CTRL_D) {
             // end of input
             mp_hal_stdout_tx_str("\r\n");
+            #if MICROPY_REPL_ASYNCIO
+            int ret = repl_exec_line(MP_PARSE_FILE_INPUT);
+            if (ret == PYEXEC_ASYNC_PENDING) {
+                return ret;
+            }
+            #else
             int ret = parse_compile_execute(MP_STATE_VM(repl_line), MP_PARSE_FILE_INPUT, EXEC_FLAG_ALLOW_DEBUGGING | EXEC_FLAG_IS_REPL | EXEC_FLAG_SOURCE_IS_VSTR);
+            #endif
             if (ret & PYEXEC_FORCED_EXIT) {
                 return ret;
             }
@@ -425,7 +483,7 @@ static int pyexec_friendly_repl_process_char(int c) {
         } else {
             // add char to buffer and echo
             vstr_add_byte(MP_STATE_VM(repl_line), c);
-            if (c == '\r') {
+            if (c == '\r' || c == '\n') {
                 mp_hal_stdout_tx_str("\r\n=== ");
             } else {
                 char buf[1] = {c};
@@ -478,6 +536,12 @@ static int pyexec_friendly_repl_process_char(int c) {
             return 0;
         }
 
+        if (vstr_len(MP_STATE_VM(repl_line)) == 0) {
+            // Empty line: re-prompt without executing (avoids a spurious
+            // SyntaxError from compiling an empty source).
+            goto input_restart;
+        }
+
         if (!mp_repl_continue_with_input(vstr_null_terminated_str(MP_STATE_VM(repl_line)))) {
             goto exec;
         }
@@ -510,12 +574,22 @@ static int pyexec_friendly_repl_process_char(int c) {
         }
 
     exec:;
-        int ret = parse_compile_execute(MP_STATE_VM(repl_line), MP_PARSE_SINGLE_INPUT, EXEC_FLAG_ALLOW_DEBUGGING | EXEC_FLAG_IS_REPL | EXEC_FLAG_SOURCE_IS_VSTR);
-        if (ret & PYEXEC_FORCED_EXIT) {
-            return ret;
+        #if MICROPY_REPL_ASYNCIO
+        int exec_ret = repl_exec_line(MP_PARSE_SINGLE_INPUT);
+        if (exec_ret == PYEXEC_ASYNC_PENDING) {
+            return exec_ret;
+        }
+        #else
+        int exec_ret = parse_compile_execute(MP_STATE_VM(repl_line), MP_PARSE_SINGLE_INPUT, EXEC_FLAG_ALLOW_DEBUGGING | EXEC_FLAG_IS_REPL | EXEC_FLAG_SOURCE_IS_VSTR);
+        #endif
+        if (exec_ret & PYEXEC_FORCED_EXIT) {
+            return exec_ret;
         }
 
     input_restart:
+        // If the GC is locked at this point there is no way out except a reset,
+        // so force the GC to be unlocked to help the user debug what went wrong.
+        MP_STATE_THREAD(gc_lock_depth) = 0;
         vstr_reset(MP_STATE_VM(repl_line));
         repl.cont_line = false;
         repl.paste_mode = false;
@@ -539,15 +613,26 @@ int pyexec_event_repl_process_char(int c) {
 
 MP_REGISTER_ROOT_POINTER(vstr_t * repl_line);
 
-#else // MICROPY_REPL_EVENT_DRIVEN
-
-#if !MICROPY_HAL_HAS_STDIO_MODE_SWITCH
-// If the port doesn't need any stdio mode switching calls then provide trivial ones.
-static inline void mp_hal_stdio_mode_raw(void) {
+#if MICROPY_REPL_ASYNCIO
+bool pyexec_event_repl_async;
+void pyexec_event_repl_resume(void) {
+    // Re-prompt after the asyncio driver has awaited a deferred
+    // (PYEXEC_ASYNC_PENDING) coroutine on the event loop.
+    MP_STATE_VM(repl_pending_coro) = MP_OBJ_NULL;
+    // As in pyexec_friendly_repl_process_char: don't let a GC lock left by the
+    // awaited coroutine strand the REPL.
+    MP_STATE_THREAD(gc_lock_depth) = 0;
+    vstr_reset(MP_STATE_VM(repl_line));
+    repl.cont_line = false;
+    repl.paste_mode = false;
+    readline_init(MP_STATE_VM(repl_line), mp_repl_get_ps1());
 }
-static inline void mp_hal_stdio_mode_orig(void) {
-}
+MP_REGISTER_ROOT_POINTER(mp_obj_t repl_pending_coro);
 #endif
+
+#endif // MICROPY_REPL_EVENT_DRIVEN || MICROPY_REPL_ASYNCIO
+
+#if !MICROPY_REPL_EVENT_DRIVEN
 
 int pyexec_raw_repl(void) {
     vstr_t line;
@@ -617,6 +702,15 @@ raw_repl_reset:
 }
 
 int pyexec_friendly_repl(void) {
+    #if MICROPY_REPL_ASYNCIO
+    // arepl is the REPL: it runs the asyncio event loop and prints its own
+    // banner and prompt via repl_event_init().  It is frozen so it always
+    // loads, and the blocking friendly REPL below is not compiled.  Ctrl-D
+    // returns 0, which maps to a forced soft reset.
+    int ret = pyexec_asyncio_repl();
+    return ret == 0 ? PYEXEC_FORCED_EXIT : ret;
+    #else
+
     vstr_t line;
     vstr_init(&line, 32);
 
@@ -730,9 +824,104 @@ friendly_repl_reset:
         }
         mp_hal_stdio_mode_raw();
     }
+    #endif // !MICROPY_REPL_ASYNCIO
 }
 
-#endif // MICROPY_REPL_EVENT_DRIVEN
+#endif // !MICROPY_REPL_EVENT_DRIVEN
+
+#if MICROPY_REPL_ASYNCIO
+// Blocking breakpoint REPL: no banner, Ctrl-D returns to caller.
+// Terminal raw mode must be set by caller (e.g. from arepl).
+// Uses readline push/pop for reentrant state.
+int pyexec_repl_breakpoint(void) {
+    vstr_t line;
+    vstr_init(&line, 32);
+
+    // readline_push() returns false when a save is already active (nested
+    // breakpoint); only the outermost caller owns the restore.
+    bool pushed = readline_push();
+
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) != 0) {
+        // Unwind readline state on an escaping exception and re-raise, so the
+        // single-level save slot can't leak (rl_saved_valid stuck set).
+        vstr_clear(&line);
+        if (pushed) {
+            readline_pop();
+        }
+        nlr_jump(nlr.ret_val);
+    }
+
+    for (;;) {
+    breakpoint_input_restart:
+        vstr_reset(&line);
+        int ret = readline(&line, mp_repl_get_ps1());
+
+        if (ret == CHAR_CTRL_C) {
+            mp_hal_stdout_tx_str("\r\n");
+            continue;
+        } else if (ret == CHAR_CTRL_D) {
+            // Exit breakpoint, return to caller.
+            mp_hal_stdout_tx_str("\r\n");
+            break;
+        } else if (ret == CHAR_CTRL_A || ret == CHAR_CTRL_B || ret == CHAR_CTRL_E) {
+            // Ignore raw REPL, banner reset, and paste mode in breakpoint.
+            mp_hal_stdout_tx_str("\r\n");
+            continue;
+        } else if (vstr_len(&line) == 0) {
+            continue;
+        } else {
+            // Multi-line continuation.
+            while (mp_repl_continue_with_input(vstr_null_terminated_str(&line))) {
+                vstr_add_byte(&line, '\n');
+                ret = readline(&line, mp_repl_get_ps2());
+                if (ret == CHAR_CTRL_C) {
+                    mp_hal_stdout_tx_str("\r\n");
+                    goto breakpoint_input_restart;
+                } else if (ret == CHAR_CTRL_D) {
+                    break;
+                }
+            }
+        }
+
+        mp_hal_stdio_mode_orig();
+        ret = parse_compile_execute(&line, MP_PARSE_SINGLE_INPUT,
+            EXEC_FLAG_ALLOW_DEBUGGING | EXEC_FLAG_IS_REPL | EXEC_FLAG_SOURCE_IS_VSTR);
+        mp_hal_stdio_mode_raw();
+        if (ret & PYEXEC_FORCED_EXIT) {
+            break;
+        }
+    }
+
+    nlr_pop();
+    vstr_clear(&line);
+    if (pushed) {
+        readline_pop();
+    }
+    return 0;
+}
+#endif // MICROPY_REPL_ASYNCIO
+
+#if MICROPY_REPL_ASYNCIO
+int pyexec_asyncio_repl(void) {
+    static const char boot_code[] =
+        "import asyncio.arepl\n"  // binds asyncio too
+        "asyncio.new_event_loop()\n"
+        "asyncio.create_task(asyncio.arepl.task())\n"
+        "asyncio.get_event_loop().run_forever()\n";
+    // Wrap boot_code in a read-only vstr for parse_compile_execute.
+    // EXEC_FLAG_SOURCE_IS_VSTR uses the vstr as-is without modification or
+    // freeing; fixed_buf makes an accidental mutation fail loudly rather than
+    // m_renew a ROM pointer.
+    vstr_t vstr = {0};
+    vstr.buf = (char *)boot_code;
+    vstr.len = sizeof(boot_code) - 1;
+    vstr.fixed_buf = true;
+    return parse_compile_execute(&vstr, MP_PARSE_FILE_INPUT,
+        EXEC_FLAG_SOURCE_IS_VSTR | EXEC_FLAG_ALLOW_DEBUGGING);
+}
+#endif
+
 #endif // MICROPY_ENABLE_COMPILER
 
 int pyexec_file(const char *filename) {

--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -868,7 +868,7 @@ friendly_repl_reset:
 
 #endif // !MICROPY_REPL_EVENT_DRIVEN
 
-#if MICROPY_REPL_ASYNCIO
+#if MICROPY_REPL_ASYNCIO_BREAKPOINT
 // Blocking breakpoint REPL: no banner, Ctrl-D returns to caller.
 // Terminal raw mode must be set by caller (e.g. from arepl).
 // Uses readline push/pop for reentrant state.
@@ -939,7 +939,7 @@ int pyexec_repl_breakpoint(void) {
     }
     return 0;
 }
-#endif // MICROPY_REPL_ASYNCIO
+#endif // MICROPY_REPL_ASYNCIO_BREAKPOINT
 
 #if MICROPY_REPL_ASYNCIO
 int pyexec_asyncio_repl(void) {

--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -636,6 +636,41 @@ MP_REGISTER_ROOT_POINTER(mp_obj_t repl_pending_coro);
 
 #if !MICROPY_REPL_EVENT_DRIVEN
 
+#if MICROPY_REPL_ASYNCIO
+// Blocking raw REPL, used after a soft reset while the host is still in raw
+// REPL mode: a feed loop over the event-driven raw REPL core, so the raw
+// REPL protocol isn't implemented a second time for ports that also carry
+// the asyncio REPL.
+int pyexec_raw_repl(void) {
+    mp_hal_stdio_mode_raw();
+
+    pyexec_mode_kind = PYEXEC_MODE_RAW_REPL;
+    pyexec_event_repl_init();
+
+    int ret = 0;
+    for (;;) {
+        int c = mp_hal_stdin_rx_chr();
+        if (c == CHAR_CTRL_B) {
+            // Change to friendly REPL: return to the caller, which prints
+            // the banner. Handled here rather than by the core, whose
+            // in-place mode switch prints the banner itself and would
+            // otherwise produce it a second time.
+            mp_hal_stdout_tx_str("\r\n");
+            pyexec_mode_kind = PYEXEC_MODE_FRIENDLY_REPL;
+            break;
+        }
+        ret = pyexec_raw_repl_process_char(c);
+        if (ret != 0) {
+            break;
+        }
+    }
+
+    mp_hal_stdio_mode_orig();
+    return ret;
+}
+
+#else // !MICROPY_REPL_ASYNCIO
+
 int pyexec_raw_repl(void) {
     vstr_t line;
     vstr_init(&line, 32);
@@ -702,6 +737,8 @@ raw_repl_reset:
         mp_hal_stdio_mode_raw();
     }
 }
+
+#endif // MICROPY_REPL_ASYNCIO
 
 int pyexec_friendly_repl(void) {
     #if MICROPY_REPL_ASYNCIO

--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -518,9 +518,11 @@ static int pyexec_friendly_repl_process_char(int c) {
             mp_hal_stdout_tx_str("\r\n");
             goto input_restart;
         } else if (ret == CHAR_CTRL_D) {
-            // exit for a soft reset
+            // Ctrl-D: signal exit.  Reset (not free) the line so the buffer
+            // survives for reuse if the caller re-prompts instead of exiting
+            // (e.g. a persistent asyncio REPL).
             mp_hal_stdout_tx_str("\r\n");
-            vstr_clear(MP_STATE_VM(repl_line));
+            vstr_reset(MP_STATE_VM(repl_line));
             return PYEXEC_FORCED_EXIT;
         } else if (ret == CHAR_CTRL_E) {
             // paste mode

--- a/shared/runtime/pyexec.h
+++ b/shared/runtime/pyexec.h
@@ -36,6 +36,15 @@ typedef enum {
 extern pyexec_mode_kind_t pyexec_mode_kind;
 
 #define PYEXEC_FORCED_EXIT (0x100)
+// Returned by the event-driven REPL when MICROPY_REPL_ASYNCIO is enabled and a
+// complete friendly-REPL line contains a top-level await: the line is compiled
+// to a coroutine left in MP_STATE_VM(repl_pending_coro) for the asyncio driver
+// to await on the event loop, after which it calls pyexec_event_repl_resume().
+#define PYEXEC_ASYNC_PENDING (0x200)
+// ORed into repl_event()'s return while the REPL is in raw mode, so the asyncio
+// driver feeds input synchronously (without yielding) and a concurrent task's
+// stdout cannot corrupt a raw/raw-paste transfer.
+#define PYEXEC_RAW_ACTIVE (0x400)
 
 #if MICROPY_PYEXEC_ENABLE_EXIT_CODE_HANDLING
 #define PYEXEC_NORMAL_EXIT (0)
@@ -50,6 +59,10 @@ extern pyexec_mode_kind_t pyexec_mode_kind;
 
 int pyexec_raw_repl(void);
 int pyexec_friendly_repl(void);
+#if MICROPY_REPL_ASYNCIO
+int pyexec_repl_breakpoint(void);
+int pyexec_asyncio_repl(void);
+#endif
 int pyexec_file(const char *filename);
 int pyexec_file_if_exists(const char *filename);
 int pyexec_frozen_module(const char *name, bool allow_keyboard_interrupt);
@@ -57,6 +70,15 @@ int pyexec_vstr(vstr_t *str, bool allow_keyboard_interrupt);
 void pyexec_event_repl_init(void);
 int pyexec_event_repl_process_char(int c);
 extern uint8_t pyexec_repl_active;
+#if MICROPY_REPL_ASYNCIO
+// When true, the event-driven friendly REPL defers execution of any complete
+// line containing "await" back to the caller (PYEXEC_ASYNC_PENDING) instead of
+// running it synchronously.  Set by the asyncio REPL driver.
+extern bool pyexec_event_repl_async;
+// Re-prompt and reset line state after the driver has executed a deferred
+// (PYEXEC_ASYNC_PENDING) line on the event loop.
+void pyexec_event_repl_resume(void);
+#endif
 
 #if MICROPY_REPL_INFO
 mp_obj_t pyb_set_repl_info(mp_obj_t o_value);

--- a/shared/runtime/pyexec.h
+++ b/shared/runtime/pyexec.h
@@ -60,8 +60,10 @@ extern pyexec_mode_kind_t pyexec_mode_kind;
 int pyexec_raw_repl(void);
 int pyexec_friendly_repl(void);
 #if MICROPY_REPL_ASYNCIO
-int pyexec_repl_breakpoint(void);
 int pyexec_asyncio_repl(void);
+#endif
+#if MICROPY_REPL_ASYNCIO_BREAKPOINT
+int pyexec_repl_breakpoint(void);
 #endif
 int pyexec_file(const char *filename);
 int pyexec_file_if_exists(const char *filename);

--- a/tests/cmdline/repl_asyncio.py
+++ b/tests/cmdline/repl_asyncio.py
@@ -1,0 +1,15 @@
+# Test the asyncio REPL, which runs via the compiler's top-level-await support.
+# If the standard (non-async) REPL were running, await would be a SyntaxError.
+# A multi-line async def and tuple-unpacking assignment from await both work
+# here (the earlier text-heuristic REPL mishandled them).
+await asyncio.sleep(0)
+async def f():
+    await asyncio.sleep(0)
+    return 42
+
+r = await f()
+print("r =", r)
+a, b = (await f(), 99)
+print("a, b =", a, b)
+await f()
+print("async_ok")

--- a/tests/cmdline/repl_asyncio.py.exp
+++ b/tests/cmdline/repl_asyncio.py.exp
@@ -1,0 +1,22 @@
+MicroPython \.\+ version
+Type "help()" for more information.
+>>> # Test the asyncio REPL, which runs via the compiler's top-level-await support.
+>>> # If the standard (non-async) REPL were running, await would be a SyntaxError.
+>>> # A multi-line async def and tuple-unpacking assignment from await both work
+>>> # here (the earlier text-heuristic REPL mishandled them).
+>>> await asyncio.sleep(0)
+>>> async def f():
+...        await asyncio.sleep(0)
+...     return 42
+... 
+>>> r = await f()
+>>> print("r =", r)
+r = 42
+>>> a, b = (await f(), 99)
+>>> print("a, b =", a, b)
+a, b = 42 99
+>>> await f()
+42
+>>> print("async_ok")
+async_ok
+>>> 

--- a/tests/cmdline/repl_asyncio_intr.py
+++ b/tests/cmdline/repl_asyncio_intr.py
@@ -1,0 +1,6 @@
+# Test that Ctrl-C cancels a running top-level await in the asyncio REPL.
+# The REPL runs in raw mode, so Ctrl-C arrives as a byte that the driver's
+# interrupt watcher reads to cancel the coroutine (not delivered as SIGINT).
+await asyncio.sleep(10)
+{\x03}
+print("cancelled")

--- a/tests/cmdline/repl_asyncio_intr.py.exp
+++ b/tests/cmdline/repl_asyncio_intr.py.exp
@@ -1,0 +1,10 @@
+MicroPython \.\+ version
+Type "help()" for more information.
+>>> # Test that Ctrl-C cancels a running top-level await in the asyncio REPL.
+>>> # The REPL runs in raw mode, so Ctrl-C arrives as a byte that the driver's
+>>> # interrupt watcher reads to cancel the coroutine (not delivered as SIGINT).
+>>> await asyncio.sleep(10)
+>>> 
+>>> print("cancelled")
+cancelled
+>>> 

--- a/tests/cmdline/repl_ctrl_c_interrupt_execution.py.exp
+++ b/tests/cmdline/repl_ctrl_c_interrupt_execution.py.exp
@@ -8,6 +8,7 @@ Type "help()" for more information.
 >>> time.sleep(10)
 ########
 \.\*Traceback (most recent call last):
+########
   File "<stdin>", line 1, in <module>
 KeyboardInterrupt: \$
 >>> print('repl still responds')

--- a/tests/cmdline/repl_paste.py.exp
+++ b/tests/cmdline/repl_paste.py.exp
@@ -115,6 +115,7 @@ paste mode; Ctrl-C to cancel, Ctrl-D to finish
 ===     print('Missing parameter')
 === \$
 Traceback (most recent call last):
+########
   File "<stdin>", line 2
 SyntaxError: invalid syntax
 >>> \$
@@ -129,6 +130,7 @@ paste mode; Ctrl-C to cancel, Ctrl-D to finish
 === will_error()
 === \$
 Traceback (most recent call last):
+########
   File "<stdin>", line 5, in <module>
   File "<stdin>", line 3, in will_error
 NameError: name 'undefined_variable' isn't defined

--- a/tests/cmdline/repl_stdio_mode_raw.py
+++ b/tests/cmdline/repl_stdio_mode_raw.py
@@ -1,0 +1,2 @@
+# Test micropython.stdio_mode_raw terminal mode switching.
+import termios, micropython; c=termios.tcgetattr(0); micropython.stdio_mode_raw(True); r=termios.tcgetattr(0); micropython.stdio_mode_raw(False); d=termios.tcgetattr(0); print(c[3]!=0, r[3]==0, r[0]!=c[0], d[3]==c[3], d[0]==c[0])

--- a/tests/cmdline/repl_stdio_mode_raw.py.exp
+++ b/tests/cmdline/repl_stdio_mode_raw.py.exp
@@ -1,0 +1,6 @@
+MicroPython \.\+ version
+Type "help()" for more information.
+>>> # Test micropython.stdio_mode_raw terminal mode switching.
+>>> import termios, micropython; c=termios.tcgetattr(0); micropython.stdio_mode_raw(True); r=termios.tcgetattr(0); micropython.stdio_mode_raw(False); d=termios.tcgetattr(0); print(c[3]!=0, r[3]==0, r[0]!=c[0], d[3]==c[3], d[0]==c[0])
+True True True True True
+>>> 

--- a/tests/micropython/repl_breakpoint.py
+++ b/tests/micropython/repl_breakpoint.py
@@ -1,0 +1,20 @@
+# Test that micropython.repl() (the blocking breakpoint REPL) exists and is
+# callable.  The interactive REPL can't be driven from the test runner (it
+# reads stdin, which is the test script), so this is a presence smoke check.
+
+try:
+    import micropython
+
+    micropython.repl
+except (ImportError, AttributeError):
+    print("SKIP")
+    raise SystemExit
+
+# We can't test the interactive REPL directly in the test runner since
+# it reads from stdin which is the test script itself. Instead verify
+# the function exists and is callable.
+
+# Verify repl is a callable
+print(callable(micropython.repl))
+
+print("repl_breakpoint_ok")

--- a/tests/micropython/repl_breakpoint.py.exp
+++ b/tests/micropython/repl_breakpoint.py.exp
@@ -1,0 +1,2 @@
+True
+repl_breakpoint_ok

--- a/tests/micropython/stdio_mode_raw.py
+++ b/tests/micropython/stdio_mode_raw.py
@@ -1,0 +1,19 @@
+# Test micropython.stdio_mode_raw doesn't crash.
+try:
+    import micropython
+
+    micropython.stdio_mode_raw
+except (ImportError, AttributeError):
+    print("SKIP")
+    raise SystemExit
+
+# Enable raw mode then restore original.
+# On Unix this changes terminal settings; when stdin is a pipe (test runner)
+# it may silently fail but should not crash.
+micropython.stdio_mode_raw(True)
+micropython.stdio_mode_raw(False)
+print("stdio_mode_raw_ok")
+
+# Double-disable is safe
+micropython.stdio_mode_raw(False)
+print("double_disable_ok")

--- a/tests/micropython/stdio_mode_raw.py.exp
+++ b/tests/micropython/stdio_mode_raw.py.exp
@@ -1,0 +1,2 @@
+stdio_mode_raw_ok
+double_disable_ok

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -227,6 +227,7 @@ flaky_tests_to_ignore = {
     "thread/stress_recurse.py": ("stack overflow under emulation", None),
     "thread/stress_heap.py": ("flaky on macOS", ("darwin",)),
     "cmdline/repl_lock.py": ("REPL timing under QEMU", None),
+    "cmdline/repl_inspect.py": ("REPL timing under QEMU", None),
     "cmdline/repl_cont.py": ("REPL escaping on macOS", ("darwin",)),
     "extmod/time_time_ns.py": ("CI runner clock precision", None),
 }

--- a/tests/unix/async_repl_manifest.py
+++ b/tests/unix/async_repl_manifest.py
@@ -1,0 +1,1 @@
+include("$(PORT_DIR)/variants/standard/manifest.py")

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -123,6 +123,7 @@ function ci_code_size_build {
             OUTFILE=$2
             IGNORE_ERRORS=$3
 
+            git restore ports/esp32/lockfiles/*  # esp32 port may update local lockfile
             git checkout --detach $COMMIT
             git submodule update --init $SUBMODULES
             git show -s


### PR DESCRIPTION
Reuses the event-driven REPL core for the asyncio REPL instead of the text-heuristic aiorepl implementation, so top-level await, multi-line async def, and tuple-unpacking assignment from await all work through the same parser path as the blocking REPL.

Includes persistent/stop_loop_on_exit options, a fix for a closed dupterm slot wedging the async REPL, breakpoint() gated behind its own flag, and a fix so ruff's exclude/extend-exclude lists in pyproject.toml are honored by tools/pre-push-check.sh, which passes changed files explicitly rather than letting ruff discover them.